### PR TITLE
Make advertiser_id optional for GAM query operations

### DIFF
--- a/src/adapters/gam/managers/orders.py
+++ b/src/adapters/gam/managers/orders.py
@@ -21,13 +21,15 @@ NON_GUARANTEED_LINE_ITEM_TYPES = {"NETWORK", "BULK", "PRICE_PRIORITY", "HOUSE"}
 class GAMOrdersManager:
     """Manages Google Ad Manager order operations."""
 
-    def __init__(self, client_manager, advertiser_id: str, trafficker_id: str, dry_run: bool = False):
+    def __init__(
+        self, client_manager, advertiser_id: str | None = None, trafficker_id: str | None = None, dry_run: bool = False
+    ):
         """Initialize orders manager.
 
         Args:
             client_manager: GAMClientManager instance
-            advertiser_id: GAM advertiser ID
-            trafficker_id: GAM trafficker ID
+            advertiser_id: GAM advertiser ID (required for order creation operations)
+            trafficker_id: GAM trafficker ID (required for order creation operations)
             dry_run: Whether to run in dry-run mode
         """
         self.client_manager = client_manager
@@ -58,8 +60,16 @@ class GAMOrdersManager:
             Created order ID as string
 
         Raises:
+            ValueError: If advertiser_id or trafficker_id not configured
             Exception: If order creation fails
         """
+        # Validate required configuration for order creation
+        if not self.advertiser_id or not self.trafficker_id:
+            raise ValueError(
+                "Order creation requires both advertiser_id and trafficker_id. "
+                "These must be provided when initializing GAMOrdersManager for order operations."
+            )
+
         # Create Order object
         order = {
             "name": order_name,

--- a/tests/unit/test_gam_orders_manager.py
+++ b/tests/unit/test_gam_orders_manager.py
@@ -56,3 +56,32 @@ def test_dry_run_simulation():
 
     assert simulated_order_id == "dry_run_12345"
     assert service_called is False
+
+
+def test_optional_advertiser_id_for_query_operations():
+    """Test that advertiser_id and trafficker_id are optional for query operations like get_advertisers()."""
+    from datetime import datetime
+    from unittest.mock import MagicMock
+
+    from src.adapters.gam.managers.orders import GAMOrdersManager
+
+    # Mock client manager
+    mock_client_manager = MagicMock()
+
+    # Test 1: Can initialize without advertiser_id/trafficker_id
+    manager = GAMOrdersManager(client_manager=mock_client_manager, advertiser_id=None, trafficker_id=None, dry_run=True)
+    assert manager.advertiser_id is None
+    assert manager.trafficker_id is None
+
+    # Test 2: get_advertisers() should work without advertiser_id
+    advertisers = manager.get_advertisers()
+    assert isinstance(advertisers, list)
+    assert len(advertisers) == 2  # Dry-run returns 2 mock advertisers
+
+    # Test 3: create_order() should fail with clear error when advertiser_id is missing
+    with pytest.raises(ValueError) as exc_info:
+        manager.create_order(
+            order_name="Test Order", total_budget=1000.0, start_time=datetime.now(), end_time=datetime.now()
+        )
+    assert "advertiser_id and trafficker_id" in str(exc_info.value)
+    assert "order creation" in str(exc_info.value).lower()


### PR DESCRIPTION
## Summary
Fixed the "No advertisers found" issue in the GAM advertisers dropdown by making advertiser_id/trafficker_id optional for query operations.

## Root Cause
The `get_advertisers()` method was returning an empty list when called from `principals.py` with `advertiser_id=None`.

**The Problem:**
- `get_advertisers()` delegates to `orders_manager.get_advertisers()`
- `orders_manager` was only initialized if BOTH `advertiser_id` AND `trafficker_id` were provided
- When called with `advertiser_id=None`, `orders_manager` remained `None`
- This caused `get_advertisers()` to return `[]` instead of querying GAM

**Why This Was Wrong:**
- `get_advertisers()` queries ALL advertisers from GAM using CompanyService
- It does NOT need `advertiser_id` or `trafficker_id` - these are only used when creating orders
- Other query methods (`get_order_status()`, `archive_order()`) also don't require these IDs
- Only `create_order()` actually needs both IDs

## Solution
Made `advertiser_id` and `trafficker_id` optional parameters in `GAMOrdersManager`, with validation in methods that need them.

**Changes:**

1. **`src/adapters/gam/managers/orders.py`**:
   - Made `advertiser_id` and `trafficker_id` optional in `__init__()` (line 24-26)
   - Updated docstring to clarify they're required only for order creation
   - Added validation in `create_order()` to raise clear `ValueError` if missing (lines 65-69)

2. **`src/adapters/google_ad_manager.py`**:
   - Always initialize `orders_manager` regardless of advertiser_id presence (line 113)
   - Removed conditional `orders_manager` initialization
   - Simplified `get_advertisers()` method (line 311-313)
   - Updated `create_media_buy()` validation to check IDs directly (lines 231-240)
   - Updated `archive_order()` validation similarly (lines 304-309)

3. **`tests/unit/test_gam_orders_manager.py`**:
   - Added comprehensive test `test_optional_advertiser_id_for_query_operations()`
   - Tests initialization without advertiser_id
   - Verifies `get_advertisers()` works correctly
   - Confirms `create_order()` fails with clear error message

## Benefits

1. **Separation of Concerns**: Query operations don't require configuration that's only needed for creation operations
2. **Fail Fast**: Clear error messages when trying to create orders without proper configuration
3. **Backwards Compatible**: Existing code that provides both IDs continues to work
4. **Maintainable**: No need for separate managers or duplicate code
5. **Architecture Consistency**: Maintains the modular manager pattern

## Testing
- ✅ All existing tests pass
- ✅ New test validates the specific use case from principals.py
- ✅ All pre-commit hooks pass

## Impact
Fixes the "No advertisers found" issue in production. The GAM advertisers dropdown will now successfully populate with advertisers from Google Ad Manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)