### PR TITLE
Fix broken migration chain for missing revision 7e66d36b68a4

### DIFF
--- a/alembic/versions/023_add_authorized_properties.py
+++ b/alembic/versions/023_add_authorized_properties.py
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "023_add_authorized_properties"
-down_revision = "6e19576203a0"
+down_revision = "7e66d36b68a4"
 branch_labels = None
 depends_on = None
 

--- a/alembic/versions/7e66d36b68a4_ghost_revision_placeholder.py
+++ b/alembic/versions/7e66d36b68a4_ghost_revision_placeholder.py
@@ -1,0 +1,35 @@
+"""ghost_revision_placeholder
+
+Revision ID: 7e66d36b68a4
+Revises: 6e19576203a0
+Create Date: 2025-09-21 18:45:00.000000
+
+This is a placeholder migration for a ghost revision that appeared in production
+but doesn't exist in the migration history. This allows Alembic to find the
+revision and continue the migration chain properly.
+
+"""
+
+from collections.abc import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = "7e66d36b68a4"
+down_revision: str | Sequence[str] | None = "6e19576203a0"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema - placeholder for ghost revision.
+
+    This is a no-op migration that exists only to provide the missing
+    revision 7e66d36b68a4 that somehow got set in production database
+    but never existed in our migration files.
+    """
+    # No schema changes needed - this is just to fill the gap in the chain
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass


### PR DESCRIPTION
## Summary
- Fixes critical production deployment issue where Alembic can't locate revision '7e66d36b68a4'
- Adds ghost revision placeholder that appeared in production but never existed in migration files
- Updates authorized properties migration to use correct down_revision chain
- Ensures proper migration chain continuity: 023 -> 7e66d36b68a4 -> 6e19576203a0

## Test plan
- [x] Validate migration chain integrity with `alembic history`
- [x] Test local migration chain validation passes
- [x] Pre-commit hooks and formatting checks pass
- [ ] Deploy to production and verify migrations run successfully
- [ ] Monitor production logs for successful database initialization

## Background
Production deployment was failing with error:
```
❌ Error running migrations: Can't locate revision identified by '7e66d36b68a4'
```

This revision somehow got set in the production database's `alembic_version` table but never existed in our migration files. This is a common issue when migrations are run in production that don't match the repository state.

## Solution
Created a ghost revision placeholder (`7e66d36b68a4_ghost_revision_placeholder.py`) that:
- Provides the missing revision ID that Alembic is looking for
- Contains no actual schema changes (no-op migration)
- Properly links the migration chain between existing revisions
- Allows Alembic to continue with normal migration operations

🤖 Generated with [Claude Code](https://claude.ai/code)