### PR TITLE
Show actual error in GAM advertisers dropdown

### DIFF
--- a/templates/create_principal.html
+++ b/templates/create_principal.html
@@ -103,7 +103,14 @@ function loadAdvertisers() {
         }),
         credentials: 'same-origin'
     })
-    .then(response => response.json())
+    .then(response => {
+        if (!response.ok) {
+            return response.text().then(text => {
+                throw new Error(`HTTP ${response.status}: ${text.substring(0, 200)}`);
+            });
+        }
+        return response.json();
+    })
     .then(data => {
         if (data.error) {
             throw new Error(data.error);


### PR DESCRIPTION
Add better error handling to display actual HTTP response text when the GAM advertisers API fails, instead of generic JSON parse error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)