### PR TITLE
Fix dynamic subdomain routing for AdCP protocol domains

### DIFF
--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -77,6 +77,91 @@ http {
         }
     }
 
+    # AdCP Protocol subdomain routing (any subdomain under adcontextprotocol.org)
+    server {
+        listen 8000;
+        server_name ~^(?<agent>[^.]+)\.adcontextprotocol\.org$;
+
+        # MCP endpoint
+        location /mcp {
+            proxy_pass http://localhost:8080;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header x-adcp-agent $agent;
+            proxy_set_header x-adcp-auth $http_x_adcp_auth;
+            proxy_cache_bypass $http_upgrade;
+        }
+
+        # A2A agent discovery endpoints
+        location /.well-known/ {
+            proxy_pass http://localhost:8091/.well-known/;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header x-adcp-agent $agent;
+        }
+
+        # A2A agent card endpoint
+        location /agent.json {
+            proxy_pass http://localhost:8091/agent.json;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header x-adcp-agent $agent;
+        }
+
+        # A2A endpoint
+        location /a2a {
+            proxy_pass http://localhost:8091;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header x-adcp-agent $agent;
+            proxy_cache_bypass $http_upgrade;
+        }
+
+        # Root serves agent info page
+        location = / {
+            return 200 "AdCP Protocol Agent: $agent\n\nEndpoints:\n- MCP: https://$agent.adcontextprotocol.org/mcp/\n- A2A: https://$agent.adcontextprotocol.org/a2a/\n- Health: https://$agent.adcontextprotocol.org/health\n";
+            add_header Content-Type text/plain;
+        }
+
+        # MCP server (default for all other routes)
+        location / {
+            proxy_pass http://mcp_server;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header x-adcp-agent $agent;
+            proxy_set_header x-adcp-auth $http_x_adcp_auth;
+            proxy_cache_bypass $http_upgrade;
+        }
+
+        # Health check
+        location /health {
+            access_log off;
+            return 200 "$agent-agent healthy\n";
+            add_header Content-Type text/plain;
+        }
+    }
+
     # Tenant-specific subdomain routing
     server {
         listen 8000;

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -398,9 +398,8 @@ def get_adapter(principal: Principal, dry_run: bool = False, testing_context=Non
 
 
 # --- Initialization ---
-# Only initialize DB if not in test mode
-if not os.environ.get("PYTEST_CURRENT_TEST"):
-    init_db()  # Tests will call with exit_on_error=False
+# NOTE: Database initialization moved to startup script to avoid import-time failures
+# The run_all_services.py script handles database initialization before starting the MCP server
 
 # Try to load config, but use defaults if no tenant context available
 try:


### PR DESCRIPTION
## Summary
- ✅ Fix redirect issue where `test-agent.adcontextprotocol.org` was redirecting to `sales-agent.scope3.com`
- ✅ Add dynamic subdomain routing for any `*.adcontextprotocol.org` domain
- ✅ Fix 502 Bad Gateway error on MCP endpoints caused by import-time database initialization
- ✅ Implement regex-based nginx configuration without hardcoding specific subdomains

## Problems Solved

### 1. Redirect Issue
The nginx default fallback server was catching all unrecognized domains (including `test-agent.adcontextprotocol.org`) and redirecting them to `sales-agent.scope3.com`. This broke the AdCP protocol test server functionality.

### 2. MCP Server 502 Errors
The MCP server was failing to start because `src/core/main.py` was calling `init_db()` at module import time, causing failures when database connections weren't ready during container startup.

## Root Causes
1. DNS was correctly configured with CNAME pointing `test-agent.adcontextprotocol.org` to the Fly.io app, but nginx configuration lacked a server block to handle AdCP protocol domains.
2. Module-level `init_db()` call in `src/core/main.py:403` caused database connection failures during import, preventing MCP server from starting.

## Solution

### Dynamic Subdomain Routing
Added a new server block with regex pattern `~^(?<agent>[^.]+)\.adcontextprotocol\.org$` that:
- ✅ Dynamically matches any subdomain under `adcontextprotocol.org`
- ✅ Captures subdomain name in `$agent` variable
- ✅ Passes agent identifier via `x-adcp-agent` header to backend services
- ✅ Supports MCP, A2A, and health endpoints
- ✅ Follows existing pattern used for tenant subdomain routing

### MCP Server Startup Fix
- ✅ Removed `init_db()` call from module import time in `src/core/main.py`
- ✅ Database initialization remains handled by `entrypoint.sh` script
- ✅ MCP server can now import successfully without database dependency
- ✅ Tests continue to work via their own `init_db()` calls in `conftest_db.py`

## Benefits
- **No hardcoding**: Subdomains are dynamically routed without nginx config changes
- **Scalable**: Works for any subdomain with proper DNS configuration
- **Consistent**: Uses same approach as existing `sales-agent.scope3.com` tenant routing
- **Maintainable**: Single configuration handles all AdCP protocol subdomains
- **Reliable**: MCP server starts consistently without database timing issues

## Testing Results
```bash
# Before: Redirected to sales-agent.scope3.com
curl -I https://test-agent.adcontextprotocol.org/mcp
# HTTP/2 301 (redirect)

# After: Working dynamic routing and proper MCP responses
curl https://test-agent.adcontextprotocol.org/health
# test-agent-agent healthy

curl https://test-agent.adcontextprotocol.org/
# AdCP Protocol Agent: test-agent
# Endpoints: MCP, A2A, Health...

curl -I https://test-agent.adcontextprotocol.org/mcp
# HTTP/2 405 Method Not Allowed (correct MCP server response)

curl https://test-agent.adcontextprotocol.org/.well-known/agent.json
# {"name":"AdCP Sales Agent","skills":[...]} (working A2A agent card)
```

## Technical Details
- **DNS Management**: External CNAME configuration (no changes needed)
- **Nginx Pattern**: Regex captures subdomain into nginx variable
- **Header Passing**: `x-adcp-agent: test-agent` sent to backend services
- **Endpoint Coverage**: MCP (`/mcp`), A2A (`/a2a`, `/.well-known/`, `/agent.json`), Health (`/health`)
- **Database Initialization**: Moved from import-time to startup script for reliability

🤖 Generated with [Claude Code](https://claude.ai/code)