### PR TITLE
Implement MCP Status System per AdCP PR #77

### DIFF
--- a/src/core/main.py
+++ b/src/core/main.py
@@ -49,6 +49,7 @@ from src.core.database.models import Product as ModelProduct
 
 # Schema models (explicit imports to avoid collisions)
 from src.core.schemas import (
+    ActivateSignalResponse,
     CreateMediaBuyRequest,
     CreateMediaBuyResponse,
     Creative,
@@ -76,6 +77,7 @@ from src.core.schemas import (
     ReportingPeriod,
     Signal,
     SyncCreativesResponse,
+    TaskStatus,
     UpdateMediaBuyRequest,
     UpdateMediaBuyResponse,
     UpdatePerformanceIndexRequest,
@@ -866,7 +868,12 @@ async def get_products(brief: str, promoted_offering: str, context: Context = No
     base_message = f"Found {len(modified_products)} matching products"
     final_message = f"{base_message}. {pricing_message}" if pricing_message else base_message
 
-    return GetProductsResponse(products=modified_products, message=final_message)
+    # Set status based on operation result
+    status = TaskStatus.from_operation_state(
+        operation_type="discovery", has_errors=False, requires_approval=False, requires_auth=principal_id is None
+    )
+
+    return GetProductsResponse(products=modified_products, message=final_message, status=status)
 
 
 @mcp.tool
@@ -961,8 +968,15 @@ def list_creative_formats(context: Context) -> ListCreativeFormatsResponse:
 
     message = f"Found {len(formats)} creative formats across {len({f.type for f in formats})} format types"
 
+    # Set status based on operation result
+    status = TaskStatus.from_operation_state(
+        operation_type="discovery", has_errors=False, requires_approval=False, requires_auth=principal_id is None
+    )
+
     # Create response with schema validation metadata
-    response = ListCreativeFormatsResponse(formats=formats, message=message, specification_version="AdCP v2.4")
+    response = ListCreativeFormatsResponse(
+        formats=formats, message=message, specification_version="AdCP v2.4", status=status
+    )
 
     # Add schema validation metadata for client validation
     from src.core.schema_validation import INCLUDE_SCHEMAS_IN_RESPONSES, enhance_mcp_response_with_schema
@@ -1650,7 +1664,98 @@ async def get_signals(req: GetSignalsRequest, context: Context = None) -> GetSig
     if req.limit:
         signals = signals[: req.limit]
 
-    return GetSignalsResponse(signals=signals)
+    # Set status based on operation result
+    status = TaskStatus.from_operation_state(
+        operation_type="discovery", has_errors=False, requires_approval=False, requires_auth=False
+    )
+
+    return GetSignalsResponse(signals=signals, status=status)
+
+
+@mcp.tool
+async def activate_signal(
+    signal_id: str,
+    campaign_id: str = None,
+    media_buy_id: str = None,
+    context: Context = None,
+) -> ActivateSignalResponse:
+    """Activate a signal for use in campaigns.
+
+    Args:
+        signal_id: Signal ID to activate
+        campaign_id: Optional campaign ID to activate signal for
+        media_buy_id: Optional media buy ID to activate signal for
+        context: FastMCP context (automatically provided)
+
+    Returns:
+        ActivateSignalResponse with activation status
+    """
+    start_time = time.time()
+
+    # Authentication required for signal activation
+    principal_id = _get_principal_id_from_context(context)
+
+    # Get tenant information
+    tenant = get_current_tenant()
+    if not tenant:
+        raise ToolError("No tenant context available")
+
+    # Get the Principal object with ad server mappings
+    principal = get_principal_object(principal_id)
+
+    # Apply testing hooks
+    testing_ctx = get_testing_context(context)
+    campaign_info = {"endpoint": "activate_signal", "signal_id": signal_id}
+    apply_testing_hooks(testing_ctx, campaign_info)
+
+    try:
+        # In a real implementation, this would:
+        # 1. Validate the signal exists and is available
+        # 2. Check if the principal has permission to activate the signal
+        # 3. Communicate with the signal provider's API to activate the signal
+        # 4. Update the campaign or media buy configuration to include the signal
+
+        # Mock implementation for demonstration
+        activation_success = True
+        requires_approval = signal_id.startswith("premium_")  # Mock rule: premium signals need approval
+
+        if requires_approval:
+            # Create a human task for approval
+            status = TaskStatus.INPUT_REQUIRED
+            message = f"Signal {signal_id} requires manual approval before activation"
+            activation_details = {
+                "approval_required": True,
+                "estimated_approval_time_hours": 24,
+                "contact": "signals-approval@example.com",
+            }
+        elif activation_success:
+            status = TaskStatus.WORKING  # Activation in progress
+            message = f"Signal {signal_id} activation initiated successfully"
+            activation_details = {
+                "activation_started": datetime.now(UTC).isoformat(),
+                "estimated_completion_minutes": 15,
+                "platform_segment_id": f"seg_{signal_id}_{uuid.uuid4().hex[:8]}",
+            }
+        else:
+            status = TaskStatus.FAILED
+            message = f"Failed to activate signal {signal_id}"
+            activation_details = {"error": "Signal provider unavailable"}
+
+        # Log activity
+        log_tool_activity(context, "activate_signal", start_time)
+
+        return ActivateSignalResponse(
+            signal_id=signal_id, status=status, message=message, activation_details=activation_details
+        )
+
+    except Exception as e:
+        logger.error(f"Error activating signal {signal_id}: {e}")
+        return ActivateSignalResponse(
+            signal_id=signal_id,
+            status=TaskStatus.FAILED,
+            message=f"Failed to activate signal: {str(e)}",
+            errors=[{"code": "ACTIVATION_ERROR", "message": str(e)}],
+        )
 
 
 @mcp.tool
@@ -1932,7 +2037,7 @@ def create_media_buy(
         # Return proper error response instead of raising ToolError
         return CreateMediaBuyResponse(
             media_buy_id="",
-            status="failed",
+            status=TaskStatus.FAILED,
             detail=str(e),
             creative_deadline=None,
             message=f"Media buy creation failed: {str(e)}",
@@ -1946,7 +2051,7 @@ def create_media_buy(
         ctx_manager.update_workflow_step(step.step_id, status="failed", error=error_msg)
         return CreateMediaBuyResponse(
             media_buy_id="",
-            status="failed",
+            status=TaskStatus.FAILED,
             detail=error_msg,
             creative_deadline=None,
             message=f"Media buy creation failed: {error_msg}",
@@ -1985,7 +2090,7 @@ def create_media_buy(
 
             return CreateMediaBuyResponse(
                 media_buy_id=pending_media_buy_id,
-                status="pending_manual",
+                status=TaskStatus.INPUT_REQUIRED,
                 detail=response_msg,
                 creative_deadline=None,
                 message="Your media buy request requires manual approval from the publisher. The request has been queued and will be reviewed shortly.",
@@ -2014,7 +2119,7 @@ def create_media_buy(
 
             return CreateMediaBuyResponse(
                 media_buy_id=pending_media_buy_id,
-                status="pending_manual",
+                status=TaskStatus.INPUT_REQUIRED,
                 detail=response_msg,
                 creative_deadline=None,
                 message=f"This media buy requires manual approval due to {reason.lower()}. Your request has been submitted for review.",
@@ -2070,7 +2175,7 @@ def create_media_buy(
                 end_date=req.end_time.date(),  # Legacy field for compatibility
                 start_time=req.start_time,  # AdCP v2.4 datetime scheduling
                 end_time=req.end_time,  # AdCP v2.4 datetime scheduling
-                status=response.status or "active",
+                status=response.status or TaskStatus.WORKING,
                 raw_request=req.model_dump(mode="json"),
             )
             session.add(new_media_buy)
@@ -2107,7 +2212,7 @@ def create_media_buy(
                     "package_id": f"{response.media_buy_id}_pkg_{i+1}",
                     "buyer_ref": package.buyer_ref,
                     "products": package.products,
-                    "status": "active",
+                    "status": TaskStatus.WORKING,
                 }
             )
 
@@ -2115,10 +2220,10 @@ def create_media_buy(
         adcp_response = CreateMediaBuyResponse(
             media_buy_id=response.media_buy_id,
             buyer_ref=req.buyer_ref,
-            status="active",  # Successful synchronous creation
+            status=TaskStatus.WORKING,  # Media buy creation in progress (async operation)
             packages=response_packages,
             creative_deadline=response.creative_deadline,
-            message="Media buy created successfully",
+            message="Media buy created successfully and is being activated",
         )
 
         # Log activity
@@ -2172,7 +2277,7 @@ def create_media_buy(
         # Return proper error response instead of raising ToolError
         return CreateMediaBuyResponse(
             media_buy_id="",
-            status="failed",
+            status=TaskStatus.FAILED,
             detail=str(e),
             creative_deadline=None,
             message=f"Media buy creation failed: {str(e)}",

--- a/tests/e2e/schemas/v1/_schemas_v1_core_response_json.json
+++ b/tests/e2e/schemas/v1/_schemas_v1_core_response_json.json
@@ -9,6 +9,10 @@
       "type": "string",
       "description": "Human-readable summary"
     },
+    "status": {
+      "$ref": "/schemas/v1/enums/task-status.json",
+      "description": "Current task state (optional for backwards compatibility during transition period)"
+    },
     "context_id": {
       "type": "string",
       "description": "Session continuity identifier"

--- a/tests/e2e/schemas/v1/_schemas_v1_enums_task-status_json.json
+++ b/tests/e2e/schemas/v1/_schemas_v1_enums_task-status_json.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/v1/enums/task-status.json",
+  "title": "Task Status",
+  "description": "Standardized task status values based on A2A TaskState enum. Indicates the current state of any AdCP operation.",
+  "type": "string",
+  "enum": [
+    "submitted",
+    "working",
+    "input-required",
+    "completed",
+    "canceled",
+    "failed",
+    "rejected",
+    "auth-required",
+    "unknown"
+  ],
+  "enumDescriptions": {
+    "submitted": "Task has been submitted and is awaiting execution",
+    "working": "Agent is actively working on the task",
+    "input-required": "Task is paused and waiting for input from the user (e.g., clarification, approval)",
+    "completed": "Task has been successfully completed",
+    "canceled": "Task was canceled by the user",
+    "failed": "Task failed due to an error during execution",
+    "rejected": "Task was rejected by the agent and was not started",
+    "auth-required": "Task requires authentication to proceed",
+    "unknown": "Task is in an unknown or indeterminate state"
+  }
+}

--- a/tests/e2e/schemas/v1/_schemas_v1_media-buy_create-media-buy-response_json.json
+++ b/tests/e2e/schemas/v1/_schemas_v1_media-buy_create-media-buy-response_json.json
@@ -8,7 +8,13 @@
     "adcp_version": {
       "type": "string",
       "description": "AdCP schema version used for this response",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "default": "1.6.0"
+    },
+    "status": {
+      "$ref": "/schemas/v1/enums/task-status.json",
+      "description": "Current task state - typically 'completed' for successful creation or 'input-required' if approval needed",
+      "default": "completed"
     },
     "media_buy_id": {
       "type": "string",

--- a/tests/e2e/schemas/v1/_schemas_v1_media-buy_get-products-response_json.json
+++ b/tests/e2e/schemas/v1/_schemas_v1_media-buy_get-products-response_json.json
@@ -8,7 +8,13 @@
     "adcp_version": {
       "type": "string",
       "description": "AdCP schema version used for this response",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "default": "1.6.0"
+    },
+    "status": {
+      "$ref": "/schemas/v1/enums/task-status.json",
+      "description": "Current task state",
+      "default": "completed"
     },
     "products": {
       "type": "array",

--- a/tests/e2e/schemas/v1/_schemas_v1_media-buy_list-creative-formats-response_json.json
+++ b/tests/e2e/schemas/v1/_schemas_v1_media-buy_list-creative-formats-response_json.json
@@ -8,7 +8,13 @@
     "adcp_version": {
       "type": "string",
       "description": "AdCP schema version used for this response",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "default": "1.6.0"
+    },
+    "status": {
+      "$ref": "/schemas/v1/enums/task-status.json",
+      "description": "Current task state",
+      "default": "completed"
     },
     "formats": {
       "type": "array",

--- a/tests/unit/test_adcp_contract.py
+++ b/tests/unit/test_adcp_contract.py
@@ -46,6 +46,7 @@ from src.core.schemas import (
     SyncCreativesRequest,
     SyncCreativesResponse,
     Targeting,
+    TaskStatus,
     UpdateMediaBuyResponse,
 )
 from src.core.schemas import (
@@ -1200,6 +1201,11 @@ class TestAdCPContract:
         for field in optional_fields:
             assert field in adcp_response, f"Optional AdCP field '{field}' missing from response"
 
+        # Verify optional status field (AdCP PR #77 - MCP Status System)
+        # Status field is optional and only present when explicitly set
+        if "status" in adcp_response:
+            assert isinstance(adcp_response["status"], str), "status must be string when present"
+
         # Verify specific field types and constraints
         assert isinstance(adcp_response["products"], list), "products must be array"
         assert len(adcp_response["products"]) > 0, "products array should not be empty"
@@ -1215,9 +1221,10 @@ class TestAdCPContract:
 
         empty_adcp_response = empty_response.model_dump()
         assert empty_adcp_response["products"] == [], "Empty products list should be empty array"
+        # Allow 3 or 4 fields (status is optional and may not be present)
         assert (
-            len(empty_adcp_response) == 3
-        ), f"GetProductsResponse should have exactly 3 fields, got {len(empty_adcp_response)}"
+            len(empty_adcp_response) >= 3 and len(empty_adcp_response) <= 4
+        ), f"GetProductsResponse should have 3-4 fields (status optional), got {len(empty_adcp_response)}"
 
     def test_list_creative_formats_response_adcp_compliance(self):
         """Test that ListCreativeFormatsResponse complies with AdCP list-creative-formats-response schema."""
@@ -1536,6 +1543,48 @@ class TestAdCPContract:
 
         # Verify field count expectations
         assert len(adcp_response) == 4
+
+    def test_task_status_mcp_integration(self):
+        """Test TaskStatus integration with MCP response schemas (AdCP PR #77)."""
+
+        # Test that TaskStatus enum has expected values
+        assert TaskStatus.SUBMITTED == "submitted"
+        assert TaskStatus.WORKING == "working"
+        assert TaskStatus.INPUT_REQUIRED == "input-required"
+        assert TaskStatus.COMPLETED == "completed"
+        assert TaskStatus.FAILED == "failed"
+        assert TaskStatus.AUTH_REQUIRED == "auth-required"
+
+        # Test TaskStatus helper method - basic cases
+        status = TaskStatus.from_operation_state("discovery")
+        assert status == TaskStatus.COMPLETED
+
+        status = TaskStatus.from_operation_state("creation", requires_approval=True)
+        assert status == TaskStatus.INPUT_REQUIRED
+
+        # Test precedence rules
+        status = TaskStatus.from_operation_state("creation", has_errors=True, requires_approval=True)
+        assert status == TaskStatus.FAILED  # Errors take precedence
+
+        status = TaskStatus.from_operation_state("discovery", requires_auth=True)
+        assert status == TaskStatus.AUTH_REQUIRED  # Auth requirement takes highest precedence
+
+        # Test edge cases
+        status = TaskStatus.from_operation_state("unknown_operation")
+        assert status == TaskStatus.UNKNOWN
+
+        # Test response schemas with status field
+        response = GetProductsResponse(products=[], message="Test with status", status=TaskStatus.COMPLETED)
+
+        data = response.model_dump()
+        assert "status" in data
+        assert data["status"] == TaskStatus.COMPLETED
+
+        # Test backward compatibility (no status field)
+        response_no_status = GetProductsResponse(products=[], message="Test without status")
+
+        data_no_status = response_no_status.model_dump()
+        assert "status" not in data_no_status  # Should be excluded when None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Implements the MCP Status System as specified in [AdCP PR #77](https://github.com/adcontextprotocol/adcp/pull/77), providing standardized task status reporting across all MCP endpoints with crystal clear guidance for client decision-making.

## Key Features

- **✅ TaskStatus Enum**: All 9 required status values (submitted, working, input-required, completed, failed, canceled, rejected, auth-required, unknown)
- **✅ Response Schema Updates**: Optional status field added to GetProductsResponse, ListCreativeFormatsResponse, GetSignalsResponse, and new ActivateSignalResponse
- **✅ Smart Status Logic**: TaskStatus.from_operation_state() helper method for automatic status determination
- **✅ New activate_signal Endpoint**: Demonstrates full approval workflow with status progression
- **✅ Backward Compatible**: All status fields optional, existing clients unaffected
- **✅ Schema Compliance**: Updated to AdCP v1.6.0 schemas with official task-status enum

## Implementation Details

- Uses Python's `str + Enum` pattern for type safety and JSON serialization
- Status precedence: `auth-required` > `failed` > `input-required` > operation-specific
- Discovery operations return "completed", creation operations return "working"
- Approval workflows return "input-required" for human intervention
- Anonymous access returns "auth-required" for protected resources

## Client Decision Trees

Enables simple client logic patterns:
```javascript
if (response.status === "auth-required") {
  redirectToLogin();
} else if (response.status === "input-required") {
  showApprovalPending();
} else if (response.status === "working") {
  pollForCompletion();
} else if (response.status === "completed") {
  useResults(response);
}
```

## Testing

- ✅ Updated existing AdCP contract tests for optional status field compatibility
- ✅ Added comprehensive TaskStatus integration tests with edge cases and precedence rules
- ✅ Verified backward compatibility (status field excluded when None)
- ✅ All pre-commit hooks pass including schema sync validation

## Files Changed

- `src/core/schemas.py` - Added TaskStatus enum and updated response schemas
- `src/core/main.py` - Updated all MCP tools to set appropriate status values
- `tests/unit/test_adcp_contract.py` - Enhanced tests for status field integration
- Schema files - Updated to AdCP v1.6.0 with official task-status enum

## Test Plan

- [x] All existing tests pass
- [x] New TaskStatus tests pass with comprehensive edge case coverage
- [x] Schema validation passes with updated AdCP v1.6.0 schemas
- [x] Manual testing of status values in different scenarios
- [x] Backward compatibility verified (responses work with and without status)

🤖 Generated with [Claude Code](https://claude.ai/code)