### PR TITLE
Fix A2A agent pricing attribute error

### DIFF
--- a/src/core/tools.py
+++ b/src/core/tools.py
@@ -125,10 +125,19 @@ async def get_products_raw(brief: str, promoted_offering: str, context: Context 
             "name": db_product.name,
             "description": db_product.description or "",
             "formats": safe_json_loads(db_product.formats, []),
-            "pricing": safe_json_loads(db_product.pricing, {}),
-            "targeting_template": safe_json_loads(db_product.targeting_template, {}),
-            "countries": safe_json_loads(db_product.countries, ["US"]),
-            "created_date": db_product.created_date.isoformat() if db_product.created_date else None,
+            "delivery_type": db_product.delivery_type,
+            "is_fixed_price": db_product.is_fixed_price,
+            "cpm": float(db_product.cpm) if db_product.cpm else None,
+            "min_spend": float(db_product.min_spend) if db_product.min_spend else None,
+            "measurement": safe_json_loads(db_product.measurement, None) if db_product.measurement else None,
+            "creative_policy": (
+                safe_json_loads(db_product.creative_policy, None) if db_product.creative_policy else None
+            ),
+            "is_custom": db_product.is_custom or False,
+            "expires_at": db_product.expires_at,
+            "implementation_config": (
+                safe_json_loads(db_product.implementation_config, None) if db_product.implementation_config else None
+            ),
         }
         products.append(Product(**product_data))
 


### PR DESCRIPTION
## Summary
Fixes critical A2A agent bug where  was failing with .

## Problem
The A2A agent was returning empty products array with error message instead of actual product data due to accessing a non-existent database field.

## Root Cause  
In , the code was trying to access  which doesn't exist in the database model. The Product database model has fields like , , etc. but no  field.

## Fix
- ❌ Removed invalid  field access
- ✅ Added proper mapping of all valid database fields to Product schema
- ✅ Added correct type conversions (Decimal → float)
- ✅ Added proper JSON parsing for complex fields

## Fields Now Properly Mapped
- 
-  
-  (with Decimal to float conversion)
-  (with Decimal to float conversion)
-  (with JSON parsing)
-  (with JSON parsing)
- 
- 
-  (with JSON parsing)

## Test Plan
- [x] A2A agent no longer crashes on product retrieval
- [x] Products array populates with actual data instead of empty array
- [x] All database fields properly mapped to schema
- [x] Type conversions work correctly

## Before/After
**Before:** 


**After:**


## Related Issues
- Addresses test coverage gap identified in #161
- Part of broader A2A stability improvements

🤖 Generated with [Claude Code](https://claude.ai/code)