### PR TITLE
Fix branding and virtual host routing for custom domains

### DIFF
--- a/src/core/main.py
+++ b/src/core/main.py
@@ -4588,17 +4588,22 @@ if os.environ.get("ADCP_UNIFIED_MODE"):
     @mcp.custom_route("/", methods=["GET"])
     async def root(request: Request):
         """Handle root route - show landing page for virtual hosts, redirect to admin for others."""
-        # Check for Apx-Incoming-Host header (Approximated.app virtual host)
         headers = dict(request.headers)
-        apx_host = headers.get("apx-incoming-host")
 
-        if apx_host:
+        # Check for Apx-Incoming-Host header (Approximated.app virtual host)
+        apx_host = headers.get("apx-incoming-host")
+        # Also check standard Host header for direct virtual hosts
+        host_header = headers.get("host")
+
+        virtual_host = apx_host or host_header
+
+        if virtual_host:
             # Look up tenant by virtual host
-            tenant = get_tenant_by_virtual_host(apx_host)
+            tenant = get_tenant_by_virtual_host(virtual_host)
             if tenant:
                 # Generate enhanced landing page using dedicated module
                 try:
-                    html_content = generate_tenant_landing_page(tenant, apx_host)
+                    html_content = generate_tenant_landing_page(tenant, virtual_host)
                     return HTMLResponse(content=html_content)
                 except Exception as e:
                     logger.error(f"Error generating landing page for tenant {tenant.get('name', 'unknown')}: {e}")

--- a/src/landing/templates/tenant_landing.html
+++ b/src/landing/templates/tenant_landing.html
@@ -4,7 +4,7 @@
     <title>{{ page_title }}</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="{{ tenant_name }} AdCP Sales Agent - Connect your agent via MCP or A2A for programmatic advertising">
+    <meta name="description" content="{{ tenant_name }} Sales Agent - Connect your agent via MCP or A2A for programmatic advertising">
     <style>
         /* Modern, professional styling */
         * {
@@ -331,7 +331,7 @@
             Powered by <a href="{{ adcp_docs_url }}" target="_blank">AdCP Protocol</a>
             | <a href="{{ scope3_url }}" target="_blank">Scope3</a>
             {% if tenant_subdomain %}
-            | Tenant: {{ tenant_subdomain }}
+            | Account: {{ tenant_subdomain }}
             {% endif %}
         </div>
     </div>

--- a/templates/add_creative_format_ai.html
+++ b/templates/add_creative_format_ai.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}AI Creative Format Discovery - AdCP Admin{% endblock %}
+{% block title %}AI Creative Format Discovery - Scribd Sales Agent Admin{% endblock %}
 
 {% block content %}
 <div class="card">

--- a/templates/add_product.html
+++ b/templates/add_product.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Add Product - AdCP Admin{% endblock %}
+{% block title %}Add Product - Scribd Sales Agent Admin{% endblock %}
 
 {% block content %}
 <div class="card">

--- a/templates/add_product_ai.html
+++ b/templates/add_product_ai.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}AI Product Creation - AdCP Admin{% endblock %}
+{% block title %}AI Product Creation - Scribd Sales Agent Admin{% endblock %}
 
 {% block content %}
 <div class="card">

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{% block title %}AdCP Admin{% endblock %}</title>
+    <title>{% block title %}Scribd Sales Agent Admin{% endblock %}</title>
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Font Awesome -->
@@ -117,7 +117,7 @@
                 {% if session.tenant_name and session.role != 'super_admin' %}
                     {{ session.tenant_name }} Sales Agent Admin
                 {% else %}
-                    AdCP Sales Agent Admin
+                    Scribd Sales Agent Admin
                 {% endif %}
             </h1>
             <nav>
@@ -139,8 +139,8 @@
                         {% endif %}
                     </span>
                     {% if session.role == 'super_admin' %}
-                        <a href="{{ script_name }}/">Tenants</a>
-                        <a href="{{ script_name }}/create_tenant">Create Tenant</a>
+                        <a href="{{ script_name }}/">Accounts</a>
+                        <a href="{{ script_name }}/create_tenant">Create Account</a>
                     {% endif %}
                     <a href="{{ script_name }}/logout">Logout</a>
                 {% endif %}

--- a/templates/bulk_product_upload.html
+++ b/templates/bulk_product_upload.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Bulk Product Upload - AdCP Admin{% endblock %}
+{% block title %}Bulk Product Upload - Scribd Sales Agent Admin{% endblock %}
 
 {% block content %}
 <div class="card">

--- a/templates/choose_tenant.html
+++ b/templates/choose_tenant.html
@@ -1,13 +1,13 @@
 {% extends "base.html" %}
 
-{% block title %}Select Tenant - AdCP Admin{% endblock %}
+{% block title %}Select Account - Scribd Sales Agent Admin{% endblock %}
 
 {% block content %}
 <div class="card" style="max-width: 600px; margin: 4rem auto;">
-    <h2>Select Tenant</h2>
+    <h2>Select Account</h2>
 
     <p style="margin-bottom: 2rem;">
-        Your email address has access to multiple tenants. Please select which one you'd like to manage:
+        Your email address has access to multiple accounts. Please select which one you'd like to manage:
     </p>
 
     <form method="POST" action="{{ url_for('auth.select_tenant') }}">

--- a/templates/create_principal.html
+++ b/templates/create_principal.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Add Advertiser - AdCP Admin{% endblock %}
+{% block title %}Add Advertiser - Scribd Sales Agent Admin{% endblock %}
 
 {% block content %}
 <div class="card" style="max-width: 600px; margin: 0 auto;">

--- a/templates/create_tenant.html
+++ b/templates/create_tenant.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 
-{% block title %}Create Tenant - AdCP Admin{% endblock %}
+{% block title %}Create Account - Scribd Sales Agent Admin{% endblock %}
 
 {% block content %}
 <div class="card" style="max-width: 600px; margin: 0 auto;">
-    <h2>Create New Tenant</h2>
+    <h2>Create New Account</h2>
     <p style="color: #666; margin-bottom: 2rem;">
         Create a new publisher account. The publisher will complete their setup after logging in.
     </p>
@@ -52,7 +52,7 @@
         </div>
 
         <div style="margin-top: 2rem; display: flex; gap: 1rem;">
-            <button type="submit" class="btn">Create Tenant</button>
+            <button type="submit" class="btn">Create Account</button>
             <a href="/" class="btn btn-secondary">Cancel</a>
         </div>
     </form>

--- a/templates/creative_formats.html
+++ b/templates/creative_formats.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Creative Formats - {{ tenant_name }} - AdCP Admin{% endblock %}
+{% block title %}Creative Formats - {{ tenant_name }} - Scribd Sales Agent Admin{% endblock %}
 
 {% block content %}
 <div class="card">

--- a/templates/edit_creative_format.html
+++ b/templates/edit_creative_format.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Edit Creative Format - {{ format.name }} - AdCP Admin{% endblock %}
+{% block title %}Edit Creative Format - {{ format.name }} - Scribd Sales Agent Admin{% endblock %}
 
 {% block content %}
 <div class="card">

--- a/templates/edit_product.html
+++ b/templates/edit_product.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Edit Product - {{ product.name }} - AdCP Admin{% endblock %}
+{% block title %}Edit Product - {{ product.name }} - Scribd Sales Agent Admin{% endblock %}
 
 {% block content %}
 <div class="card">

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,17 +1,17 @@
 {% extends "base.html" %}
 
-{% block title %}Tenants - AdCP Admin{% endblock %}
+{% block title %}Accounts - Scribd Sales Agent Admin{% endblock %}
 
 {% block content %}
 <div class="card">
     <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
-        <h2>Tenants</h2>
+        <h2>Accounts</h2>
         <div>
             {% if session.role == 'super_admin' %}
             <a href="{{ script_name }}/mcp-test" class="btn btn-secondary">MCP Protocol Test</a>
             <a href="{{ script_name }}/settings" class="btn btn-secondary">Settings</a>
             {% endif %}
-            <a href="{{ script_name }}/create_tenant" class="btn">Create New Tenant</a>
+            <a href="{{ script_name }}/create_tenant" class="btn">Create New Account</a>
         </div>
     </div>
 
@@ -121,7 +121,7 @@
 
         <div style="text-align: center; padding: 1rem; background: #f8f9fa; border-radius: 4px;">
             <div style="font-size: 2rem; font-weight: bold; color: #1a73e8;">{{ gam_tenants|length }}</div>
-            <div style="color: #666;">GAM Tenants</div>
+            <div style="color: #666;">GAM Accounts</div>
         </div>
 
         <div style="text-align: center; padding: 1rem; background: #f8f9fa; border-radius: 4px;">

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Login - AdCP Admin{% endblock %}
+{% block title %}Login - Scribd Sales Agent Admin{% endblock %}
 
 {% block content %}
 <div class="card" style="max-width: 400px; margin: 4rem auto; text-align: center;">
@@ -12,12 +12,12 @@
 
     {% if tenant_context %}
         <h2>{{ tenant_name or tenant_context }} Sales Agent Admin</h2>
-        <p style="color: #666; margin-bottom: 2rem;">Sign in to access your tenant</p>
+        <p style="color: #666; margin-bottom: 2rem;">Sign in to access your account</p>
     {% elif tenant_id %}
         <h2>{{ tenant_name or tenant_id }} Sales Agent Admin</h2>
         <p style="color: #666; margin-bottom: 2rem;">Sign in to access your account</p>
     {% else %}
-        <h2>AdCP Sales Agent Admin</h2>
+        <h2>Scribd Sales Agent Admin</h2>
         <p style="color: #666; margin-bottom: 2rem;">Super Admin Login</p>
     {% endif %}
 
@@ -67,8 +67,8 @@
                 <select name="email" required style="width: 100%; padding: 0.5rem; border: 1px solid #ddd; border-radius: 4px;">
                     <option value="">Select a test user...</option>
                     <option value="test_super_admin@example.com">Test Super Admin</option>
-                    <option value="test_tenant_admin@example.com">Test Tenant Admin</option>
-                    <option value="test_tenant_user@example.com">Test Tenant User</option>
+                    <option value="test_tenant_admin@example.com">Test Account Admin</option>
+                    <option value="test_tenant_user@example.com">Test Account User</option>
                 </select>
             </div>
 
@@ -79,7 +79,7 @@
 
             {% if not tenant_id %}
             <div style="margin-bottom: 1rem;">
-                <label style="display: block; margin-bottom: 0.5rem;">Tenant ID (for tenant users):</label>
+                <label style="display: block; margin-bottom: 0.5rem;">Account ID (for account users):</label>
                 <input type="text" name="tenant_id" placeholder="e.g., tenant_abc123" style="width: 100%; padding: 0.5rem; border: 1px solid #ddd; border-radius: 4px;">
             </div>
             {% endif %}
@@ -99,15 +99,15 @@
         Contact your administrator if you need access.
         {% else %}
         Access is restricted to super administrators.<br>
-        For tenant access, use your tenant-specific login URL.
+        For account access, use your account-specific login URL.
         {% endif %}
     </p>
 
     {% if not tenant_id and not tenant_context %}
     <div style="margin-top: 3rem; padding-top: 2rem; border-top: 1px solid #eee;">
         <p style="color: #666; font-size: 13px;">
-            <strong>Tenant Access:</strong> Use your tenant-specific URL<br>
-            <code>https://[tenant-subdomain].sales-agent.scope3.com</code>
+            <strong>Account Access:</strong> Use your account-specific URL<br>
+            <code>https://[account-subdomain].sales-agent.scope3.com</code>
         </p>
     </div>
     {% endif %}

--- a/templates/mcp_test.html
+++ b/templates/mcp_test.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}MCP Protocol Test - AdCP Admin{% endblock %}
+{% block title %}MCP Protocol Test - Scribd Sales Agent Admin{% endblock %}
 
 {% block content %}
 <style>

--- a/templates/product_setup_wizard.html
+++ b/templates/product_setup_wizard.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Product Setup Wizard - AdCP Admin{% endblock %}
+{% block title %}Product Setup Wizard - Scribd Sales Agent Admin{% endblock %}
 
 {% block content %}
 <div class="wizard-container">

--- a/templates/product_templates.html
+++ b/templates/product_templates.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Product Templates - AdCP Admin{% endblock %}
+{% block title %}Product Templates - Scribd Sales Agent Admin{% endblock %}
 
 {% block content %}
 <div class="card">

--- a/templates/products.html
+++ b/templates/products.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Products - {{ tenant_name }} - AdCP Admin{% endblock %}
+{% block title %}Products - {{ tenant_name }} - Scribd Sales Agent Admin{% endblock %}
 
 {% block content %}
 <div class="card">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Settings - AdCP Admin{% endblock %}
+{% block title %}Settings - Scribd Sales Agent Admin{% endblock %}
 
 {% block content %}
 <div class="card">

--- a/templates/tenant_settings.html
+++ b/templates/tenant_settings.html
@@ -462,7 +462,7 @@
                                 <p><strong>To use a custom domain:</strong></p>
                                 <ol style="margin: 0.5rem 0; padding-left: 1.5rem; font-size: 0.9em;">
                                     <li>Enter your custom domain above (e.g., ad-sales.yourcompany.com)</li>
-                                    <li>Create a CNAME record pointing your domain to: <code>adcp-sales-agent.fly.dev</code></li>
+                                    <li>Create a CNAME record pointing your domain to: <code>sales-agent.scope3.com</code></li>
                                     <li>Save your settings below</li>
                                     <li>Wait for DNS propagation (5-30 minutes)</li>
                                 </ol>


### PR DESCRIPTION
## Summary
- **Branding**: Complete rebrand from "AdCP Admin" to "Scribd Sales Agent Admin" throughout the interface
- **Terminology**: Replace user-facing "tenant" language with "account" to hide multi-tenant architecture  
- **Virtual Host Fix**: Enable custom domains like `test-agent.adcontextprotocol.org` to display landing pages instead of redirecting to admin

## Branding Updates
- ✅ All page titles: "AdCP Admin" → "Scribd Sales Agent Admin"
- ✅ Header branding: "AdCP Sales Agent Admin" → "Scribd Sales Agent Admin"  
- ✅ Navigation: "Tenants" → "Accounts", "Create Tenant" → "Create Account"
- ✅ Login page: "Sign in to access your tenant" → "Sign in to access your account"
- ✅ Account selection: "Select Tenant" → "Select Account"
- ✅ Test users: "Test Tenant Admin/User" → "Test Account Admin/User"
- ✅ Virtual host instructions: Fixed CNAME target to `sales-agent.scope3.com`

## Virtual Host Routing Fix
- ✅ Root route now checks both `apx-incoming-host` AND `host` headers
- ✅ Custom domains properly lookup tenants via `get_tenant_by_virtual_host()`
- ✅ Landing pages display instead of admin redirects for virtual hosts
- ✅ Fixes `test-agent.adcontextprotocol.org` routing to default publisher

## Test Plan
- [ ] Test branding changes in admin interface
- [ ] Verify `test-agent.adcontextprotocol.org` shows landing page (not admin redirect)
- [ ] Check MCP/A2A endpoints work with virtual host: `test-agent.adcontextprotocol.org/mcp/`
- [ ] Validate admin interface still accessible: `test-agent.adcontextprotocol.org/admin/`

🤖 Generated with [Claude Code](https://claude.ai/code)