### PR TITLE
Fix missing script_name prefix in GAM advertisers fetch URL

### DIFF
--- a/templates/create_principal.html
+++ b/templates/create_principal.html
@@ -93,7 +93,7 @@ function loadAdvertisers() {
     errorDiv.style.display = 'none';
 
     // Fetch advertisers from API
-    fetch('/tenant/{{ tenant_id }}/api/gam/get-advertisers', {
+    fetch('{{ script_name }}/tenant/{{ tenant_id }}/api/gam/get-advertisers', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
Fixed production 404 error when loading GAM advertisers dropdown in the create principal page.

## Root Cause
The fetch call in `create_principal.html` was using a hardcoded path:
```javascript
fetch('/tenant/{id}/api/gam/get-advertisers', ...)
```

This works in local dev (no path prefix) but **fails in production** where the admin UI is mounted at `/admin`:
```
❌ Production request: /tenant/{id}/api/gam/get-advertisers → 404
✅ Should be:          /admin/tenant/{id}/api/gam/get-advertisers
```

## Solution
Added `{{ script_name }}` prefix to the fetch URL to match the pattern used in other templates:
```javascript
fetch('{{ script_name }}/tenant/{{ tenant_id }}/api/gam/get-advertisers', ...)
```

The `script_name` variable is:
- Empty string in local dev: `"" + /tenant/...` → `/tenant/...`
- `/admin` in production: `"/admin" + /tenant/...` → `/admin/tenant/...`

## Testing
- ✅ All pre-commit hooks pass
- ✅ Template url_for validation passes
- ✅ Matches pattern in `tenant_settings.html` (lines 1296, 1338, 1375)

## Impact
Fixes the GAM advertisers dropdown 404 error in production (wonderstruck.sales-agent.scope3.com).

🤖 Generated with [Claude Code](https://claude.com/claude-code)