### PR TITLE
feat: Policy settings UI redesign with view/edit modes

### DIFF
--- a/policy_check_service.py
+++ b/policy_check_service.py
@@ -126,21 +126,29 @@ Respond with a JSON object containing:
 Be strict in your analysis. When in doubt, mark as restricted rather than allowed."""
 
         # Add tenant-specific policies if provided
-        if tenant_policies and tenant_policies.get("custom_rules"):
-            custom_rules = tenant_policies["custom_rules"]
+        if tenant_policies:
             rules_text = []
             
-            if custom_rules.get("prohibited_advertisers"):
-                rules_text.append(f"Prohibited advertisers: {', '.join(custom_rules['prohibited_advertisers'])}")
+            # Default prohibited categories and tactics are enforced for all
+            default_categories = tenant_policies.get("default_prohibited_categories", [])
+            default_tactics = tenant_policies.get("default_prohibited_tactics", [])
             
-            if custom_rules.get("prohibited_categories"):
-                rules_text.append(f"Prohibited categories: {', '.join(custom_rules['prohibited_categories'])}")
+            # Combine default and custom policies
+            all_prohibited_advertisers = tenant_policies.get("prohibited_advertisers", [])
+            all_prohibited_categories = default_categories + tenant_policies.get("prohibited_categories", [])
+            all_prohibited_tactics = default_tactics + tenant_policies.get("prohibited_tactics", [])
             
-            if custom_rules.get("prohibited_tactics"):
-                rules_text.append(f"Prohibited tactics: {', '.join(custom_rules['prohibited_tactics'])}")
+            if all_prohibited_advertisers:
+                rules_text.append(f"Prohibited advertisers/domains: {', '.join(all_prohibited_advertisers)}")
+            
+            if all_prohibited_categories:
+                rules_text.append(f"Prohibited content categories: {', '.join(all_prohibited_categories)}")
+            
+            if all_prohibited_tactics:
+                rules_text.append(f"Prohibited advertising tactics: {', '.join(all_prohibited_tactics)}")
             
             if rules_text:
-                system_prompt += f"\n\nAdditional tenant-specific rules:\n" + "\n".join(rules_text)
+                system_prompt += f"\n\nPolicy rules to enforce:\n" + "\n".join(rules_text)
         
         try:
             response = await self.model.generate_content([

--- a/setup_tenant.py
+++ b/setup_tenant.py
@@ -63,12 +63,11 @@ def create_tenant(args):
         },
         "policy_settings": {
             "enabled": True,
-            "custom_rules": {
-                "prohibited_advertisers": [],
-                "prohibited_categories": [],
-                "prohibited_tactics": []
-            },
-            "require_manual_review": False
+            "require_manual_review": False,
+            "prohibited_advertisers": [],
+            "prohibited_categories": [],
+            "prohibited_tactics": []
+            # Default policies are defined in the application code
         },
         "admin_token": args.admin_token or secrets.token_urlsafe(32)
     })

--- a/templates/policy_settings_comprehensive.html
+++ b/templates/policy_settings_comprehensive.html
@@ -1,0 +1,399 @@
+{% extends "base.html" %}
+
+{% block title %}Policy Settings - {{ tenant_name }}{% endblock %}
+
+{% block content %}
+<style>
+    /* View mode styles */
+    .view-mode .edit-only {
+        display: none !important;
+    }
+    .view-mode .form-check-input {
+        pointer-events: none;
+        opacity: 0.8;
+    }
+    .view-mode .card {
+        background-color: #f8f9fa;
+    }
+    .view-mode .card-header {
+        background-color: #e9ecef;
+    }
+    
+    /* Edit mode styles */
+    .edit-mode .view-only {
+        display: none !important;
+    }
+    .edit-mode .card {
+        border-color: #007bff;
+        box-shadow: 0 0 0 0.2rem rgba(0,123,255,.25);
+    }
+    .edit-mode .card-header {
+        background-color: #007bff;
+        color: white;
+    }
+    
+    /* List display in view mode */
+    .policy-list {
+        max-height: 200px;
+        overflow-y: auto;
+        background-color: white;
+        border: 1px solid #dee2e6;
+        border-radius: 0.25rem;
+        padding: 0.5rem;
+    }
+    .policy-list-item {
+        padding: 0.25rem 0;
+        border-bottom: 1px solid #f8f9fa;
+    }
+    .policy-list-item:last-child {
+        border-bottom: none;
+    }
+    .policy-count {
+        color: #6c757d;
+        font-weight: 500;
+    }
+</style>
+
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-12 d-flex justify-content-between align-items-center">
+            <div>
+                <h1>Policy Settings - {{ tenant_name }}</h1>
+                <nav aria-label="breadcrumb">
+                    <ol class="breadcrumb">
+                        <li class="breadcrumb-item"><a href="/tenant/{{ tenant_id }}">Dashboard</a></li>
+                        <li class="breadcrumb-item active">Policy Settings</li>
+                    </ol>
+                </nav>
+            </div>
+            <div class="view-only">
+                <button type="button" class="btn btn-primary" onclick="enterEditMode()">
+                    <i class="fas fa-edit"></i> Edit Settings
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <div id="policy-container" class="view-mode">
+        <form action="/tenant/{{ tenant_id }}/policy/update" method="POST" id="policy-form">
+        <div class="row mt-4">
+            <!-- General Settings -->
+            <div class="col-md-4">
+                <div class="card">
+                    <div class="card-header">
+                        <h5 class="mb-0">General Settings</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="form-check mb-3">
+                            <input class="form-check-input" type="checkbox" id="enabled" name="enabled" 
+                                   {% if policy_settings.enabled %}checked{% endif %}>
+                            <label class="form-check-label" for="enabled">
+                                Enable Policy Checks
+                            </label>
+                            <small class="form-text text-muted">
+                                When enabled, all advertising briefs will be checked against policy rules
+                            </small>
+                        </div>
+
+                        <div class="form-check mb-3">
+                            <input class="form-check-input" type="checkbox" id="require_manual_review" name="require_manual_review" 
+                                   {% if policy_settings.require_manual_review %}checked{% endif %}>
+                            <label class="form-check-label" for="require_manual_review">
+                                Require Manual Review
+                            </label>
+                            <small class="form-text text-muted">
+                                Create review tasks for policy violations instead of auto-rejecting
+                            </small>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Pending Reviews -->
+                <div class="card mt-3">
+                    <div class="card-header">
+                        <h5 class="mb-0">Pending Reviews ({{ pending_reviews|length }})</h5>
+                    </div>
+                    <div class="card-body">
+                        {% if pending_reviews %}
+                            <div class="list-group">
+                                {% for review in pending_reviews[:5] %}
+                                <a href="/tenant/{{ tenant_id }}/policy/review/{{ review.task_id }}" 
+                                   class="list-group-item list-group-item-action">
+                                    <div class="d-flex w-100 justify-content-between">
+                                        <h6 class="mb-1">{{ review.brief[:50] }}...</h6>
+                                        <small>{{ review.created_at }}</small>
+                                    </div>
+                                    <small class="text-muted">Click to review</small>
+                                </a>
+                                {% endfor %}
+                            </div>
+                            {% if pending_reviews|length > 5 %}
+                                <div class="mt-2 text-center">
+                                    <small class="text-muted">and {{ pending_reviews|length - 5 }} more...</small>
+                                </div>
+                            {% endif %}
+                        {% else %}
+                            <p class="text-muted mb-0">No pending reviews</p>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+
+            <!-- Prohibited Categories -->
+            <div class="col-md-4">
+                <div class="card">
+                    <div class="card-header">
+                        <h5 class="mb-0">Prohibited Categories</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="form-group">
+                            <label>Default Prohibited Categories</label>
+                            <div class="border rounded p-2 mb-3" style="background-color: #f8f9fa;">
+                                <small class="text-muted">These are enforced by default:</small>
+                                <ul class="mb-0 small">
+                                {% for category in policy_settings.default_prohibited_categories %}
+                                    <li>{{ category.replace('_', ' ').title() }}</li>
+                                {% endfor %}
+                                </ul>
+                            </div>
+                            
+                            <label for="prohibited_categories">Additional Prohibited Categories <span class="policy-count view-only">({{ policy_settings.prohibited_categories|length }})</span></label>
+                            
+                            <!-- View mode display -->
+                            <div class="view-only">
+                                {% if policy_settings.prohibited_categories %}
+                                    <div class="policy-list">
+                                        {% for category in policy_settings.prohibited_categories %}
+                                            <div class="policy-list-item">{{ category }}</div>
+                                        {% endfor %}
+                                    </div>
+                                {% else %}
+                                    <div class="text-muted">No additional categories configured</div>
+                                {% endif %}
+                            </div>
+                            
+                            <!-- Edit mode input -->
+                            <div class="edit-only">
+                                <textarea class="form-control" id="prohibited_categories" name="prohibited_categories" 
+                                          rows="10" placeholder="Enter one category per line">{{ '\n'.join(policy_settings.prohibited_categories) }}</textarea>
+                                <small class="form-text text-muted">
+                                    Add custom categories specific to your publication
+                                </small>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Prohibited Tactics & Advertisers -->
+            <div class="col-md-4">
+                <div class="card">
+                    <div class="card-header">
+                        <h5 class="mb-0">Prohibited Tactics</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="form-group">
+                            <label>Default Prohibited Tactics</label>
+                            <div class="border rounded p-2 mb-3" style="background-color: #f8f9fa;">
+                                <small class="text-muted">These are enforced by default:</small>
+                                <ul class="mb-0 small">
+                                {% for tactic in policy_settings.default_prohibited_tactics %}
+                                    <li>{{ tactic.replace('_', ' ').title() }}</li>
+                                {% endfor %}
+                                </ul>
+                            </div>
+                            
+                            <label for="prohibited_tactics">Additional Prohibited Tactics <span class="policy-count view-only">({{ policy_settings.prohibited_tactics|length }})</span></label>
+                            
+                            <!-- View mode display -->
+                            <div class="view-only">
+                                {% if policy_settings.prohibited_tactics %}
+                                    <div class="policy-list">
+                                        {% for tactic in policy_settings.prohibited_tactics %}
+                                            <div class="policy-list-item">{{ tactic }}</div>
+                                        {% endfor %}
+                                    </div>
+                                {% else %}
+                                    <div class="text-muted">No additional tactics configured</div>
+                                {% endif %}
+                            </div>
+                            
+                            <!-- Edit mode input -->
+                            <div class="edit-only">
+                                <textarea class="form-control" id="prohibited_tactics" name="prohibited_tactics" 
+                                          rows="6" placeholder="Enter one tactic per line">{{ '\n'.join(policy_settings.prohibited_tactics) }}</textarea>
+                                <small class="form-text text-muted">
+                                    Add tactics that violate your advertising standards
+                                </small>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="card mt-3">
+                    <div class="card-header">
+                        <h5 class="mb-0">Prohibited Advertisers</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="form-group">
+                            <label for="prohibited_advertisers">Blocked Domains/Companies <span class="policy-count view-only">({{ policy_settings.prohibited_advertisers|length }})</span></label>
+                            
+                            <!-- View mode display -->
+                            <div class="view-only">
+                                {% if policy_settings.prohibited_advertisers %}
+                                    <div class="policy-list">
+                                        {% for advertiser in policy_settings.prohibited_advertisers %}
+                                            <div class="policy-list-item">{{ advertiser }}</div>
+                                        {% endfor %}
+                                    </div>
+                                {% else %}
+                                    <div class="text-muted">No advertisers blocked</div>
+                                {% endif %}
+                            </div>
+                            
+                            <!-- Edit mode input -->
+                            <div class="edit-only">
+                                <textarea class="form-control" id="prohibited_advertisers" name="prohibited_advertisers" 
+                                          rows="6" placeholder="Enter one advertiser/domain per line
+Example:
+spam-site.com
+competitor.com">{{ '\n'.join(policy_settings.prohibited_advertisers) }}</textarea>
+                                <small class="form-text text-muted">
+                                    These advertisers will be blocked from advertising
+                                </small>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row mt-3 edit-only">
+            <div class="col-md-12">
+                <button type="submit" class="btn btn-primary">Save All Policy Settings</button>
+                <button type="button" class="btn btn-secondary" onclick="exitEditMode()">Cancel</button>
+            </div>
+        </div>
+        </form>
+    </div>
+
+    <!-- Recent Policy Checks -->
+    <div class="row mt-5">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="mb-0">Recent Policy Checks</h5>
+                </div>
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <table class="table table-sm">
+                            <thead>
+                                <tr>
+                                    <th>Timestamp</th>
+                                    <th>Principal</th>
+                                    <th>Status</th>
+                                    <th>Brief</th>
+                                    <th>Reason</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for check in recent_checks %}
+                                <tr>
+                                    <td>{{ check.timestamp }}</td>
+                                    <td>{{ check.principal_id }}</td>
+                                    <td>
+                                        {% if check.status == 'blocked' %}
+                                            <span class="badge badge-danger">Blocked</span>
+                                        {% elif check.status == 'restricted' %}
+                                            <span class="badge badge-warning">Restricted</span>
+                                        {% elif check.status == 'allowed' %}
+                                            <span class="badge badge-success">Allowed</span>
+                                        {% else %}
+                                            <span class="badge badge-secondary">{{ check.status }}</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>{{ check.brief[:50] }}...</td>
+                                    <td>{{ check.reason if check.reason else '-' }}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                        {% if not recent_checks %}
+                            <p class="text-muted text-center">No policy checks recorded yet</p>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row mt-4">
+        <div class="col-md-12">
+            <div class="alert alert-info">
+                <h5>How Policy Checks Work</h5>
+                <ul class="mb-0">
+                    <li><strong>AI-Powered Analysis:</strong> All advertising briefs are analyzed using AI to detect policy violations.</li>
+                    <li><strong>Default Policies:</strong> Standard prohibited categories and tactics are enforced automatically.</li>
+                    <li><strong>Custom Policies:</strong> Add your own prohibited categories, tactics, and advertisers specific to your publication.</li>
+                    <li><strong>Manual Review:</strong> Enable to review violations before rejection, or disable for automatic blocking.</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+function enterEditMode() {
+    const container = document.getElementById('policy-container');
+    container.classList.remove('view-mode');
+    container.classList.add('edit-mode');
+    
+    // Focus on first input
+    setTimeout(() => {
+        document.getElementById('enabled').focus();
+    }, 100);
+}
+
+function exitEditMode() {
+    const container = document.getElementById('policy-container');
+    container.classList.remove('edit-mode');
+    container.classList.add('view-mode');
+    
+    // Reset form to original values (reload page to get fresh data)
+    if (confirm('Discard any unsaved changes?')) {
+        window.location.reload();
+    } else {
+        // Stay in edit mode if user cancels
+        container.classList.add('edit-mode');
+        container.classList.remove('view-mode');
+    }
+}
+
+// Add visual feedback when form is dirty
+document.addEventListener('DOMContentLoaded', function() {
+    const form = document.getElementById('policy-form');
+    const formElements = form.querySelectorAll('input, textarea');
+    let formChanged = false;
+    let isSubmitting = false;
+    
+    formElements.forEach(element => {
+        element.addEventListener('change', function() {
+            formChanged = true;
+        });
+    });
+    
+    // Mark form as submitting when save button is clicked
+    form.addEventListener('submit', function() {
+        isSubmitting = true;
+    });
+    
+    // Warn before leaving if form has changes (but not when submitting)
+    window.addEventListener('beforeunload', function(e) {
+        if (formChanged && !isSubmitting && document.getElementById('policy-container').classList.contains('edit-mode')) {
+            e.preventDefault();
+            e.returnValue = '';
+        }
+    });
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Redesigned policy settings page with distinct view and edit modes
- Unified all policy settings (default + custom) on a single comprehensive page
- Fixed PostgreSQL JSONB parsing issues and OAuth redirect behavior

## Changes

### UI/UX Improvements
- **View/Edit Modes**: 
  - View mode shows read-only display with gray background and policy lists
  - Edit mode highlights cards with blue borders and shows form inputs
  - "Edit Settings" button to enter edit mode, Save/Cancel buttons only in edit mode
  
- **Enhanced Policy Display**:
  - Item counts shown next to section labels in view mode
  - Scrollable lists for viewing configured policies
  - Clear empty states when no policies are configured
  
- **User Safety**:
  - Confirmation dialog when canceling edit mode with unsaved changes
  - Browser warning on navigation with unsaved changes (except on form submit)
  - Form change tracking to prevent accidental data loss

### Backend Changes
- **JSON Parsing Fix**: Added `parse_json_config()` helper to handle both SQLite string and PostgreSQL JSONB dictionary formats
- **OAuth Redirect Fix**: Store and restore original URL after OAuth login using session['next_url']
- **Policy Structure**: Flattened policy configuration, removed nested "custom_rules" concept
- **Policy Enforcement**: Combined default and tenant-specific policies in AI prompts

### Technical Details
- Updated `admin_ui.py` with new routes and logic
- Created new template `policy_settings_comprehensive.html`
- Modified `policy_check_service.py` to merge default and custom policies
- Updated `setup_tenant.py` with new config structure

## Test Plan
- [x] Test view/edit mode transitions
- [x] Test policy editing and saving
- [x] Test OAuth redirect to policy page
- [x] Verify no browser warnings on form submit
- [ ] Test with both SQLite and PostgreSQL
- [ ] Verify policy enforcement with combined rules

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>