### PR TITLE
Fix duplicate URL prefix in principals blueprint causing 404 errors

### DIFF
--- a/src/admin/blueprints/principals.py
+++ b/src/admin/blueprints/principals.py
@@ -15,8 +15,8 @@ from src.core.database.models import MediaBuy, Principal, Tenant
 
 logger = logging.getLogger(__name__)
 
-# Create Blueprint
-principals_bp = Blueprint("principals", __name__, url_prefix="/tenant/<tenant_id>")
+# Create Blueprint (url_prefix is set during registration in app.py)
+principals_bp = Blueprint("principals", __name__)
 
 
 @principals_bp.route("/principals")

--- a/templates/create_principal.html
+++ b/templates/create_principal.html
@@ -103,7 +103,14 @@ function loadAdvertisers() {
         }),
         credentials: 'same-origin'
     })
-    .then(response => response.json())
+    .then(response => {
+        if (!response.ok) {
+            return response.text().then(text => {
+                throw new Error(`HTTP ${response.status}: ${text.substring(0, 200)}`);
+            });
+        }
+        return response.json();
+    })
     .then(data => {
         if (data.error) {
             throw new Error(data.error);


### PR DESCRIPTION
## Summary
Fixed a routing bug where the GAM advertisers API endpoint was returning 404 due to duplicate URL prefix configuration.

## Root Cause
The `principals_bp` Blueprint was defining `url_prefix="/tenant/<tenant_id>"` in its creation (line 19 of principals.py), and then being registered **again** with the same prefix in app.py (line 195). This caused a double prefix:
```
/tenant/<tenant_id>/tenant/<tenant_id>/api/gam/get-advertisers → 404 ❌
```

## Solution
Removed the duplicate `url_prefix` from the Blueprint definition in `principals.py`, keeping it only in the registration in `app.py`. Now the route correctly resolves to:
```
/tenant/<tenant_id>/api/gam/get-advertisers → 200 ✅
```

## Testing
- ✅ Docker services restart successfully
- ✅ All pre-commit hooks pass
- ✅ Route is registered correctly in Flask route map
- ✅ Backend logs show no errors
- ✅ Endpoint responds correctly (302 redirect for unauthenticated, proper auth flow for authenticated)

## Impact
Fixes the GAM advertisers dropdown 404 error that prevented users from loading advertiser lists when creating new principals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)