### PR TITLE
Use AWS Public ECR to eliminate Docker Hub rate limits

### DIFF
--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -1,8 +1,9 @@
 # Fly.io Dockerfile for AdCP Sales Agent with A2A Server
 # syntax=docker/dockerfile:1.4
 
-# Use BuildKit secrets for Docker Hub authentication (avoids rate limits)
-FROM python:3.12-slim
+# Use AWS Public ECR to avoid Docker Hub rate limits
+# Public ECR mirrors official Docker images without rate limiting
+FROM public.ecr.aws/docker/library/python:3.12-slim
 
 # Install dependencies including nginx
 RUN apt-get update && apt-get install -y \

--- a/docs/docker-hub-auth.md
+++ b/docs/docker-hub-auth.md
@@ -1,4 +1,4 @@
-# Docker Hub Authentication for Fly.io Deployment
+# Docker Hub Rate Limit Solution for Fly.io Deployment
 
 ## Problem
 Fly.io deployments fail with Docker Hub rate limit errors:
@@ -6,8 +6,25 @@ Fly.io deployments fail with Docker Hub rate limit errors:
 429 Too Many Requests - Server message: toomanyrequests: You have reached your unauthenticated pull rate limit.
 ```
 
-## Solution
-Configure Docker Hub authentication credentials in Fly.io.
+## Implemented Solution ✅
+**Use AWS Public ECR instead of Docker Hub.**
+
+The `Dockerfile.fly` now uses:
+```dockerfile
+FROM public.ecr.aws/docker/library/python:3.12-slim
+```
+
+**Benefits:**
+- ✅ No rate limits for public images
+- ✅ No authentication required
+- ✅ Mirrors official Docker images (same SHA)
+- ✅ No configuration needed in Fly.io
+- ✅ High availability and fast pulls
+
+AWS Public ECR provides a mirror of Docker's official images without rate limiting or authentication requirements. This is the simplest and most reliable solution for Fly.io deployments.
+
+## Alternative: Docker Hub Authentication (Advanced)
+If you specifically need Docker Hub, you can configure authentication (note: this is more complex and requires additional setup).
 
 ## Setup Steps
 


### PR DESCRIPTION
## Summary
Switches from Docker Hub to AWS Public ECR for base image, completely eliminating rate limit issues without requiring any authentication or configuration.

## Problem
Despite PR #214 adding BuildKit syntax, deployments still fail with Docker Hub rate limits because Fly.io's remote builder doesn't have access to the Docker Hub credentials configured as secrets.

## Solution
Use AWS Public ECR mirror of official Docker images:
```dockerfile
FROM public.ecr.aws/docker/library/python:3.12-slim
```

## Benefits
- ✅ **No rate limits** for public images
- ✅ **No authentication required** - zero configuration
- ✅ **Same official images** - identical SHA as Docker Hub
- ✅ **High availability** - AWS infrastructure
- ✅ **Verified working** - successful test build completed

## Testing
Ran test deployment which completed successfully:
```bash
flyctl deploy --build-only --push -a adcp-sales-agent
# ✅ Build succeeded without rate limit errors
```

## Test Plan
- [x] Verify Dockerfile changes
- [x] Test build completes without rate limits
- [x] Confirm image SHA matches official Python image
- [ ] Deploy to production and verify services start correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)