### PR TITLE
Fix excessive mocking in GAM tenant setup tests

### DIFF
--- a/scripts/setup/setup_tenant.py
+++ b/scripts/setup/setup_tenant.py
@@ -42,6 +42,10 @@ def create_tenant(args):
             sys.exit(1)
 
         # Create tenant with new schema
+        from datetime import datetime
+
+        now = datetime.utcnow()
+
         tenant = Tenant(
             tenant_id=tenant_id,
             name=args.name,
@@ -55,6 +59,8 @@ def create_tenant(args):
             policy_settings=policy_settings,
             is_active=True,
             billing_plan="standard",
+            created_at=now,
+            updated_at=now,
         )
         session.add(tenant)
 


### PR DESCRIPTION
## Summary
Fixes the "excessive mocking" error that was blocking pre-commit hooks and forcing developers to use `--no-verify` for commits.

- **Reduced mock count**: 17 → 3 mocks (well under the 10-mock limit)  
- **Fixed pre-commit hook**: `no-excessive-mocking` now passes ✅
- **Improved test quality**: Uses real database instead of extensive mocking
- **Follows project standards**: Integration tests now use real DB and only mock external APIs

## Changes Made

### Core Refactoring
- **Removed database session mocking**: Eliminated 12+ Mock objects for database operations
- **Used proper test fixtures**: Leveraged `test_database` fixtures from `conftest_db.py`
- **Converted to SQLAlchemy ORM**: Replaced raw SQL with proper ORM operations
- **Added test isolation**: Uses unique UUID-based tenant IDs to prevent test conflicts

### Bug Fixes  
- **Fixed timestamp issue**: Added required `created_at`/`updated_at` to `setup_tenant.py`
- **Fixed skip decorator**: Changed `@pytest.mark.skip` to `@pytest.mark.xfail` per project rules

## Test Results
```
Before: 17 mocks (failed pre-commit)
After:  3 mocks (passes pre-commit) ✅
```

All core tests pass and the pre-commit hook now works correctly.

## Files Changed
- `tests/integration/test_gam_tenant_setup.py`: Massive simplification (-163 lines, +73 lines)
- `scripts/setup/setup_tenant.py`: Added missing timestamp handling (+6 lines)

## Impact
✅ Developers can now commit normally without `--no-verify`  
✅ Tests are more reliable and follow project testing patterns  
✅ Integration tests properly verify database operations work

🤖 Generated with [Claude Code](https://claude.ai/code)