### PR TITLE
Fix GAM inventory sync by making advertiser_id optional

### DIFF
--- a/src/services/gam_inventory_service.py
+++ b/src/services/gam_inventory_service.py
@@ -814,20 +814,17 @@ def create_inventory_endpoints(app):
                 platform_mappings={"gam_advertiser_id": adapter_config.gam_company_id or "system"},
             )
 
-            # Validate required fields
+            # Validate required fields for inventory sync (only network code is required)
             if not adapter_config.gam_network_code:
                 return jsonify({"error": "GAM network code not configured"}), 400
-            if not adapter_config.gam_company_id:
-                return jsonify({"error": "GAM company/advertiser ID not configured"}), 400
-            if not adapter_config.gam_trafficker_id:
-                return jsonify({"error": "GAM trafficker ID not configured"}), 400
+            # Note: company_id and trafficker_id are only required for order operations, not inventory sync
 
             adapter = GoogleAdManager(
                 config=gam_config,
                 principal=principal,
                 network_code=adapter_config.gam_network_code,
-                advertiser_id=adapter_config.gam_company_id,
-                trafficker_id=adapter_config.gam_trafficker_id,
+                advertiser_id=None,  # Not needed for inventory sync
+                trafficker_id=None,  # Not needed for inventory sync
                 tenant_id=tenant_id,
                 dry_run=False,
             )


### PR DESCRIPTION
GAM inventory sync was failing with "GAM company/advertiser ID not configured" because the GoogleAdManager constructor required advertiser_id for all operations. Inventory sync only needs network-level access, not advertiser-specific data.

Changes:
- Make advertiser_id and trafficker_id optional in GoogleAdManager constructor
- Only initialize order/creative managers when advertiser_id is provided
- Remove advertiser_id validation requirement for inventory sync operations
- Update inventory sync service to pass None for advertiser fields

This allows inventory sync to work with just network_code and refresh_token, while preserving advertiser_id requirement for order/campaign operations.

🤖 Generated with [Claude Code](https://claude.ai/code)