### PR TITLE
feat: Add .mcp.json for UI testing subagent configuration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,19 @@
+{
+  "name": "adcp-sales-agent",
+  "description": "AdCP Sales Agent MCP tools and services",
+  "mcpServers": {
+    "ui-test-assistant": {
+      "name": "UI Test Assistant",
+      "description": "UI testing tools for AdCP Admin interface",
+      "command": "uv",
+      "args": ["run", "python", "ui_test_server.py"],
+      "cwd": "ui_tests/claude_subagent",
+      "env": {
+        "PYTHONPATH": ".",
+        "BASE_URL": "${BASE_URL:-http://localhost:8001}",
+        "ADMIN_UI_PORT": "${ADMIN_UI_PORT:-8001}",
+        "HEADLESS": "${HEADLESS:-true}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `.mcp.json` configuration file to enable Claude Desktop integration with the UI testing subagent
- This configuration was originally part of PR #15 but is being submitted separately as requested

## Details
The `.mcp.json` file configures the UI Test Assistant MCP server that provides 8 tools for automating the AdCP Admin interface:
- `run_test_suite` - Execute predefined test suites
- `test_login` - Test authentication flow
- `test_tenant_operations` - Test tenant management
- `get_element_info` - Inspect UI elements
- `capture_screenshot` - Take screenshots
- `check_page_errors` - Monitor console errors
- `validate_ui_state` - Verify page state
- `get_network_activity` - Monitor API calls

## Configuration
The MCP server supports environment-based configuration:
- `BASE_URL`: Target URL for testing (defaults to http://localhost:8001)
- `ADMIN_UI_PORT`: Admin UI port (defaults to 8001)
- `HEADLESS`: Run browser in headless mode (defaults to true)

## Usage
After merging, users can:
1. Install UI test dependencies: `uv sync --extra ui-tests`
2. Configure Claude Desktop to use the `.mcp.json` file
3. Use the UI Test Assistant in Claude to automate Admin UI testing

🤖 Generated with [Claude Code](https://claude.ai/code)