### PR TITLE
feat: Add Conductor port reservation system for Google OAuth

### DIFF
--- a/CONDUCTOR_PORTS.md
+++ b/CONDUCTOR_PORTS.md
@@ -1,0 +1,134 @@
+# Conductor Port Reservation System
+
+This system manages a predefined pool of ports for Conductor workspaces to avoid constantly updating Google OAuth redirect URIs.
+
+## Prerequisites
+
+Before using Conductor workspaces, set these environment variables in your shell:
+
+```bash
+# Required for Admin UI access
+export SUPER_ADMIN_EMAILS='your-email@example.com'
+
+# Optional - allows any user from these domains
+export SUPER_ADMIN_DOMAINS='example.com,company.com'
+
+# Required for creative generation features
+export GEMINI_API_KEY='your-gemini-api-key'
+
+# Required for Google OAuth login
+export GOOGLE_CLIENT_ID='your-client-id.apps.googleusercontent.com'
+export GOOGLE_CLIENT_SECRET='your-client-secret'
+```
+
+Add these to your `~/.bashrc` or `~/.zshrc` to make them permanent:
+
+```bash
+# AdCP Conductor Configuration
+export SUPER_ADMIN_EMAILS='bokelley@scope3.com'
+export GEMINI_API_KEY='your-key-here'
+export GOOGLE_CLIENT_ID='your-id-here'
+export GOOGLE_CLIENT_SECRET='your-secret-here'
+```
+
+## Setup
+
+1. **Configure Google OAuth**: Add all the redirect URLs to your Google OAuth app:
+   ```bash
+   python manage_conductor_ports.py oauth-urls
+   ```
+   
+   This will output 10 redirect URLs:
+   - http://localhost:8002/callback
+   - http://localhost:8003/callback
+   - http://localhost:8004/callback
+   - ... through port 8011
+
+2. **Add these URLs to Google OAuth Console**:
+   - Go to [Google Cloud Console](https://console.cloud.google.com/)
+   - Navigate to your OAuth 2.0 Client ID
+   - Add all 10 redirect URIs under "Authorized redirect URIs"
+   - Save changes
+
+## Usage
+
+### Automatic Port Reservation
+
+When you create a new Conductor workspace, the `setup_conductor_workspace.sh` script will automatically:
+1. Reserve an available port set from the pool
+2. Configure the workspace to use those ports
+3. Update the `.env` file with the assigned ports
+
+### Manual Port Management
+
+```bash
+# List all current port reservations
+python manage_conductor_ports.py list
+
+# Manually reserve ports for a workspace
+python manage_conductor_ports.py reserve my-workspace
+
+# Release ports when done
+python manage_conductor_ports.py release my-workspace
+
+# Get OAuth URLs for Google configuration
+python manage_conductor_ports.py oauth-urls
+```
+
+## Port Pool
+
+The system manages 10 predefined port sets:
+
+| Set | PostgreSQL | MCP Server | Admin UI |
+|-----|------------|------------|----------|
+| 1   | 5433       | 8081       | 8002     |
+| 2   | 5434       | 8082       | 8003     |
+| 3   | 5435       | 8083       | 8004     |
+| 4   | 5436       | 8084       | 8005     |
+| 5   | 5437       | 8085       | 8006     |
+| 6   | 5438       | 8086       | 8007     |
+| 7   | 5439       | 8087       | 8008     |
+| 8   | 5440       | 8088       | 8009     |
+| 9   | 5441       | 8089       | 8010     |
+| 10  | 5442       | 8090       | 8011     |
+
+## Configuration
+
+The port configuration is stored in `conductor_ports.json`:
+- `available_port_sets`: List of all port sets
+- `reserved_ports`: Current reservations by workspace name
+
+## Integration with Conductor
+
+1. **Workspace Creation**: `setup_conductor_workspace.sh` automatically reserves ports
+2. **Workspace Cleanup**: `cleanup_conductor_workspace.sh` releases ports
+3. **Fallback**: If port reservation fails, falls back to hash-based port assignment
+
+## Benefits
+
+1. **No more OAuth updates**: Once configured, all workspaces use pre-approved ports
+2. **Predictable ports**: Know exactly which ports are in use
+3. **Automatic management**: Ports are reserved/released automatically
+4. **Conflict prevention**: File locking prevents port conflicts
+5. **Easy monitoring**: See all port usage with one command
+
+## Troubleshooting
+
+### All ports are reserved
+If you get "No available port sets!" error:
+1. List current reservations: `python manage_conductor_ports.py list`
+2. Release unused workspaces: `python manage_conductor_ports.py release <workspace>`
+3. Consider adding more port sets to `conductor_ports.json`
+
+### Port conflicts
+If you have port conflicts:
+1. Check what's using the port: `lsof -i :8002`
+2. Stop conflicting services
+3. Use the cleanup script to properly release ports
+
+### OAuth still failing
+Make sure:
+1. All 10 redirect URIs are added to Google OAuth
+2. The URIs match exactly (including http:// prefix)
+3. You've saved changes in Google Cloud Console
+4. The OAuth client ID/secret are correctly configured

--- a/cleanup_conductor_workspace.sh
+++ b/cleanup_conductor_workspace.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# cleanup_conductor_workspace.sh - Clean up resources when removing a Conductor workspace
+
+# Check if Conductor environment variables are set
+if [ -z "$CONDUCTOR_WORKSPACE_NAME" ]; then
+    echo "Error: This script should be run within a Conductor workspace"
+    echo "CONDUCTOR_WORKSPACE_NAME is not set"
+    exit 1
+fi
+
+echo "Cleaning up Conductor workspace: $CONDUCTOR_WORKSPACE_NAME"
+
+BASE_DIR="$CONDUCTOR_ROOT_PATH"
+PORT_MANAGER="$BASE_DIR/manage_conductor_ports.py"
+
+# Stop any running containers
+if [ -f "docker-compose.yml" ]; then
+    echo "Stopping Docker containers..."
+    docker-compose down -v 2>/dev/null || true
+fi
+
+# Release reserved ports
+if [ -f "$PORT_MANAGER" ]; then
+    echo "Releasing reserved ports..."
+    python3 "$PORT_MANAGER" release "$CONDUCTOR_WORKSPACE_NAME"
+else
+    echo "Port manager not found, skipping port release"
+fi
+
+echo "Cleanup complete for workspace: $CONDUCTOR_WORKSPACE_NAME"

--- a/conductor_ports.json
+++ b/conductor_ports.json
@@ -1,0 +1,55 @@
+{
+  "available_port_sets": [
+    {
+      "postgres": 5433,
+      "mcp": 8081,
+      "admin": 8002
+    },
+    {
+      "postgres": 5434,
+      "mcp": 8082,
+      "admin": 8003
+    },
+    {
+      "postgres": 5435,
+      "mcp": 8083,
+      "admin": 8004
+    },
+    {
+      "postgres": 5436,
+      "mcp": 8084,
+      "admin": 8005
+    },
+    {
+      "postgres": 5437,
+      "mcp": 8085,
+      "admin": 8006
+    },
+    {
+      "postgres": 5438,
+      "mcp": 8086,
+      "admin": 8007
+    },
+    {
+      "postgres": 5439,
+      "mcp": 8087,
+      "admin": 8008
+    },
+    {
+      "postgres": 5440,
+      "mcp": 8088,
+      "admin": 8009
+    },
+    {
+      "postgres": 5441,
+      "mcp": 8089,
+      "admin": 8010
+    },
+    {
+      "postgres": 5442,
+      "mcp": 8090,
+      "admin": 8011
+    }
+  ],
+  "reserved_ports": {}
+}

--- a/manage_conductor_ports.py
+++ b/manage_conductor_ports.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+Conductor Port Management System
+
+Manages a pool of predefined ports for Conductor workspaces to avoid
+having to constantly update Google OAuth redirect URIs.
+"""
+
+import json
+import os
+import sys
+import fcntl
+from datetime import datetime
+from pathlib import Path
+
+
+class ConductorPortManager:
+    def __init__(self, config_file="conductor_ports.json"):
+        self.config_file = Path(config_file).absolute()
+        self.lock_file = self.config_file.with_suffix('.lock')
+        
+    def _load_config(self):
+        """Load port configuration with file locking."""
+        with open(self.config_file, 'r') as f:
+            return json.load(f)
+    
+    def _save_config(self, config):
+        """Save port configuration with file locking."""
+        with open(self.config_file, 'w') as f:
+            json.dump(config, f, indent=2)
+    
+    def _with_lock(self, func):
+        """Execute function with exclusive file lock."""
+        lock_fd = os.open(str(self.lock_file), os.O_CREAT | os.O_WRONLY, 0o600)
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            return func()
+        finally:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            os.close(lock_fd)
+    
+    def reserve_ports(self, workspace_name):
+        """Reserve a port set for a workspace."""
+        def _reserve():
+            config = self._load_config()
+            
+            # Check if workspace already has ports reserved
+            if workspace_name in config['reserved_ports']:
+                return config['reserved_ports'][workspace_name]
+            
+            # Find first available port set
+            for i, port_set in enumerate(config['available_port_sets']):
+                # Check if this port set is already reserved
+                is_reserved = False
+                for reserved in config['reserved_ports'].values():
+                    if reserved['ports'] == port_set:
+                        is_reserved = True
+                        break
+                
+                if not is_reserved:
+                    # Reserve this port set
+                    reservation = {
+                        'ports': port_set,
+                        'reserved_at': datetime.now().isoformat(),
+                        'index': i
+                    }
+                    config['reserved_ports'][workspace_name] = reservation
+                    self._save_config(config)
+                    return reservation
+            
+            raise RuntimeError("No available port sets! All ports are reserved.")
+        
+        return self._with_lock(_reserve)
+    
+    def release_ports(self, workspace_name):
+        """Release ports reserved by a workspace."""
+        def _release():
+            config = self._load_config()
+            
+            if workspace_name in config['reserved_ports']:
+                del config['reserved_ports'][workspace_name]
+                self._save_config(config)
+                return True
+            return False
+        
+        return self._with_lock(_release)
+    
+    def get_reserved_ports(self, workspace_name):
+        """Get ports reserved by a workspace."""
+        config = self._load_config()
+        if workspace_name in config['reserved_ports']:
+            return config['reserved_ports'][workspace_name]['ports']
+        return None
+    
+    def list_reservations(self):
+        """List all current port reservations."""
+        config = self._load_config()
+        return config['reserved_ports']
+    
+    def get_oauth_urls(self):
+        """Generate list of OAuth redirect URLs for all port sets."""
+        config = self._load_config()
+        urls = []
+        for port_set in config['available_port_sets']:
+            urls.append(f"http://localhost:{port_set['admin']}/callback")
+        return urls
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python manage_conductor_ports.py <command> [args]")
+        print("Commands:")
+        print("  reserve <workspace_name>  - Reserve ports for a workspace")
+        print("  release <workspace_name>  - Release ports for a workspace")
+        print("  list                      - List all reservations")
+        print("  oauth-urls                - List all OAuth redirect URLs")
+        sys.exit(1)
+    
+    manager = ConductorPortManager()
+    command = sys.argv[1]
+    
+    if command == "reserve":
+        if len(sys.argv) < 3:
+            print("Error: workspace name required")
+            sys.exit(1)
+        workspace = sys.argv[2]
+        try:
+            reservation = manager.reserve_ports(workspace)
+            ports = reservation['ports']
+            print(f"Reserved ports for {workspace}:")
+            print(f"  PostgreSQL: {ports['postgres']}")
+            print(f"  MCP Server: {ports['mcp']}")
+            print(f"  Admin UI: {ports['admin']}")
+        except RuntimeError as e:
+            print(f"Error: {e}")
+            sys.exit(1)
+    
+    elif command == "release":
+        if len(sys.argv) < 3:
+            print("Error: workspace name required")
+            sys.exit(1)
+        workspace = sys.argv[2]
+        if manager.release_ports(workspace):
+            print(f"Released ports for {workspace}")
+        else:
+            print(f"No ports reserved for {workspace}")
+    
+    elif command == "list":
+        reservations = manager.list_reservations()
+        if not reservations:
+            print("No port reservations")
+        else:
+            print("Current port reservations:")
+            for workspace, info in reservations.items():
+                ports = info['ports']
+                print(f"\n{workspace}:")
+                print(f"  PostgreSQL: {ports['postgres']}")
+                print(f"  MCP Server: {ports['mcp']}")
+                print(f"  Admin UI: {ports['admin']}")
+                print(f"  Reserved at: {info['reserved_at']}")
+    
+    elif command == "oauth-urls":
+        urls = manager.get_oauth_urls()
+        print("Add these redirect URLs to your Google OAuth configuration:")
+        for url in urls:
+            print(f"  {url}")
+    
+    else:
+        print(f"Unknown command: {command}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds a port reservation system to eliminate the need to constantly update Google OAuth redirect URIs for new Conductor workspaces
- Implements environment variable validation to ensure proper configuration
- Provides automatic port management with reservation and release capabilities

## Problem
When creating new Conductor workspaces, each workspace gets randomly generated ports. This requires adding new redirect URIs to Google OAuth configuration every time, which is tedious and error-prone.

## Solution
This PR introduces a port reservation system that:
1. Uses a predefined pool of 10 port sets (Admin UI ports 8002-8011)
2. Automatically reserves ports when creating workspaces
3. Automatically releases ports when cleaning up workspaces
4. Falls back to hash-based ports if the reservation system fails

## Key Features

### Port Reservation System
- **10 predefined port sets** that can be registered once with Google OAuth
- **File locking** to prevent conflicts between concurrent operations
- **Automatic management** - ports are reserved on setup and released on cleanup
- **Easy monitoring** with `python3 manage_conductor_ports.py list`

### Environment Variable Validation
- **Required variables checked**:
  - `SUPER_ADMIN_EMAILS` - for Admin UI access
  - `GEMINI_API_KEY` - for creative generation
  - `GOOGLE_CLIENT_ID/SECRET` - for OAuth login
- **Helpful guidance** provided for missing variables
- **Interactive prompt** to continue despite missing variables

## Files Added
- `manage_conductor_ports.py` - Port reservation manager with file locking
- `conductor_ports.json` - Configuration with 10 predefined port sets
- `cleanup_conductor_workspace.sh` - Cleanup script that releases ports
- `CONDUCTOR_PORTS.md` - Complete documentation

## Setup Instructions
1. Run `python3 manage_conductor_ports.py oauth-urls` to get all redirect URLs
2. Add these 10 URLs to your Google OAuth app (ports 8002-8011)
3. Set required environment variables in your shell
4. Create workspaces - they'll automatically use reserved ports

## Test plan
- [ ] Create a new Conductor workspace and verify port reservation
- [ ] Check that environment variables are validated
- [ ] Verify cleanup script releases ports properly
- [ ] Test concurrent workspace creation (file locking)
- [ ] Verify fallback to hash-based ports works

🤖 Generated with [Claude Code](https://claude.ai/code)