### PR TITLE
Fix nginx routing for adcontextprotocol.org domains to show proper web interface

### DIFF
--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -133,10 +133,16 @@ http {
             proxy_cache_bypass $http_upgrade;
         }
 
-        # Root serves agent info page
+        # Root serves tenant landing page via MCP server (like tenant subdomains)
         location = / {
-            return 200 "AdCP Protocol Agent: $agent\n\nEndpoints:\n- MCP: https://$agent.adcontextprotocol.org/mcp/\n- A2A: https://$agent.adcontextprotocol.org/a2a/\n- Health: https://$agent.adcontextprotocol.org/health\n";
-            add_header Content-Type text/plain;
+            proxy_pass http://localhost:8080/;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header x-adcp-agent $agent;
+            proxy_cache_bypass $http_upgrade;
         }
 
         # MCP server (default for all other routes)


### PR DESCRIPTION
## Summary
- Fixes test-agent.adcontextprotocol.org to show proper web interface instead of text-based landing page
- Routes root path to MCP server which serves the correct landing page (same as tenant subdomains)
- Removes outdated text-based response that was returning plain text instead of HTML interface

## Problem
The test-agent.adcontextprotocol.org domain was showing a text-based landing page with endpoint information instead of the proper web interface that tenant subdomains display.

## Solution
Updated nginx configuration to route the root path (`/`) for adcontextprotocol.org domains to the MCP server, which serves the proper landing page interface.

## Before/After
- **Before**: Plain text page showing "AdCP Protocol Agent: test-agent" with endpoint URLs
- **After**: Proper web interface matching tenant subdomain experience (like wonderstruck.sales-agent.scope3.com)

## Testing
- Verified nginx configuration syntax
- Ready for deployment to see updated interface at test-agent.adcontextprotocol.org

🤖 Generated with [Claude Code](https://claude.ai/code)