### PR TITLE
Add missing unit test files for product validation and debugging

### DIFF
--- a/tests/unit/test_ai_provider_bug.py
+++ b/tests/unit/test_ai_provider_bug.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Test to see if the AI provider has the Product validation bug."""
+
+import asyncio
+import json
+import logging
+import sys
+from pathlib import Path
+
+# Add the src directory to Python path
+sys.path.insert(0, str(Path(__file__).parent / "src"))
+sys.path.insert(0, str(Path(__file__).parent))
+
+# Enable debug logging
+logging.basicConfig(level=logging.INFO)
+
+from product_catalog_providers.ai import AIProductCatalog
+
+
+async def test_ai_provider_bug():
+    """Test if the AI provider has Product validation issues."""
+
+    print("🔍 Testing AI provider for Product validation bug...")
+
+    # First, let's create a problematic product in the database to test with
+    # This simulates what might be causing the issue on the external server
+
+    from src.core.database.database_session import get_db_session
+    from src.core.database.models import Product as ProductModel
+
+    with get_db_session() as session:
+        # Create a test product with potentially problematic format data
+        test_product = ProductModel(
+            tenant_id="default",
+            product_id="test_audio_bug",
+            name="Test Audio Product",
+            description="Test product to reproduce bug",
+            formats=json.dumps(["audio_15s", "audio_30s"]),  # Valid format list but with audio formats
+            targeting_template={},
+            delivery_type="guaranteed",
+            is_fixed_price=True,
+            cpm=10.0,
+            is_custom=False,
+        )
+        session.merge(test_product)
+        session.commit()
+        print("   ✅ Created test product with problematic format data")
+
+    try:
+        # Test the AI provider
+        config = {"model": "gemini-1.5-flash", "max_products": 5}
+        provider = AIProductCatalog(config)
+
+        products = await provider.get_products(
+            brief="test audio campaign",
+            tenant_id="default",
+            principal_id="test_principal",
+            context={"promoted_offering": "test"},
+            principal_data={},
+        )
+
+        print(f"   ✅ AI provider returned {len(products)} products")
+
+        # Check if any product has the validation issue
+        for _i, product in enumerate(products):
+            product_dict = product.model_dump()
+            if product.product_id == "test_audio_bug":
+                print(f"   🔍 Found test product: {product.product_id}")
+                print(f"   📊 Product data: {json.dumps(product_dict, indent=2)}")
+
+                # Check if audio fields leaked as top-level keys
+                if "audio_15s" in product_dict or "audio_30s" in product_dict:
+                    print("   ❌ BUG FOUND: Audio format fields are top-level Product keys!")
+                    return False
+                else:
+                    print("   ✅ No audio fields as top-level keys")
+
+    except Exception as e:
+        print(f"   ❌ AI provider failed with error: {e}")
+        import traceback
+
+        traceback.print_exc()
+
+        # Check if this is the specific validation error we're looking for
+        if "Field required" in str(e) and "formats" in str(e):
+            print("   🎯 This matches the original validation error!")
+            return False
+
+    finally:
+        # Clean up test product
+        with get_db_session() as session:
+            test_product = (
+                session.query(ProductModel).filter_by(tenant_id="default", product_id="test_audio_bug").first()
+            )
+            if test_product:
+                session.delete(test_product)
+                session.commit()
+                print("   🧹 Cleaned up test product")
+
+    print("   ✅ AI provider test completed without reproducing the bug")
+    return True
+
+
+if __name__ == "__main__":
+    success = asyncio.run(test_ai_provider_bug())
+    sys.exit(0 if success else 1)

--- a/tests/unit/test_comprehensive_product_validation.py
+++ b/tests/unit/test_comprehensive_product_validation.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Comprehensive test to verify all product catalog providers create valid Product objects."""
+
+import asyncio
+import json
+import logging
+import sys
+from pathlib import Path
+
+# Add the src directory to Python path
+sys.path.insert(0, str(Path(__file__).parent / "src"))
+sys.path.insert(0, str(Path(__file__).parent))
+
+# Enable debug logging
+logging.basicConfig(level=logging.INFO)
+
+from product_catalog_providers.factory import get_product_catalog_provider
+from src.core.schemas import Product
+
+
+async def test_all_providers():
+    """Test all product catalog providers to ensure they create valid Product objects."""
+
+    print("🧪 Testing all product catalog providers for Product validation...")
+
+    tenant_id = "default"
+    principal_id = "test_principal"
+    brief = "Test advertising campaign"
+    context = {"promoted_offering": "test product", "tenant_id": tenant_id, "principal_id": principal_id}
+    principal_data = {"principal_id": principal_id, "name": "Test Principal", "platform_mappings": {}}
+
+    providers_to_test = [
+        {"name": "Database Provider", "config": {"provider": "database", "config": {}}},
+        {
+            "name": "Hybrid Provider (no signals)",
+            "config": {
+                "provider": "hybrid",
+                "config": {
+                    "database": {},
+                    "signals_discovery": {"enabled": False},
+                    "ranking_strategy": "database_first",
+                    "max_products": 10,
+                },
+            },
+        },
+        {
+            "name": "Signals Provider (fallback mode)",
+            "config": {
+                "provider": "signals",
+                "config": {"enabled": False, "fallback_to_database": True},  # Will fallback to database
+            },
+        },
+        {
+            "name": "AI Provider",
+            "config": {
+                "provider": "ai",
+                "config": {"model": "gemini-1.5-flash", "max_products": 5, "temperature": 0.3},
+            },
+        },
+    ]
+
+    all_passed = True
+
+    for provider_test in providers_to_test:
+        provider_name = provider_test["name"]
+        config = provider_test["config"]
+
+        print(f"\n📋 Testing {provider_name}...")
+
+        try:
+            # Get provider
+            provider = await get_product_catalog_provider(tenant_id, config)
+
+            # Get products
+            products = await provider.get_products(
+                brief=brief,
+                tenant_id=tenant_id,
+                principal_id=principal_id,
+                context=context,
+                principal_data=principal_data,
+            )
+
+            print(f"   ✅ Provider returned {len(products)} products")
+
+            # Validate each product
+            for i, product in enumerate(products):
+                try:
+                    # Check that it's a Product instance
+                    assert isinstance(product, Product), f"Product {i} is not a Product instance: {type(product)}"
+
+                    # Get model dump to check AdCP compliance
+                    product_dict = product.model_dump()
+
+                    # Check required AdCP fields
+                    required_fields = [
+                        "product_id",
+                        "name",
+                        "description",
+                        "delivery_type",
+                        "is_fixed_price",
+                        "is_custom",
+                    ]
+                    for field in required_fields:
+                        assert field in product_dict, f"Product {i} missing required field: {field}"
+                        assert product_dict[field] is not None, f"Product {i} has null required field: {field}"
+
+                    # Check that formats field was converted to format_ids
+                    assert (
+                        "format_ids" in product_dict
+                    ), f"Product {i} missing format_ids field (should be converted from formats)"
+                    assert isinstance(
+                        product_dict["format_ids"], list
+                    ), f"Product {i} format_ids is not a list: {type(product_dict['format_ids'])}"
+
+                    # Check that internal fields are not present
+                    internal_fields = [
+                        "tenant_id",
+                        "created_at",
+                        "updated_at",
+                        "implementation_config",
+                        "targeting_template",
+                    ]
+                    for field in internal_fields:
+                        assert field not in product_dict, f"Product {i} contains internal field: {field}"
+
+                    # Check format_ids are valid strings
+                    for format_id in product_dict["format_ids"]:
+                        assert isinstance(
+                            format_id, str
+                        ), f"Product {i} has non-string format_id: {format_id} ({type(format_id)})"
+                        assert format_id.strip(), f"Product {i} has empty format_id"
+
+                    # Verify there are no unexpected audio format fields as top-level keys
+                    unexpected_audio_fields = ["audio_15s", "audio_30s", "audio_60s"]
+                    for field in unexpected_audio_fields:
+                        assert (
+                            field not in product_dict
+                        ), f"Product {i} has unexpected audio field as top-level key: {field}"
+
+                    print(f"   ✅ Product {i} ({product.product_id}) validation passed")
+
+                except AssertionError as e:
+                    print(f"   ❌ Product {i} validation failed: {e}")
+                    print(f"      Product data: {json.dumps(product_dict, indent=2)}")
+                    all_passed = False
+                except Exception as e:
+                    print(f"   ❌ Product {i} validation error: {e}")
+                    all_passed = False
+
+        except Exception as e:
+            print(f"   ❌ {provider_name} failed: {e}")
+            import traceback
+
+            traceback.print_exc()
+            all_passed = False
+
+    print(f"\n{'='*60}")
+    if all_passed:
+        print("🎉 ALL TESTS PASSED! All product catalog providers create valid Product objects.")
+    else:
+        print("💥 SOME TESTS FAILED! There are Product validation issues.")
+    print(f"{'='*60}")
+
+    return all_passed
+
+
+if __name__ == "__main__":
+    success = asyncio.run(test_all_providers())
+    sys.exit(0 if success else 1)

--- a/tests/unit/test_direct_get_products.py
+++ b/tests/unit/test_direct_get_products.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Test script to directly call get_products and reproduce the validation issue."""
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+# Add the src directory to Python path
+sys.path.insert(0, str(Path(__file__).parent / "src"))
+sys.path.insert(0, str(Path(__file__).parent))
+
+# Enable debug logging
+logging.basicConfig(level=logging.DEBUG)
+
+from src.core.main import get_products
+from src.core.tool_context import ToolContext
+
+
+async def test_direct_get_products():
+    """Test the get_products function directly."""
+
+    print("Testing direct get_products call...")
+
+    # Create a test context similar to what would come from MCP
+    test_context = ToolContext(
+        tenant_id="default",
+        principal_id="test_principal",
+        testing_context={},
+        context_id="test-context",
+        tool_name="get_products",
+        request_timestamp="2025-09-20T18:00:00Z",
+    )
+
+    try:
+        # Call get_products directly
+        result = await get_products(
+            brief="Discover available advertising products for testing",
+            promoted_offering="gourmet robot food",
+            context=test_context,
+        )
+
+        print("✅ get_products call succeeded!")
+        print(f"Response type: {type(result)}")
+        print(f"Response: {result.model_dump() if hasattr(result, 'model_dump') else result}")
+
+        if hasattr(result, "products"):
+            print(f"Number of products: {len(result.products)}")
+            for i, product in enumerate(result.products):
+                print(f"Product {i}: {product.model_dump()}")
+
+    except Exception as e:
+        print(f"❌ get_products call failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+
+
+if __name__ == "__main__":
+    asyncio.run(test_direct_get_products())

--- a/tests/unit/test_product_provider_direct.py
+++ b/tests/unit/test_product_provider_direct.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Test script to directly call the product catalog provider."""
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+# Add the src directory to Python path
+sys.path.insert(0, str(Path(__file__).parent / "src"))
+sys.path.insert(0, str(Path(__file__).parent))
+
+# Enable debug logging
+logging.basicConfig(level=logging.DEBUG)
+
+from product_catalog_providers.database import DatabaseProductCatalog
+
+
+async def test_product_provider():
+    """Test the database product catalog provider directly."""
+
+    print("Testing DatabaseProductCatalog directly...")
+
+    # Create database provider
+    provider = DatabaseProductCatalog({})
+
+    # Initialize it
+    await provider.initialize()
+
+    try:
+        # Call get_products directly
+        products = await provider.get_products(
+            brief="Discover available advertising products for testing",
+            tenant_id="default",
+            principal_id="test_principal",
+            context={
+                "promoted_offering": "gourmet robot food",
+                "tenant_id": "default",
+                "principal_id": "test_principal",
+            },
+            principal_data={"principal_id": "test_principal", "name": "Test Principal", "platform_mappings": {}},
+        )
+
+        print("✅ DatabaseProductCatalog.get_products call succeeded!")
+        print(f"Number of products: {len(products)}")
+
+        for i, product in enumerate(products):
+            print(f"Product {i}: {type(product)} - {product.model_dump()}")
+
+    except Exception as e:
+        print(f"❌ DatabaseProductCatalog.get_products call failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+
+
+if __name__ == "__main__":
+    asyncio.run(test_product_provider())

--- a/tests/unit/test_product_validation.py
+++ b/tests/unit/test_product_validation.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+Test that demonstrates the exact validation gap that allowed the AI provider bug to slip through.
+
+This test would have caught the issue by testing the real database→schema conversion path.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+# Add the src directory to Python path
+sys.path.insert(0, str(Path(__file__).parent / "src"))
+
+from pydantic import ValidationError
+
+from src.core.schemas import Product
+
+
+def test_ai_provider_bug_reproduction():
+    """
+    This test reproduces the exact bug that was in the AI provider.
+
+    It demonstrates how passing internal database fields to the Product constructor
+    fails validation - this is the test that should have been written to catch the bug.
+    """
+
+    # Simulate the problematic product_data dict that the AI provider was creating
+    # This is the EXACT pattern from ai.py lines 93-110 before the fix
+    product_model_data = {
+        "product_id": "test_product",
+        "name": "Test Product",
+        "description": "Test description",
+        "formats": ["display_300x250", "audio_15s", "audio_30s"],
+        "delivery_type": "guaranteed",
+        "is_fixed_price": True,
+        "cpm": 10.0,
+        # BUG: These fields were being passed to Product constructor but aren't valid
+        "targeting_template": {"demographics": "adults"},  # INVALID - internal field
+        "price_guidance": {"min": 5.0, "max": 15.0},  # INVALID - not in Product schema
+        "implementation_config": {"placement": "123"},  # INVALID - internal field
+        "countries": ["US", "CA"],  # INVALID - not in Product schema
+        "expires_at": "2024-12-31",  # INVALID - internal field
+        "is_custom": False,
+    }
+
+    print("Testing the exact Product construction pattern that was failing...")
+    print(f"Attempting to create Product with data: {json.dumps(product_model_data, indent=2)}")
+
+    # This reveals the ACTUAL problem: Pydantic silently accepts extra fields!
+    try:
+        product = Product(**product_model_data)
+        print("🚨 CRITICAL ISSUE: Product construction succeeded when it should have failed!")
+        print("🚨 This means our Product schema accepts ANY extra fields!")
+
+        # Check what fields actually got set
+        actual_fields = list(product.__dict__.keys())
+        print(f"🔍 Fields that got set on Product object: {actual_fields}")
+
+        # Check what's in the AdCP response
+        adcp_response = product.model_dump()
+        print(f"🔍 Fields in AdCP response: {list(adcp_response.keys())}")
+
+        # The dangerous part: do internal fields leak into the AdCP response?
+        internal_fields = ["targeting_template", "price_guidance", "implementation_config", "countries"]
+        leaked_fields = [field for field in internal_fields if field in adcp_response]
+
+        if leaked_fields:
+            print(f"💥 SECURITY ISSUE: Internal fields leaked to AdCP response: {leaked_fields}")
+            raise AssertionError(f"Internal fields {leaked_fields} should not be in AdCP response!")
+        else:
+            print("✅ Good: Internal fields were ignored and not included in AdCP response")
+
+        return True  # Product construction succeeded (unexpectedly)
+
+    except ValidationError as e:
+        print(f"✅ Validation error caught as expected: {e}")
+        return False  # Product construction failed (as expected)
+
+
+def test_correct_product_construction():
+    """
+    Test the CORRECT way to construct Product objects (as fixed in the AI provider).
+
+    This demonstrates the proper pattern that should be used by all providers.
+    """
+
+    # Correct product_data dict with only AdCP-compliant fields
+    correct_product_data = {
+        "product_id": "test_product",
+        "name": "Test Product",
+        "description": "Test description",
+        "formats": ["display_300x250", "audio_15s", "audio_30s"],
+        "delivery_type": "guaranteed",
+        "is_fixed_price": True,
+        "cpm": 10.0,
+        "is_custom": False,
+        # NOTE: Internal fields like targeting_template, price_guidance, etc. are NOT included
+    }
+
+    print("Testing the CORRECT Product construction pattern...")
+    print(f"Creating Product with clean data: {json.dumps(correct_product_data, indent=2)}")
+
+    # This should SUCCEED
+    product = Product(**correct_product_data)
+
+    print("✅ Product created successfully!")
+
+    # Verify the AdCP-compliant response
+    adcp_response = product.model_dump()
+    print(f"AdCP response: {json.dumps(adcp_response, indent=2)}")
+
+    # Verify required fields are present
+    assert "product_id" in adcp_response
+    assert "format_ids" in adcp_response  # Note: formats becomes format_ids in response
+    assert adcp_response["format_ids"] == ["display_300x250", "audio_15s", "audio_30s"]
+
+    # Verify internal fields are NOT in the response
+    internal_fields = ["targeting_template", "price_guidance", "implementation_config", "countries", "expires_at"]
+    for field in internal_fields:
+        assert field not in adcp_response, f"Internal field '{field}' should not be in AdCP response"
+
+    print("✅ All AdCP compliance checks passed!")
+
+
+if __name__ == "__main__":
+    print("=" * 80)
+    print("TESTING THE VALIDATION GAP THAT ALLOWED THE AI PROVIDER BUG")
+    print("=" * 80)
+
+    print("\n1. Testing the BROKEN pattern (should fail):")
+    construction_succeeded = test_ai_provider_bug_reproduction()
+
+    print("\n2. Testing the CORRECT pattern (should succeed):")
+    test_correct_product_construction()
+
+    print("\n" + "=" * 80)
+    print("✅ ALL TESTS PASSED - Validation gap has been identified!")
+    print("This test should be added to the test suite to prevent regressions.")
+    print("=" * 80)


### PR DESCRIPTION
## Summary
Adds 5 unit test files that were moved from root directory to `tests/unit/` but were accidentally left untracked during the PR #174 cleanup process.

## Test Files Added
- `test_ai_provider_bug.py` - Debug test for AI provider validation issues  
- `test_comprehensive_product_validation.py` - Comprehensive validation test across all product providers
- `test_direct_get_products.py` - Direct testing of `get_products` tool
- `test_product_provider_direct.py` - Direct testing of product catalog providers
- `test_product_validation.py` - Specific test demonstrating AI provider bug reproduction

## Test Coverage
These files provide debugging and validation coverage for product catalog providers and MCP tools, complementing the comprehensive test suite.

🤖 Generated with [Claude Code](https://claude.ai/code)