### PR TITLE
Improve advertiser/principal adapter configuration UX

### DIFF
--- a/templates/create_principal.html
+++ b/templates/create_principal.html
@@ -38,6 +38,9 @@
         </div>
 
         {% if has_gam %}
+        <div class="alert alert-info" style="margin: 1rem 0;">
+            <strong>ℹ️ Note:</strong> This tenant uses Google Ad Manager. All campaigns will be executed through GAM and will write to your GAM network.
+        </div>
         <div class="form-group">
             <label for="gam_advertiser_id">GAM Advertiser <span style="color: red;">*</span></label>
             <select id="gam_advertiser_id" name="gam_advertiser_id" required
@@ -47,6 +50,11 @@
             <small>Select which advertiser company this is in Google Ad Manager.</small>
             <div id="advertiser-loading-error" style="display: none; color: red; margin-top: 0.5rem;"></div>
         </div>
+        {% else %}
+        <div class="alert alert-info" style="margin: 1rem 0;">
+            <strong>ℹ️ Note:</strong> This tenant uses the Mock adapter for testing. No real ad server API calls will be made.
+            <br><strong>To use a real ad server</strong>, configure GAM or another adapter in the Settings → Ad Server tab.
+        </div>
         {% endif %}
 
         <div style="background: #f8f9fa; padding: 1rem; border-radius: 8px; margin: 2rem 0;">
@@ -55,8 +63,9 @@
                 <li>A secure API token will be generated for this advertiser</li>
                 {% if has_gam %}
                 <li>The advertiser will be linked to their GAM account</li>
+                <li><strong>All campaigns will write to your GAM network</strong> - this is not a test environment</li>
                 {% else %}
-                <li>You can configure ad server mappings later if needed</li>
+                <li>This advertiser will use the Mock adapter for testing (no real API calls)</li>
                 {% endif %}
                 <li>Share the API token with the advertiser to access the MCP API</li>
                 <li>The advertiser can create and manage campaigns programmatically</li>

--- a/templates/tenant_settings.html
+++ b/templates/tenant_settings.html
@@ -1861,11 +1861,12 @@ function renderPrincipalEditor(principal) {
 
             <h5 class="mt-4 mb-3">Google Ad Manager</h5>
             <div class="mb-3">
-                <label for="gam_company_id" class="form-label">Company ID / Advertiser ID</label>
-                <input type="text" class="form-control" id="gam_company_id"
-                       value="${gamMapping.company_id || gamMapping.advertiser_id || ''}"
-                       placeholder="e.g., 1234567890">
-                <small class="form-text text-muted">The GAM company/advertiser ID this principal should use</small>
+                <label for="gam_company_id" class="form-label">GAM Advertiser <span style="color: red;">*</span></label>
+                <select class="form-control" id="gam_company_id">
+                    <option value="">Loading advertisers...</option>
+                </select>
+                <small class="form-text text-muted">Select which advertiser company this represents in Google Ad Manager</small>
+                <div id="edit-advertiser-loading-error" style="display: none; color: red; margin-top: 0.5rem;"></div>
             </div>
 
             <div class="mb-3">
@@ -1883,12 +1884,17 @@ function renderPrincipalEditor(principal) {
             </div>
 
             <h5 class="mt-4 mb-3">Mock Adapter (Testing)</h5>
+            <div class="alert alert-warning">
+                <strong>⚠️ About Mock vs GAM:</strong> The Mock adapter simulates ad server behavior for testing without making real API calls.
+                You can enable both Mock (for testing) and GAM (for production) on the same advertiser. When both are enabled,
+                the system will use whichever adapter is configured in your products.
+            </div>
             <div class="mb-3">
                 <label for="mock_advertiser_id" class="form-label">Mock Advertiser ID</label>
                 <input type="text" class="form-control" id="mock_advertiser_id"
                        value="${mockMapping.advertiser_id || ''}"
                        placeholder="e.g., mock_123">
-                <small class="form-text text-muted">ID for testing with mock adapter</small>
+                <small class="form-text text-muted">ID for testing with mock adapter (used when products are configured for mock adapter)</small>
             </div>
 
             <div class="mb-3 form-check">
@@ -1896,14 +1902,94 @@ function renderPrincipalEditor(principal) {
                        ${mockMapping.enabled !== false ? 'checked' : ''}>
                 <label class="form-check-label" for="mock_enabled">Enable Mock for this advertiser</label>
             </div>
-
-            <div class="alert alert-info mt-4">
-                <strong>💡 Tip:</strong> To find GAM Company IDs, check other working advertisers or use the GAM UI (Admin → Companies).
-            </div>
         </form>
     `;
 
     document.getElementById('editPrincipalForm').innerHTML = html;
+
+    // Load GAM advertisers into dropdown
+    loadGAMAdvertisersForEdit(gamMapping.company_id || gamMapping.advertiser_id || '');
+}
+
+function loadGAMAdvertisersForEdit(currentAdvertiserId) {
+    const selectElement = document.getElementById('gam_company_id');
+    const errorDiv = document.getElementById('edit-advertiser-loading-error');
+
+    if (!selectElement) {
+        return; // Element not found, probably not a GAM tenant
+    }
+
+    // Show loading state
+    selectElement.innerHTML = '<option value="">Loading advertisers...</option>';
+    selectElement.disabled = true;
+    errorDiv.style.display = 'none';
+
+    // Fetch advertisers from API (same endpoint as create form)
+    fetch('{{ script_name }}/tenant/{{ tenant.tenant_id }}/api/gam/get-advertisers', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            tenant_id: '{{ tenant.tenant_id }}'
+        }),
+        credentials: 'same-origin'
+    })
+    .then(response => {
+        if (!response.ok) {
+            return response.text().then(text => {
+                throw new Error(`HTTP ${response.status}: ${text.substring(0, 200)}`);
+            });
+        }
+        return response.json();
+    })
+    .then(data => {
+        if (data.error) {
+            throw new Error(data.error);
+        }
+
+        // Clear loading state
+        selectElement.innerHTML = '';
+        selectElement.disabled = false;
+
+        // Add default option
+        const defaultOption = document.createElement('option');
+        defaultOption.value = '';
+        defaultOption.textContent = 'Select an advertiser...';
+        selectElement.appendChild(defaultOption);
+
+        // Add advertiser options
+        if (data.advertisers && data.advertisers.length > 0) {
+            data.advertisers.forEach(advertiser => {
+                const option = document.createElement('option');
+                option.value = advertiser.id;
+                option.textContent = advertiser.name;
+                selectElement.appendChild(option);
+            });
+
+            // Restore current selection if provided
+            if (currentAdvertiserId) {
+                selectElement.value = currentAdvertiserId;
+            }
+        } else {
+            // No advertisers found
+            const noAdvertisersOption = document.createElement('option');
+            noAdvertisersOption.value = '';
+            noAdvertisersOption.textContent = 'No advertisers found in GAM';
+            noAdvertisersOption.disabled = true;
+            selectElement.appendChild(noAdvertisersOption);
+
+            errorDiv.textContent = 'No advertisers found. Please create an advertiser in Google Ad Manager first.';
+            errorDiv.style.display = 'block';
+        }
+    })
+    .catch(error => {
+        console.error('Error loading advertisers for edit:', error);
+        selectElement.innerHTML = '<option value="">Failed to load advertisers</option>';
+        selectElement.disabled = false;
+        errorDiv.textContent = 'Error loading advertisers: ' + error.message;
+        errorDiv.style.display = 'block';
+    });
 }
 
 function savePrincipalMappings() {

--- a/templates/tenant_settings.html
+++ b/templates/tenant_settings.html
@@ -1852,14 +1852,17 @@ function renderPrincipalEditor(principal) {
     const mappings = principal.platform_mappings || {};
     const gamMapping = mappings.google_ad_manager || {};
     const mockMapping = mappings.mock || {};
+    const activeAdapter = '{{ active_adapter }}';
 
-    const html = `
-        <form id="mappingsForm">
-            <div class="mb-3">
-                <label class="form-label"><strong>Principal ID:</strong> <code>${principal.principal_id}</code></label>
+    let adapterSection = '';
+
+    if (activeAdapter === 'google_ad_manager') {
+        // GAM tenant - only show GAM fields
+        adapterSection = `
+            <h5 class="mt-4 mb-3">Google Ad Manager Configuration</h5>
+            <div class="alert alert-info">
+                <strong>ℹ️ Note:</strong> This tenant uses Google Ad Manager. All campaigns will be executed through GAM.
             </div>
-
-            <h5 class="mt-4 mb-3">Google Ad Manager</h5>
             <div class="mb-3">
                 <label for="gam_company_id" class="form-label">GAM Advertiser <span style="color: red;">*</span></label>
                 <select class="form-control" id="gam_company_id">
@@ -1870,7 +1873,7 @@ function renderPrincipalEditor(principal) {
             </div>
 
             <div class="mb-3">
-                <label for="gam_trafficker_id" class="form-label">Trafficker ID</label>
+                <label for="gam_trafficker_id" class="form-label">Trafficker ID (Optional)</label>
                 <input type="text" class="form-control" id="gam_trafficker_id"
                        value="${gamMapping.trafficker_id || ''}"
                        placeholder="e.g., 9876543210">
@@ -1881,34 +1884,46 @@ function renderPrincipalEditor(principal) {
                 <input type="checkbox" class="form-check-input" id="gam_enabled"
                        ${gamMapping.enabled !== false ? 'checked' : ''}>
                 <label class="form-check-label" for="gam_enabled">Enable GAM for this advertiser</label>
-            </div>
-
-            <h5 class="mt-4 mb-3">Mock Adapter (Testing)</h5>
-            <div class="alert alert-warning">
-                <strong>⚠️ About Mock vs GAM:</strong> The Mock adapter simulates ad server behavior for testing without making real API calls.
-                You can enable both Mock (for testing) and GAM (for production) on the same advertiser. When both are enabled,
-                the system will use whichever adapter is configured in your products.
+            </div>`;
+    } else {
+        // Mock tenant - only show mock fields
+        adapterSection = `
+            <h5 class="mt-4 mb-3">Mock Adapter Configuration</h5>
+            <div class="alert alert-info">
+                <strong>ℹ️ Note:</strong> This tenant uses the Mock adapter for testing. No real ad server API calls will be made.
+                <br><strong>To use a real ad server</strong>, configure GAM or another adapter in the Ad Server settings tab.
             </div>
             <div class="mb-3">
                 <label for="mock_advertiser_id" class="form-label">Mock Advertiser ID</label>
                 <input type="text" class="form-control" id="mock_advertiser_id"
-                       value="${mockMapping.advertiser_id || ''}"
-                       placeholder="e.g., mock_123">
-                <small class="form-text text-muted">ID for testing with mock adapter (used when products are configured for mock adapter)</small>
+                       value="${mockMapping.advertiser_id || principal.principal_id}"
+                       placeholder="e.g., mock_${principal.principal_id}">
+                <small class="form-text text-muted">Mock ID for testing (auto-populated with principal ID)</small>
             </div>
 
             <div class="mb-3 form-check">
                 <input type="checkbox" class="form-check-input" id="mock_enabled"
                        ${mockMapping.enabled !== false ? 'checked' : ''}>
                 <label class="form-check-label" for="mock_enabled">Enable Mock for this advertiser</label>
+            </div>`;
+    }
+
+    const html = `
+        <form id="mappingsForm">
+            <div class="mb-3">
+                <label class="form-label"><strong>Principal ID:</strong> <code>${principal.principal_id}</code></label>
             </div>
+
+            ${adapterSection}
         </form>
     `;
 
     document.getElementById('editPrincipalForm').innerHTML = html;
 
-    // Load GAM advertisers into dropdown
-    loadGAMAdvertisersForEdit(gamMapping.company_id || gamMapping.advertiser_id || '');
+    // Load GAM advertisers if this is a GAM tenant
+    if (activeAdapter === 'google_ad_manager') {
+        loadGAMAdvertisersForEdit(gamMapping.company_id || gamMapping.advertiser_id || '');
+    }
 }
 
 function loadGAMAdvertisersForEdit(currentAdvertiserId) {


### PR DESCRIPTION
## Summary
Improves the advertiser configuration UX to prevent confusion between Mock and GAM adapters, and prevents accidental writes to production GAM from what users might think are "test" principals.

## Changes

### 1. GAM Advertiser Dropdown in Edit Modal
- Added dropdown selection for GAM advertisers in the edit modal (matching the create form)
- Dropdown loads from the same `/api/gam/get-advertisers` endpoint
- Automatically restores current selection when editing

### 2. Tenant-Specific Adapter Display
- Edit and create forms now show only the adapter fields relevant to the tenant's configuration
- **GAM tenants**: Only see GAM advertiser dropdown and settings
- **Mock tenants**: Only see Mock adapter fields
- Eliminates the confusing option to enable both Mock and GAM on the same principal

### 3. Clear Safety Messaging
- Added prominent info boxes explaining which adapter the tenant uses
- **GAM tenants**: Clear warning that "All campaigns will be executed through GAM and will write to your GAM network"
- **Mock tenants**: Clear indication that "No real ad server API calls will be made"
- Guidance on how to switch from Mock to a real adapter via Settings

## Why This Matters

### Before
- Users could enable both Mock and GAM on the same principal
- Unclear whether operations would hit production or be simulated
- Risk of accidentally writing test campaigns to production GAM

### After
- Adapters are clearly configured at the **tenant level**, not per-principal
- Each principal inherits the tenant's adapter configuration
- No mixing: Mock tenants = testing only, GAM tenants = production only
- Clear visual indicators prevent accidental production writes

## Architecture Clarification

- **Mock Tenants**: Use mock adapter → all principals are mock (testing only)
- **GAM Tenants**: Use GAM adapter → all principals map to GAM advertisers (production)
- **No mixing**: Principals can't have both Mock and GAM configurations

## Test Plan
- [x] Verify GAM tenant shows only GAM fields in edit modal
- [x] Verify Mock tenant shows only Mock fields in edit modal
- [x] Verify GAM advertiser dropdown loads and populates correctly
- [x] Verify create form shows appropriate adapter fields based on tenant
- [x] Verify info messages display correctly for both tenant types

🤖 Generated with [Claude Code](https://claude.com/claude-code)