### PR TITLE
Fix product deletion 404 error: correct JavaScript URL path

### DIFF
--- a/templates/products.html
+++ b/templates/products.html
@@ -188,7 +188,7 @@
 <script>
 function deleteProduct(productId, productName) {
     if (confirm(`Are you sure you want to delete product "${productName}"?\n\nThis action cannot be undone and may affect active campaigns.`)) {
-        fetch(`/tenant/{{ tenant_id }}/products/${productId}/delete`, {
+        fetch(`/admin/tenant/{{ tenant_id }}/products/${productId}/delete`, {
             method: 'DELETE',
             headers: {
                 'Content-Type': 'application/json'


### PR DESCRIPTION
## Problem
Product deletion was failing in production with a 404 error instead of the expected validation error. Users were getting "Failed to delete product: The string did not match the expected pattern" error.

## Root Cause Analysis
The issue was NOT with our JSON validation fix (which was working correctly), but with the JavaScript DELETE request URL:
- JavaScript was calling: `/tenant/{tenant_id}/products/{product_id}/delete`
- Correct admin route is: `/admin/tenant/{tenant_id}/products/{product_id}/delete`

## Solution
Updated `templates/products.html` line 191 to use the correct `/admin` prefix for the DELETE request URL to match the Flask blueprint registration.

## Testing
- ✅ Confirmed route exists with correct authentication (returns 302 redirect to login when not authenticated)
- ✅ Production logs show 404 errors for requests without `/admin` prefix
- ✅ Pre-commit hooks pass
- ✅ Fix targets the actual routing issue rather than validation

## Impact
This resolves the production product deletion failures and allows users to properly delete products as intended.

🤖 Generated with [Claude Code](https://claude.ai/code)