### PR TITLE
Fix agent card URL to use virtual host domain instead of raw Fly.io URL

### DIFF
--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -338,6 +338,39 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        # A2A agent discovery endpoints
+        location /.well-known/ {
+            proxy_pass http://localhost:8091/.well-known/;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # A2A agent card endpoint
+        location /agent.json {
+            proxy_pass http://localhost:8091/agent.json;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # A2A endpoint
+        location /a2a {
+            proxy_pass http://localhost:8091;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_cache_bypass $http_upgrade;
+        }
+
         # Root redirects to admin
         location = / {
             return 302 https://admin.sales-agent.scope3.com/;

--- a/fly.toml
+++ b/fly.toml
@@ -52,7 +52,7 @@ primary_region = "iad"
   DB_TYPE = "postgresql"
   # A2A Configuration
   A2A_MOCK_MODE = "false"
-  A2A_SERVER_URL = "https://adcp-sales-agent.fly.dev/a2a"
+  A2A_SERVER_URL = "https://sales-agent.scope3.com/a2a"
 
 [mounts]
   source = "adcp_data"

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -1483,10 +1483,12 @@ def main():
         else:
             # Fallback for development or unknown tenant
             fly_app = os.getenv("FLY_APP_NAME")
-            if fly_app:
+            if fly_app and fly_app != "adcp-sales-agent":
+                # Development deployment with different app name
                 server_url = f"https://{fly_app}.fly.dev/a2a/"
             else:
-                server_url = "https://adcp-sales-agent.fly.dev/a2a/"
+                # Production fallback - use virtual host domain
+                server_url = "https://sales-agent.scope3.com/a2a/"
 
         # Create a copy of the static agent card with dynamic URL
         dynamic_card = agent_card.model_copy()

--- a/src/admin/blueprints/core.py
+++ b/src/admin/blueprints/core.py
@@ -260,9 +260,9 @@ def mcp_test():
 
     # Get server URLs - use production URLs if in production, otherwise localhost
     if os.environ.get("PRODUCTION") == "true":
-        # In production, both servers are accessible at the main domain
-        mcp_server_url = "https://adcp-sales-agent.fly.dev/mcp"  # Remove trailing slash
-        a2a_server_url = "https://adcp-sales-agent.fly.dev/a2a/"
+        # In production, both servers are accessible at the virtual host domain
+        mcp_server_url = "https://sales-agent.scope3.com/mcp"  # Remove trailing slash
+        a2a_server_url = "https://sales-agent.scope3.com/a2a/"
     else:
         # In development, use localhost with the configured ports from environment
         # Default to common development ports if not set


### PR DESCRIPTION
## Summary
- Fixed agent card URL to return virtual host domain (`sales-agent.scope3.com`) instead of raw Fly.io URL
- Updated A2A server fallback URL configuration for production deployment
- Added missing A2A endpoints to base domain nginx configuration

## Changes Made
- **A2A Server**: Updated fallback URL in `src/a2a_server/adcp_a2a_server.py` to use `https://sales-agent.scope3.com/a2a/`
- **Admin UI**: Updated production URLs in `src/admin/blueprints/core.py` to use virtual host domain
- **Nginx Config**: Added A2A endpoints (`/.well-known/`, `/agent.json`, `/a2a`) to base domain server block
- **Environment**: Updated `fly.toml` A2A_SERVER_URL to use virtual host domain

## Test Results
✅ Test agent now returns correct URL: `https://sales-agent.scope3.com/a2a/`
✅ All health endpoints responding correctly
✅ Virtual host routing working properly
✅ Multi-tenant architecture maintained

## Before/After
**Before**: `"url": "https://adcp-sales-agent.fly.dev/a2a/"`
**After**: `"url": "https://sales-agent.scope3.com/a2a/"`

🤖 Generated with [Claude Code](https://claude.ai/code)