### PR TITLE
feat: Implement AdCP v2.4 protocol updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,14 @@ When working in a Conductor workspace (e.g., `.conductor/quito/`):
 
 ## Recent Major Changes
 
-### AI-Powered Product Management (Latest)
+### AdCP v2.4 Protocol Updates (Latest)
+- **Renamed Endpoints**: `list_products` renamed to `get_products` to align with signals agent spec
+- **Signal Discovery**: Added optional `get_signals` endpoint for discovering available signals (audiences, contextual, geographic, etc.)
+- **Enhanced Targeting**: Added `signals` field to targeting overlay for direct signal activation
+- **Terminology Updates**: Renamed `provided_signals` to `aee_signals` for improved clarity
+- **Unified Signal Interface**: Signals can now include audiences, contextual data, and geographic information
+
+### AI-Powered Product Management
 - **Default Products**: 6 standard products automatically created for new tenants
 - **Industry Templates**: Specialized products for news, sports, entertainment, ecommerce
 - **AI Configuration**: Uses Gemini 2.5 Flash to analyze descriptions and suggest configs
@@ -455,15 +462,25 @@ transport = StreamableHttpTransport(url="http://localhost:8080/mcp/", headers=he
 client = Client(transport=transport)
 
 async with client:
-    # List products
-    products = await client.tools.list_products()
+    # Get products
+    products = await client.tools.get_products(brief="video ads for sports content")
     
-    # Create media buy
+    # Discover available signals (optional)
+    signals = await client.tools.get_signals(
+        query="sports",
+        type="contextual"
+    )
+    
+    # Create media buy with signals
     result = await client.tools.create_media_buy(
         product_ids=["prod_1"],
         total_budget=5000.0,
         flight_start_date="2025-02-01",
-        flight_end_date="2025-02-28"
+        flight_end_date="2025-02-28",
+        targeting_overlay={
+            "geo_country_any_of": ["US"],
+            "signals": ["sports_content", "auto_intenders_q1_2025"]
+        }
     )
 ```
 

--- a/aee_signals.py
+++ b/aee_signals.py
@@ -1,7 +1,7 @@
 """
 AEE (Ad Execution Engine) signal definitions.
 
-Defines the three types of provided signals from AEE:
+Defines the three types of AEE signals:
 1. May Include - Signals to include for targeting
 2. Must Exclude - Signals that must be excluded  
 3. Creative Macro - Arbitrary string to inject into creative
@@ -11,7 +11,7 @@ from typing import Dict, List, Any, Optional
 from pydantic import BaseModel, Field
 from datetime import datetime
 
-class AEEProvidedSignals(BaseModel):
+class AEESignals(BaseModel):
     """Signals provided by AEE for ad decisioning and customization."""
     
     # Existing signal types
@@ -38,8 +38,8 @@ class AEEResponse(BaseModel):
     should_bid: bool
     bid_price: Optional[float] = None
     
-    # Provided signals (all three types)
-    provided_signals: AEEProvidedSignals
+    # AEE signals (all three types)
+    aee_signals: AEESignals
     
     # Metadata
     decision_id: str
@@ -60,7 +60,7 @@ Example AEE Response:
 {
     "should_bid": true,
     "bid_price": 5.50,
-    "provided_signals": {
+    "aee_signals": {
         "may_include": ["sports", "premium_user"],
         "must_exclude": ["competitor_xyz"],
         "creative_macro": "city:San Francisco|weather:sunny|segment:tech_professional"

--- a/client_mcp.py
+++ b/client_mcp.py
@@ -60,7 +60,7 @@ async def run_test_flow(client: FastMCPClient):
     try:
         # 1. List products
         console.print("\n[bold]1. Listing available products:[/bold]")
-        result = await client.call_tool("list_products", {})
+        result = await client.call_tool("get_products", {})
         
         if result and hasattr(result, 'products'):
             table = Table(title="Available Products")
@@ -106,7 +106,7 @@ async def run_test_flow(client: FastMCPClient):
 async def interactive_mode(client: FastMCPClient):
     """Interactive mode for testing tools."""
     console.print("\n[bold cyan]Interactive Mode[/bold cyan]")
-    console.print("Commands: list_products, create_buy, submit_creative, status, quit")
+    console.print("Commands: get_products, create_buy, submit_creative, status, quit")
     
     while True:
         try:
@@ -114,8 +114,8 @@ async def interactive_mode(client: FastMCPClient):
             
             if command == "quit":
                 break
-            elif command == "list_products":
-                result = await client.call_tool("list_products", {})
+            elif command == "get_products":
+                result = await client.call_tool("get_products", {})
                 if result and hasattr(result, 'products'):
                     for product in result.products[:5]:
                         console.print(f"  • {product.product_id}: {product.name}")

--- a/examples/upstream_quickstart.py
+++ b/examples/upstream_quickstart.py
@@ -197,7 +197,7 @@ async def test_product_listing():
             print(f"📝 Brief: {brief}")
             
             try:
-                result = await client.tools.list_products(brief=brief)
+                result = await client.tools.get_products(brief=brief)
                 products = result.get('products', [])
                 
                 print(f"📦 Got {len(products)} products:")

--- a/get_tokens.py
+++ b/get_tokens.py
@@ -42,7 +42,7 @@ def get_tokens():
     conn.close()
     
     print("\n\n💡 Example API calls:")
-    print("   curl -H \"x-adcp-auth: [TOKEN]\" http://localhost:8080/mcp/tools/list_products")
+    print("   curl -H \"x-adcp-auth: [TOKEN]\" http://localhost:8080/mcp/tools/get_products")
     print("   curl -H \"x-adcp-auth: [TOKEN]\" http://localhost:8080/mcp/tools/get_principal_summary")
     print("\n")
 

--- a/main.py
+++ b/main.py
@@ -282,7 +282,7 @@ def _verify_principal(media_buy_id: str, context: Context):
 # --- MCP Tools (Full Implementation) ---
 
 @mcp.tool
-async def list_products(req: ListProductsRequest, context: Context) -> ListProductsResponse:
+async def get_products(req: GetProductsRequest, context: Context) -> GetProductsResponse:
     principal_id = _get_principal_id_from_context(context) # Authenticate
     
     # Get tenant information
@@ -309,7 +309,105 @@ async def list_products(req: ListProductsRequest, context: Context) -> ListProdu
         context=None  # Could add additional context here if needed
     )
     
-    return ListProductsResponse(products=products)
+    return GetProductsResponse(products=products)
+
+@mcp.tool
+async def get_signals(req: GetSignalsRequest, context: Context) -> GetSignalsResponse:
+    """Optional endpoint for discovering available signals (audiences, contextual, etc.)"""
+    principal_id = _get_principal_id_from_context(context)
+    
+    # Get tenant information
+    tenant = get_current_tenant()
+    if not tenant:
+        raise ToolError("No tenant context available")
+    
+    # Mock implementation - in production, this would query from a signal provider
+    # or the ad server's available audience segments
+    signals = []
+    
+    # Sample signals for demonstration
+    sample_signals = [
+        Signal(
+            signal_id="auto_intenders_q1_2025",
+            name="Auto Intenders Q1 2025",
+            description="Users actively researching new vehicles in Q1 2025",
+            type="audience",
+            category="automotive",
+            reach=2.5,
+            cpm_uplift=3.0
+        ),
+        Signal(
+            signal_id="luxury_travel_enthusiasts",
+            name="Luxury Travel Enthusiasts",
+            description="High-income individuals interested in premium travel experiences",
+            type="audience",
+            category="travel",
+            reach=1.2,
+            cpm_uplift=5.0
+        ),
+        Signal(
+            signal_id="sports_content",
+            name="Sports Content Pages",
+            description="Target ads on sports-related content",
+            type="contextual",
+            category="sports",
+            reach=15.0,
+            cpm_uplift=1.5
+        ),
+        Signal(
+            signal_id="finance_content",
+            name="Finance & Business Content",
+            description="Target ads on finance and business content",
+            type="contextual",
+            category="finance",
+            reach=8.0,
+            cpm_uplift=2.0
+        ),
+        Signal(
+            signal_id="urban_millennials",
+            name="Urban Millennials",
+            description="Millennials living in major metropolitan areas",
+            type="audience",
+            category="demographic",
+            reach=5.0,
+            cpm_uplift=1.8
+        ),
+        Signal(
+            signal_id="pet_owners",
+            name="Pet Owners",
+            description="Households with dogs or cats",
+            type="audience",
+            category="lifestyle",
+            reach=35.0,
+            cpm_uplift=1.2
+        )
+    ]
+    
+    # Filter based on request parameters
+    for signal in sample_signals:
+        # Apply query filter
+        if req.query:
+            query_lower = req.query.lower()
+            if (query_lower not in signal.name.lower() and 
+                query_lower not in signal.description.lower() and
+                query_lower not in signal.category.lower()):
+                continue
+        
+        # Apply type filter
+        if req.type and signal.type != req.type:
+            continue
+            
+        # Apply category filter
+        if req.category and signal.category != req.category:
+            continue
+            
+        signals.append(signal)
+    
+    # Apply limit
+    if req.limit:
+        signals = signals[:req.limit]
+    
+    return GetSignalsResponse(signals=signals)
 
 @mcp.tool
 def create_media_buy(req: CreateMediaBuyRequest, context: Context) -> CreateMediaBuyResponse:

--- a/schemas.py
+++ b/schemas.py
@@ -125,6 +125,9 @@ class Targeting(BaseModel):
     audiences_any_of: Optional[List[str]] = None  # Audience segments
     audiences_none_of: Optional[List[str]] = None
     
+    # Signal targeting - can use signal IDs from get_signals endpoint
+    signals: Optional[List[str]] = None  # Signal IDs like ["auto_intenders_q1_2025", "sports_content"]
+    
     # Media type targeting
     media_type_any_of: Optional[List[str]] = None  # ["video", "audio", "display", "native"]
     media_type_none_of: Optional[List[str]] = None
@@ -214,10 +217,10 @@ class UpdatePerformanceIndexResponse(BaseModel):
     detail: str
 
 # --- Discovery ---
-class ListProductsRequest(BaseModel):
+class GetProductsRequest(BaseModel):
     brief: str
 
-class ListProductsResponse(BaseModel):
+class GetProductsResponse(BaseModel):
     products: List[Product]
 
 # --- Creative Lifecycle ---
@@ -686,4 +689,27 @@ class CheckAEERequirementsResponse(BaseModel):
     missing_dimensions: List[str]
     available_dimensions: List[str]
 
-# Creative macro is now a simple string passed via AEE provided_signals
+# Creative macro is now a simple string passed via AEE aee_signals
+
+# --- Signal Discovery ---
+class Signal(BaseModel):
+    """Represents an available signal (audience, contextual, geographic, etc.)"""
+    signal_id: str
+    name: str
+    description: str
+    type: Literal["audience", "contextual", "geographic", "behavioral", "custom"]
+    category: Optional[str] = None  # e.g., "automotive", "finance", "sports"
+    reach: Optional[float] = None  # Estimated reach percentage
+    cpm_uplift: Optional[float] = None  # Expected CPM increase when using this signal
+    metadata: Optional[Dict[str, Any]] = {}
+
+class GetSignalsRequest(BaseModel):
+    """Request to discover available signals."""
+    query: Optional[str] = None  # Natural language search query
+    type: Optional[str] = None  # Filter by signal type
+    category: Optional[str] = None  # Filter by category
+    limit: Optional[int] = 100
+
+class GetSignalsResponse(BaseModel):
+    """Response containing available signals."""
+    signals: List[Signal]

--- a/simulation_full.py
+++ b/simulation_full.py
@@ -89,8 +89,8 @@ class FullLifecycleSimulation:
         brief = "Looking for video and audio inventory to reach pet owners during prime time and drive time"
         console.print(f"[yellow]Campaign Brief:[/yellow] {brief}")
         
-        console.print("\n[yellow]Calling list_products...[/yellow]")
-        products_response = await self._call_tool("list_products", {
+        console.print("\n[yellow]Calling get_products...[/yellow]")
+        products_response = await self._call_tool("get_products", {
             "req": {"brief": brief}
         })
         self.products = products_response.get("products", [])

--- a/test_main.py
+++ b/test_main.py
@@ -3,7 +3,7 @@ import os
 import json
 
 # Ensure the main module can be imported
-from schemas import ListProductsRequest, ListProductsResponse, Product
+from schemas import GetProductsRequest, GetProductsResponse, Product
 from database import init_db
 from config_loader import set_current_tenant, get_default_tenant, get_current_tenant
 from db_config import get_db_connection
@@ -83,7 +83,7 @@ class TestAdcpServerV2_3(unittest.TestCase):
     def test_product_catalog_schema_conformance(self):
         """
         Tests that the product catalog data exists and has expected fields.
-        Since list_products now requires authentication context, we test
+        Since get_products now requires authentication context, we test
         the underlying catalog functionality instead.
         """
         # Test that we can query products from the database


### PR DESCRIPTION
## Summary
- Rename `list_products` endpoint to `get_products` for consistency with signals agent spec
- Add optional `get_signals` endpoint for discovering available signals (audiences, contextual, geographic)
- Add `signals` field to targeting schema for direct signal activation
- Rename `provided_signals` to `aee_signals` throughout codebase for clarity
- Update all tests, examples, and documentation to reflect new endpoint names

## Context
These changes align with [AdCP PR #11](https://github.com/adcontextprotocol/adcp/pull/11) to improve signal discovery and targeting capabilities across the platform.

## Changes Made

### 1. Endpoint Renaming
- Renamed `list_products` → `get_products` in:
  - main.py
  - schemas.py (ListProductsRequest/Response → GetProductsRequest/Response)
  - All test files
  - Example scripts
  - Client code

### 2. New Signal Discovery Endpoint
- Added `get_signals` endpoint with:
  - Natural language query support
  - Type filtering (audience, contextual, geographic, behavioral, custom)
  - Category filtering
  - Mock implementation with sample signals

### 3. Enhanced Targeting
- Added `signals` field to Targeting schema
- Allows direct use of signal IDs from get_signals endpoint
- Works through existing targeting_overlay in media buy creation

### 4. Terminology Updates
- Renamed AEEProvidedSignals → AEESignals
- Updated field name: provided_signals → aee_signals
- Updated documentation comments

## Test Plan
- [x] All existing tests pass with new endpoint names
- [x] Merge conflicts resolved successfully
- [ ] CI passes
- [ ] Manual testing of get_signals endpoint
- [ ] Verify backward compatibility considerations

🤖 Generated with [Claude Code](https://claude.ai/code)