### PR TITLE
Fix GAM company attribute access in orders manager

### DIFF
--- a/src/adapters/gam/managers/orders.py
+++ b/src/adapters/gam/managers/orders.py
@@ -256,16 +256,16 @@ class GAMOrdersManager:
             statement = statement_builder.ToStatement()
 
             result = company_service.getCompaniesByStatement(statement)
-            companies = result.get("results", [])
+            companies = result.results if result and hasattr(result, "results") else []
 
             # Format for UI
             advertisers = []
             for company in companies:
                 advertisers.append(
                     {
-                        "id": str(company["id"]),
-                        "name": company["name"],
-                        "type": company["type"],
+                        "id": str(company.id),
+                        "name": company.name,
+                        "type": company.type,
                     }
                 )
 


### PR DESCRIPTION
Changed from dictionary access to attribute access for GAM API response objects:
- company["id"] → company.id
- company["name"] → company.name
- company["type"] → company.type
- Added proper null checking for result.results

Fixes KeyError exceptions when retrieving advertiser companies from GAM API.

🤖 Generated with [Claude Code](https://claude.ai/code)