### PR TITLE
Fix datetime parsing bug for ISO 8601 datetime strings

### DIFF
--- a/src/core/schemas.py
+++ b/src/core/schemas.py
@@ -1822,24 +1822,18 @@ class CreateMediaBuyRequest(BaseModel):
             values["packages"] = packages
 
         # Convert dates to datetimes with defensive handling
-        # Handle start_date -> start_time conversion
-        if "start_date" in values:
-            start_time_value = values.get("start_time")
-            # Only use start_time if it's already a datetime object
-            # If it's a string (invalid time-only format), ignore it and use start_date
-            if not isinstance(start_time_value, datetime):
-                start_date = values["start_date"]
+        # Handle start_date -> start_time conversion (only if start_time not provided)
+        if "start_date" in values and not values.get("start_time"):
+            start_date = values["start_date"]
+            if start_date is not None:
                 if isinstance(start_date, str):
                     start_date = date.fromisoformat(start_date)
                 values["start_time"] = datetime.combine(start_date, time.min, tzinfo=UTC)
 
-        # Handle end_date -> end_time conversion
-        if "end_date" in values:
-            end_time_value = values.get("end_time")
-            # Only use end_time if it's already a datetime object
-            # If it's a string (invalid time-only format), ignore it and use end_date
-            if not isinstance(end_time_value, datetime):
-                end_date = values["end_date"]
+        # Handle end_date -> end_time conversion (only if end_time not provided)
+        if "end_date" in values and not values.get("end_time"):
+            end_date = values["end_date"]
+            if end_date is not None:
                 if isinstance(end_date, str):
                     end_date = date.fromisoformat(end_date)
                 values["end_time"] = datetime.combine(end_date, time.max, tzinfo=UTC)


### PR DESCRIPTION
## Summary

Fixes the production error where valid AdCP v2.4 requests with ISO 8601 datetime strings were failing with `datetime.combine() argument 1 must be datetime.date, not None`.

## Problem

The `CreateMediaBuyRequest` validator was incorrectly attempting to convert legacy `start_date`/`end_date` fields even when clients sent proper `start_time`/`end_time` ISO datetime strings. This caused `datetime.combine()` to be called with `None` values.

Example failing request:
```json
{
  "start_time": "2025-10-02T14:07:39.724Z",
  "end_time": "2025-11-01T14:07:39.724Z"
}
```

## Solution

- Only convert `start_date` → `start_time` if `start_time` is not provided
- Only convert `end_date` → `end_time` if `end_time` is not provided  
- Add None checks before calling `datetime.combine()`
- Preserves backward compatibility with legacy date-only format

## Testing

- ✅ Manual validation with ISO datetime strings
- ✅ Manual validation with legacy date-only format
- ✅ All unit/schema tests pass
- ✅ Pre-commit hooks pass

## Impact

- Fixes production issues on wonderstruck.sales-agent.scope3.com
- No breaking changes - fully backward compatible
- Aligns with AdCP v2.4 specification

🤖 Generated with [Claude Code](https://claude.com/claude-code)