### PR TITLE
Fix GAM adapter initialization in get_gam_advertisers endpoint

### DIFF
--- a/src/admin/blueprints/principals.py
+++ b/src/admin/blueprints/principals.py
@@ -316,19 +316,22 @@ def get_gam_advertisers(tenant_id):
                 )
 
                 # Build GAM config from AdapterConfig
-                gam_config = (
-                    {
-                        "network_code": tenant.adapter_config.gam_network_code,
-                        "refresh_token": tenant.adapter_config.gam_refresh_token,
-                        "trafficker_id": tenant.adapter_config.gam_trafficker_id,
-                        "manual_approval_required": tenant.adapter_config.gam_manual_approval_required or False,
-                    }
-                    if tenant.adapter_config
-                    else {}
-                )
+                if not tenant.adapter_config or not tenant.adapter_config.gam_network_code:
+                    return jsonify({"error": "GAM network code not configured for this tenant"}), 400
+
+                gam_config = {
+                    "refresh_token": tenant.adapter_config.gam_refresh_token,
+                    "manual_approval_required": tenant.adapter_config.gam_manual_approval_required or False,
+                }
 
                 adapter = GoogleAdManager(
-                    config=gam_config, principal=mock_principal, dry_run=False, tenant_id=tenant_id
+                    config=gam_config,
+                    principal=mock_principal,
+                    network_code=tenant.adapter_config.gam_network_code,
+                    advertiser_id=None,
+                    trafficker_id=tenant.adapter_config.gam_trafficker_id,
+                    dry_run=False,
+                    tenant_id=tenant_id,
                 )
 
                 # Get advertisers (companies) from GAM


### PR DESCRIPTION
## Summary
Fixed 500 error when loading GAM advertisers dropdown caused by incorrect parameter passing to GoogleAdManager constructor.

## Root Cause
The `GoogleAdManager.__init__()` method signature has `network_code` as a **keyword-only argument** (after `*`):

```python
def __init__(
    self,
    config: dict[str, Any],
    principal,
    *,  # Everything after this must be passed as kwarg
    network_code: str,
    advertiser_id: str | None = None,
    trafficker_id: str | None = None,
    ...
):
```

But the code in `principals.py` was trying to pass `network_code` via the `config` dict:

```python
gam_config = {
    "network_code": tenant.adapter_config.gam_network_code,  # ❌ Wrong
    ...
}
adapter = GoogleAdManager(config=gam_config, ...)
```

This caused:
```
GoogleAdManager.__init__() missing 1 required keyword-only argument: 'network_code'
```

## Solution
Pass `network_code`, `advertiser_id`, and `trafficker_id` as explicit keyword arguments:

```python
adapter = GoogleAdManager(
    config=gam_config,
    principal=mock_principal,
    network_code=tenant.adapter_config.gam_network_code,  # ✅ Correct
    advertiser_id=None,
    trafficker_id=tenant.adapter_config.gam_trafficker_id,
    dry_run=False,
    tenant_id=tenant_id,
)
```

Also added validation to return a clear 400 error if network_code is not configured.

## Testing
- ✅ All pre-commit hooks pass
- ✅ Follows the correct pattern from GoogleAdManager signature

## Impact
Fixes the GAM advertisers dropdown 500 error in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)