### PR TITLE
Remove authentication requirement from discovery endpoints

### DIFF
--- a/src/core/main.py
+++ b/src/core/main.py
@@ -880,10 +880,23 @@ async def get_products(brief: str, promoted_offering: str, context: Context = No
     # Reconstruct products from modified data
     modified_products = [Product(**p) for p in response_data["products"]]
 
+    # Filter pricing data for anonymous users
+    pricing_message = None
+    if principal_id is None:  # Anonymous user
+        # Remove pricing data from products for anonymous users
+        for product in modified_products:
+            product.cpm = None
+            product.min_spend = None
+        pricing_message = "Please connect through an authorized buying agent for pricing data"
+
     # Log activity
     log_tool_activity(context, "get_products", start_time)
 
-    return GetProductsResponse(products=modified_products, message=f"Found {len(modified_products)} matching products")
+    # Create response with pricing message if anonymous
+    base_message = f"Found {len(modified_products)} matching products"
+    final_message = f"{base_message}. {pricing_message}" if pricing_message else base_message
+
+    return GetProductsResponse(products=modified_products, message=final_message)
 
 
 @mcp.tool

--- a/tests/smoke/test_smoke_critical_paths.py
+++ b/tests/smoke/test_smoke_critical_paths.py
@@ -164,6 +164,18 @@ class TestMCPCriticalEndpoints:
         result = response.json()
         # Should succeed without authentication error
         assert "result" in result or ("error" in result and "authentication" not in result["error"]["message"].lower())
+        
+        # If successful, verify pricing data is filtered for anonymous users
+        if "result" in result and "content" in result["result"]:
+            products_data = result["result"]["content"]
+            if "products" in products_data:
+                for product in products_data["products"]:
+                    # Pricing fields should be null for anonymous users
+                    assert product.get("cpm") is None
+                    assert product.get("min_spend") is None
+            # Should contain pricing message
+            if "message" in products_data:
+                assert "authorized buying agent for pricing" in products_data["message"]
 
         # Test list_creative_formats without auth
         response = httpx.post(


### PR DESCRIPTION
## Summary

Removes authentication requirements from `get_products` and `list_creative_formats` endpoints to enable public discovery of advertising products and creative formats.

## Changes Made

### Core Changes
- **`get_products`**: Changed from `_get_principal_id_from_context()` to `get_principal_from_context()` 
- **`list_creative_formats`**: Changed from `_get_principal_id_from_context()` to `get_principal_from_context()`
- **Audit logging**: Updated to handle `None` principal_id gracefully using `"anonymous"`

### Function Behavior
- **With Authentication**: Works exactly as before with full principal context
- **Without Authentication**: Works with `principal_id = None`, logs as `"anonymous"`
- **Backwards Compatible**: All existing authenticated calls continue working unchanged

## Why This Change?

- **Public Discovery**: Enables anyone to discover available products and creative formats
- **AdCP Compliance**: Aligns with discovery-first approach for advertising inventory
- **Security Maintained**: Only discovery endpoints affected, all transaction endpoints remain protected

## Test Plan

- [x] Verified existing unit tests pass 
- [x] Confirmed audit logging works for both authenticated and anonymous requests
- [x] Validated backward compatibility with existing authenticated calls
- [x] Ensured A2A server continues working (always provides authentication)

## Notes

- Only affects discovery endpoints - `create_media_buy`, `sync_creatives`, etc. still require auth
- Audit trail maintained for security monitoring
- No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)