### PR TITLE
Fix GAM OAuth callback 404 error

### DIFF
--- a/src/admin/blueprints/auth.py
+++ b/src/admin/blueprints/auth.py
@@ -529,7 +529,7 @@ def test_login_form():
 
 
 # GAM OAuth Flow endpoints
-@auth_bp.route("/gam/authorize/<tenant_id>")
+@auth_bp.route("/auth/gam/authorize/<tenant_id>")
 def gam_authorize(tenant_id):
     """Initiate GAM OAuth flow for tenant."""
     # Verify tenant exists and user has access
@@ -588,7 +588,7 @@ def gam_authorize(tenant_id):
         return redirect(url_for("tenants.settings", tenant_id=tenant_id))
 
 
-@auth_bp.route("/gam/callback")
+@auth_bp.route("/auth/gam/callback")
 def gam_callback():
     """Handle GAM OAuth callback and store refresh token."""
     try:

--- a/templates/tenant_settings.html
+++ b/templates/tenant_settings.html
@@ -1413,7 +1413,7 @@ function checkOAuthConfig() {
 function startGAMOAuth() {
     // Open OAuth flow in a new window/tab
     const tenantId = '{{ tenant.tenant_id }}';
-    const oauthUrl = '{{ script_name }}/gam/authorize/' + tenantId;
+    const oauthUrl = '{{ script_name }}/auth/gam/authorize/' + tenantId;
 
     // Show loading state
     const button = event.target;


### PR DESCRIPTION
## Summary
- Fixed GAM OAuth callback returning 404 error
- Routes now match the callback URIs configured in Google Cloud Console

## Problem
The GAM OAuth callback was failing with a 404 error because:
- Google was sending callbacks to: `https://sales-agent.scope3.com/admin/auth/gam/callback`
- But the route was registered at: `/gam/callback` (which becomes `/admin/gam/callback`)

## Solution
Updated both GAM OAuth routes to include the `/auth/` prefix:
- `/gam/authorize/<tenant_id>` → `/auth/gam/authorize/<tenant_id>`
- `/gam/callback` → `/auth/gam/callback`

This aligns with the callback URIs hardcoded in the OAuth flow (auth.py lines 566 and 625).

## Test Plan
- [x] Pre-commit hooks passed
- [ ] Test GAM OAuth flow in production
- [ ] Verify callback successfully receives authorization code
- [ ] Confirm refresh token is stored correctly

## Files Changed
- `src/admin/blueprints/auth.py`: Updated route decorators
- `templates/tenant_settings.html`: Updated OAuth URL construction

🤖 Generated with [Claude Code](https://claude.com/claude-code)