### PR TITLE
fix(templates): Adjust `testSignals` fetch route to the proper settings one

### DIFF
--- a/templates/tenant_settings.html
+++ b/templates/tenant_settings.html
@@ -1690,7 +1690,7 @@ function testSignalsConnection() {
     button.textContent = 'Testing...';
     button.disabled = true;
 
-    fetch('{{ script_name }}/tenant/{{ tenant.tenant_id }}/test_signals', {
+    fetch('{{ script_name }}/tenant/{{ tenant.tenant_id }}/settings/test_signals', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',


### PR DESCRIPTION
Currently the `test_signals` API is registered under the `settings` blueprint [ref](https://github.com/adcontextprotocol/salesagent/blob/main/src/admin/blueprints/settings.py#L319) but the `fetch` call from the frontend assumes its at a top level route, this PR fixes it.