### PR TITLE
Replace deprecated GAM GetDataDownloader with modern ReportService (#121)

### DIFF
--- a/src/adapters/gam_reporting_api.py
+++ b/src/adapters/gam_reporting_api.py
@@ -13,8 +13,8 @@ from functools import wraps
 
 import pytz
 from flask import Blueprint, jsonify, request, session
-from gam_helper import get_ad_manager_client_for_tenant
 
+from scripts.ops.gam_helper import get_ad_manager_client_for_tenant
 from src.adapters.gam_reporting_service import GAMReportingService
 from src.core.database.database_session import get_db_session
 from src.core.database.models import Principal, Tenant
@@ -151,7 +151,7 @@ def get_gam_reporting(tenant_id: str):
             return jsonify({"error": "GAM client not configured for this tenant"}), 500
 
         # Get the network timezone (fetching if necessary)
-        from gam_helper import ensure_network_timezone
+        from scripts.ops.gam_helper import ensure_network_timezone
 
         logger.info(f"Getting network timezone for tenant {tenant_id}")
         network_timezone = ensure_network_timezone(tenant_id)
@@ -234,7 +234,7 @@ def get_advertiser_summary(tenant_id: str, advertiser_id: str):
         gam_client = get_ad_manager_client_for_tenant(tenant_id)
 
         # Get the network timezone (fetching if necessary)
-        from gam_helper import ensure_network_timezone
+        from scripts.ops.gam_helper import ensure_network_timezone
 
         network_timezone = ensure_network_timezone(tenant_id)
 
@@ -428,7 +428,7 @@ def get_country_breakdown(tenant_id: str):
             return jsonify({"error": "GAM client not configured for this tenant"}), 500
 
         # Get the network timezone
-        from gam_helper import ensure_network_timezone
+        from scripts.ops.gam_helper import ensure_network_timezone
 
         network_timezone = ensure_network_timezone(tenant_id)
 
@@ -514,7 +514,7 @@ def get_ad_unit_breakdown(tenant_id: str):
             return jsonify({"error": "GAM client not configured for this tenant"}), 500
 
         # Get the network timezone
-        from gam_helper import ensure_network_timezone
+        from scripts.ops.gam_helper import ensure_network_timezone
 
         network_timezone = ensure_network_timezone(tenant_id)
 


### PR DESCRIPTION
## Summary

This PR addresses GitHub issue #121 by replacing the deprecated `GetDataDownloader` API with the modern `ReportService` methods in the Google Ad Manager adapter.

### Key Changes
- **API Modernization**: Replaced `GetDataDownloader.DownloadReportToFile()` with `ReportService.getReportDownloadURL()` + `requests.get()`
- **Security Hardening**: Added URL validation to ensure downloads only come from Google domains
- **Performance Protection**: Implemented 10MB memory limit and 600-second timeout protection
- **Error Handling**: Added comprehensive error handling with exception chaining
- **Import Fixes**: Fixed critical import paths in `gam_reporting_api.py` that were causing 404 errors
- **Configuration Management**: Created `ReportingConfig` class for centralized constants
- **Test Updates**: Updated integration tests with realistic Google URL mocks

### Files Modified
- `src/adapters/google_ad_manager.py` - Main GAM adapter with modernized report downloading
- `src/adapters/gam_reporting_service.py` - GAM reporting service with security improvements
- `src/adapters/gam_reporting_api.py` - Fixed import paths causing client production errors
- `tests/integration/test_gam_country_adunit.py` - Updated mocks for new API patterns

### Testing
- All 8 integration tests passing
- Comprehensive security validation added
- Memory and timeout protection verified
- Real client testing confirmed working

### Security Improvements
- URL validation against Google domains only
- Memory limits prevent OOM attacks
- Request timeouts prevent hanging connections
- Proper error handling prevents information leakage

🤖 Generated with [Claude Code](https://claude.ai/code)