### PR TITLE
Fix GoogleAdManager initialization in get_adapter()

### DIFF
--- a/src/core/main.py
+++ b/src/core/main.py
@@ -390,7 +390,15 @@ def get_adapter(principal: Principal, dry_run: bool = False, testing_context=Non
             adapter_config, principal, dry_run, tenant_id=tenant_id, strategy_context=testing_context
         )
     elif selected_adapter == "google_ad_manager":
-        return GoogleAdManager(adapter_config, principal, dry_run, tenant_id=tenant_id)
+        return GoogleAdManager(
+            config=adapter_config,
+            principal=principal,
+            network_code=adapter_config.get("network_code", ""),
+            advertiser_id=adapter_config.get("company_id"),
+            trafficker_id=adapter_config.get("trafficker_id"),
+            dry_run=dry_run,
+            tenant_id=tenant_id,
+        )
     elif selected_adapter == "kevel":
         return Kevel(adapter_config, principal, dry_run, tenant_id=tenant_id)
     elif selected_adapter in ["triton", "triton_digital"]:


### PR DESCRIPTION
## Summary
- Fixed GoogleAdManager initialization argument passing in get_adapter()
- Changed from positional to keyword arguments to match __init__ signature
- Resolves server crash: "takes 3 positional arguments but 4 were given"

## Problem
The `GoogleAdManager.__init__()` signature requires keyword-only arguments after the `*` separator (network_code, advertiser_id, etc), but `get_adapter()` was passing `dry_run` as a positional argument, causing initialization to fail.

## Solution
Changed the instantiation in `src/core/main.py:393` to pass all required arguments as keyword arguments:
- `config`, `principal` (positional)
- `network_code`, `advertiser_id`, `trafficker_id`, `dry_run`, `tenant_id` (keyword)

## Test Plan
- [x] Server starts successfully without initialization errors
- [x] MCP `get_products` call works correctly
- [x] MCP `create_media_buy` reaches authentication step (confirming adapter initialized)
- [x] Original error no longer appears in server logs
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)