### PR TITLE
Fix A2A skill invocation to support both 'input' and 'parameters' fields

### DIFF
--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -217,16 +217,24 @@ class AdCPRequestHandler(RequestHandler):
 
                 # Handle structured data parts (explicit skill invocation)
                 elif hasattr(part, "data") and isinstance(part.data, dict):
-                    if "skill" in part.data and "parameters" in part.data:
-                        skill_invocations.append({"skill": part.data["skill"], "parameters": part.data["parameters"]})
-                        logger.info(f"Found explicit skill invocation: {part.data['skill']}")
+                    # Support both "input" (A2A spec) and "parameters" (legacy) for skill params
+                    if "skill" in part.data:
+                        params_data = part.data.get("input") or part.data.get("parameters", {})
+                        skill_invocations.append({"skill": part.data["skill"], "parameters": params_data})
+                        logger.info(
+                            f"Found explicit skill invocation: {part.data['skill']} with params: {list(params_data.keys())}"
+                        )
 
                 # Handle nested data structure (some A2A clients use this format)
                 elif hasattr(part, "root") and hasattr(part.root, "data"):
                     data = part.root.data
-                    if isinstance(data, dict) and "skill" in data and "parameters" in data:
-                        skill_invocations.append({"skill": data["skill"], "parameters": data["parameters"]})
-                        logger.info(f"Found explicit skill invocation (nested): {data['skill']}")
+                    if isinstance(data, dict) and "skill" in data:
+                        # Support both "input" (A2A spec) and "parameters" (legacy) for skill params
+                        params_data = data.get("input") or data.get("parameters", {})
+                        skill_invocations.append({"skill": data["skill"], "parameters": params_data})
+                        logger.info(
+                            f"Found explicit skill invocation (nested): {data['skill']} with params: {list(params_data.keys())}"
+                        )
 
         # Combine text for natural language fallback
         combined_text = " ".join(text_parts).strip().lower()


### PR DESCRIPTION
## Problem

The Wonderstruck A2A endpoint at `https://wonderstruck.sales-agent.scope3.com` was responding with capabilities information instead of executing the `get_products` skill when clients sent proper A2A protocol requests.

### Client Request (Correct A2A Format)
```json
{
  "skill": "get_products",
  "input": {
    "brief": "Premium coffee brands focused on sustainability",
    "promoted_offering": "Wonderstruck Premium Video Ads"
  }
}
```

### Server Response (Incorrect - Capabilities Instead of Products)
```json
{
  "supported_queries": [...],
  "example_queries": [...]
}
```

## Root Cause

The server code in `adcp_a2a_server.py` (lines 218-227) was only checking for a legacy `"parameters"` field, but the **A2A protocol specification uses `"input"`** for skill parameters:

**Before (buggy):**
```python
if "skill" in part.data and "parameters" in part.data:  # Only checked 'parameters'
    skill_invocations.append(...)
```

Since the client was correctly sending `"input"` per the A2A spec, the skill invocation was never detected, causing the request to fall through to the natural language fallback handler which returned capabilities.

## Solution

Updated the skill invocation parsing logic to support **both** the A2A spec field name (`"input"`) and the legacy field name (`"parameters"`):

**After (fixed):**
```python
# Support both "input" (A2A spec) and "parameters" (legacy) for skill params
if "skill" in part.data:
    params_data = part.data.get("input") or part.data.get("parameters", {})
    skill_invocations.append({"skill": part.data["skill"], "parameters": params_data})
```

## Testing

### New Tests Added

1. **Unit Test** (`test_a2a_skill_invocation.py::test_explicit_skill_get_products_a2a_spec`)
   - Tests A2A spec `"input"` field with mocked dependencies
   - Verifies skill invocation is recognized as explicit_skill
   - All 10 existing A2A skill invocation tests still pass

2. **Integration/Regression Test** (`test_a2a_real_data_flow.py::test_a2a_explicit_skill_with_input_field`)
   - Tests complete `on_message_send()` flow with A2A spec `"input"` field
   - Uses real database to validate end-to-end behavior
   - **Would have caught this bug** with assertions:
     - `invocation_type == "explicit_skill"` (not "natural_language")
     - Response contains `"products"` (not `"supported_queries"`)

### Testing Gap Identified

**Existing tests had a critical gap:**
- Tests called `_handle_get_products_skill()` directly with pre-extracted parameters
- This **bypassed the message parsing logic** where the bug occurred
- Never tested the A2A spec's `"input"` field format

**Example of the gap:**
```python
# This test SKIPPED the parsing logic that had the bug
response = await handler._handle_get_products_skill(
    parameters={"brief": "...", "promoted_offering": "..."},  # Already extracted!
    auth_token="test_a2a_token_123",
)
```

The new regression test ensures this pattern won't slip through again.

## Impact

✅ **Fixed**: All A2A clients using the standard `"input"` field will now have their skills executed correctly  
✅ **Maintained**: Backward compatibility with legacy clients using `"parameters"` field  
✅ **Tested**: Comprehensive test coverage prevents regression  
✅ **Production Ready**: Wonderstruck endpoint will now return actual products instead of capabilities

## Commits

- Fix A2A skill invocation to support both 'input' and 'parameters' fields
- Add regression test for A2A 'input' field parsing