### PR TITLE
Wire up application startup integration and configuration validation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,14 @@ services:
       # Gemini API key (required for AI features)
       GEMINI_API_KEY: ${GEMINI_API_KEY}
 
+      # Super admin authorization (required for startup validation)
+      SUPER_ADMIN_EMAILS: ${SUPER_ADMIN_EMAILS}
+      SUPER_ADMIN_DOMAINS: ${SUPER_ADMIN_DOMAINS}
+
+      # Optional: Google OAuth credentials via environment
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
+
       # GAM OAuth credentials (required for Google Ad Manager functionality)
       GAM_OAUTH_CLIENT_ID: ${GAM_OAUTH_CLIENT_ID:-}
       GAM_OAUTH_CLIENT_SECRET: ${GAM_OAUTH_CLIENT_SECRET:-}

--- a/scripts/run_server.py
+++ b/scripts/run_server.py
@@ -8,6 +8,23 @@ import sys
 
 def main():
     """Run the server with configurable port."""
+    # Initialize application with startup validation
+    try:
+        # Add current directory to path for imports
+        sys.path.insert(0, ".")
+        from src.core.startup import initialize_application
+
+        print("🚀 Initializing AdCP Sales Agent...")
+        initialize_application()
+        print("✅ Application initialization completed")
+
+    except SystemExit:
+        print("❌ Application initialization failed - check logs")
+        sys.exit(1)
+    except Exception as e:
+        print(f"❌ Startup error: {e}")
+        sys.exit(1)
+
     port = os.environ.get("ADCP_SALES_PORT", "8080")
     host = os.environ.get("ADCP_SALES_HOST", "0.0.0.0")
 

--- a/src/admin/blueprints/core.py
+++ b/src/admin/blueprints/core.py
@@ -67,6 +67,32 @@ def health():
         return f"Database connection failed: {str(e)}", 500
 
 
+@core_bp.route("/health/config")
+def health_config():
+    """Configuration health check endpoint."""
+    try:
+        from src.core.startup import validate_startup_requirements
+
+        validate_startup_requirements()
+        return (
+            jsonify(
+                {
+                    "status": "healthy",
+                    "service": "admin-ui",
+                    "component": "configuration",
+                    "message": "All configuration validation passed",
+                }
+            ),
+            200,
+        )
+    except Exception as e:
+        logger.error(f"Configuration health check failed: {e}")
+        return (
+            jsonify({"status": "unhealthy", "service": "admin-ui", "component": "configuration", "error": str(e)}),
+            500,
+        )
+
+
 @core_bp.route("/create_tenant", methods=["GET", "POST"])
 @require_auth(admin_only=True)
 def create_tenant():

--- a/src/admin/server.py
+++ b/src/admin/server.py
@@ -54,6 +54,24 @@ def run_uvicorn_asgi(app, port: int):
 
 def main():
     """Main entry point for the admin UI server."""
+    # Initialize application with startup validation
+    try:
+        import sys
+
+        sys.path.insert(0, ".")
+        from src.core.startup import initialize_application
+
+        logger.info("🚀 Initializing Admin UI...")
+        initialize_application()
+        logger.info("✅ Admin UI initialization completed")
+
+    except SystemExit:
+        logger.error("❌ Admin UI initialization failed - check logs")
+        sys.exit(1)
+    except Exception as e:
+        logger.error(f"❌ Admin UI startup error: {e}")
+        sys.exit(1)
+
     # Import the app factory
     from src.admin.app import create_app
 

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -4542,6 +4542,27 @@ async def health(request: Request):
     return JSONResponse({"status": "healthy", "service": "mcp"})
 
 
+@mcp.custom_route("/health/config", methods=["GET"])
+async def health_config(request: Request):
+    """Configuration health check endpoint."""
+    try:
+        from src.core.startup import validate_startup_requirements
+
+        validate_startup_requirements()
+        return JSONResponse(
+            {
+                "status": "healthy",
+                "service": "mcp",
+                "component": "configuration",
+                "message": "All configuration validation passed",
+            }
+        )
+    except Exception as e:
+        return JSONResponse(
+            {"status": "unhealthy", "service": "mcp", "component": "configuration", "error": str(e)}, status_code=500
+        )
+
+
 # Add admin UI routes when running unified
 if os.environ.get("ADCP_UNIFIED_MODE"):
     from fastapi.middleware.wsgi import WSGIMiddleware


### PR DESCRIPTION
## Summary

This PR completes the startup integration infrastructure by wiring up the application startup validation and initialization to the actual entry points of both the MCP server and Admin UI.

This builds on PR #137's Pydantic configuration system by actually integrating it into the application lifecycle.

- **Startup Integration**: Add `initialize_application()` calls to `scripts/run_server.py` and `src/admin/server.py` for early configuration validation and logging setup
- **Health Check Endpoints**: Add `/health/config` endpoints to both services for configuration validation status  
- **Environment Variables**: Ensure all required environment variables are passed to `adcp-server` service in Docker Compose
- **Error Handling**: Proper startup error handling that prevents services from starting with invalid configurations

## Changes

### Service Integration
- **MCP Server** (`scripts/run_server.py`): Call `initialize_application()` before starting FastMCP server
- **Admin UI** (`src/admin/server.py`): Call `initialize_application()` before starting Flask/Gunicorn

### Health Check Endpoints  
- **MCP**: `GET /health/config` - Configuration health check for MCP server
- **Admin UI**: `GET /health/config` - Configuration health check for Admin UI

### Docker Environment
- **docker-compose.yml**: Added missing environment variables (`SUPER_ADMIN_EMAILS`, `SUPER_ADMIN_DOMAINS`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`) to `adcp-server` service

## Test plan

- [x] Services start cleanly with proper configuration
- [x] Services fail gracefully with missing configuration  
- [x] Health check endpoints return proper status
- [x] Pre-commit hooks pass
- [x] No regression in existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)