### PR TITLE
Fix missing SQLAlchemy imports in inventory blueprint

### DIFF
--- a/src/admin/blueprints/inventory.py
+++ b/src/admin/blueprints/inventory.py
@@ -4,7 +4,7 @@ import json
 import logging
 
 from flask import Blueprint, jsonify, render_template, request, session
-from sqlalchemy import func
+from sqlalchemy import String, func, or_
 
 from src.admin.utils import get_tenant_config_from_db, require_auth, require_tenant_access
 from src.core.database.database_session import get_db_session


### PR DESCRIPTION
## Summary
Fixed 404 error when loading inventory in GAM product configuration by adding missing SQLAlchemy imports.

## Problem
When trying to load ad units or placements in the GAM product configuration UI, users received:
- Error: `Failed to fetch inventory`
- 404 response from `/inventory/api/tenant/{tenant_id}/inventory-list`

## Root Cause
The `get_inventory_list()` function at line 371 uses `or_()` (line 407) and `String` (line 409) from SQLAlchemy for search filtering, but these were not imported. This caused a `NameError` when the route was accessed.

## Solution
Added missing imports:
```python
from sqlalchemy import String, func, or_
```

## Testing
- Pre-commit hooks passed
- Route now properly handles inventory search requests

## Impact
Users can now:
- Browse ad units and placements in GAM product configuration
- Use search filtering in the inventory picker
- Configure targeting for products

🤖 Generated with [Claude Code](https://claude.com/claude-code)