### PR TITLE
Remove unnecessary 'Enable' checkboxes from advertiser edit modal

### DIFF
--- a/templates/tenant_settings.html
+++ b/templates/tenant_settings.html
@@ -2003,8 +2003,11 @@ function savePrincipalMappings() {
 
     if (activeAdapter === 'google_ad_manager') {
         // GAM tenant - save GAM fields
-        const gamCompanyId = document.getElementById('gam_company_id')?.value.trim();
-        const gamTraffickerId = document.getElementById('gam_trafficker_id')?.value.trim();
+        const gamCompanyIdEl = document.getElementById('gam_company_id');
+        const gamTraffickerIdEl = document.getElementById('gam_trafficker_id');
+
+        const gamCompanyId = gamCompanyIdEl ? gamCompanyIdEl.value.trim() : '';
+        const gamTraffickerId = gamTraffickerIdEl ? gamTraffickerIdEl.value.trim() : '';
 
         if (gamCompanyId || gamTraffickerId) {
             platformMappings.google_ad_manager = {
@@ -2020,7 +2023,8 @@ function savePrincipalMappings() {
         }
     } else {
         // Mock tenant - save mock fields
-        const mockAdvertiserId = document.getElementById('mock_advertiser_id')?.value.trim();
+        const mockAdvertiserIdEl = document.getElementById('mock_advertiser_id');
+        const mockAdvertiserId = mockAdvertiserIdEl ? mockAdvertiserIdEl.value.trim() : '';
 
         if (mockAdvertiserId) {
             platformMappings.mock = {

--- a/templates/tenant_settings.html
+++ b/templates/tenant_settings.html
@@ -1878,12 +1878,6 @@ function renderPrincipalEditor(principal) {
                        value="${gamMapping.trafficker_id || ''}"
                        placeholder="e.g., 9876543210">
                 <small class="form-text text-muted">The GAM user ID for trafficking operations</small>
-            </div>
-
-            <div class="mb-3 form-check">
-                <input type="checkbox" class="form-check-input" id="gam_enabled"
-                       ${gamMapping.enabled !== false ? 'checked' : ''}>
-                <label class="form-check-label" for="gam_enabled">Enable GAM for this advertiser</label>
             </div>`;
     } else {
         // Mock tenant - only show mock fields
@@ -1899,12 +1893,6 @@ function renderPrincipalEditor(principal) {
                        value="${mockMapping.advertiser_id || principal.principal_id}"
                        placeholder="e.g., mock_${principal.principal_id}">
                 <small class="form-text text-muted">Mock ID for testing (auto-populated with principal ID)</small>
-            </div>
-
-            <div class="mb-3 form-check">
-                <input type="checkbox" class="form-check-input" id="mock_enabled"
-                       ${mockMapping.enabled !== false ? 'checked' : ''}>
-                <label class="form-check-label" for="mock_enabled">Enable Mock for this advertiser</label>
             </div>`;
     }
 
@@ -2008,35 +1996,38 @@ function loadGAMAdvertisersForEdit(currentAdvertiserId) {
 }
 
 function savePrincipalMappings() {
-    const gamCompanyId = document.getElementById('gam_company_id').value.trim();
-    const gamTraffickerId = document.getElementById('gam_trafficker_id').value.trim();
-    const gamEnabled = document.getElementById('gam_enabled').checked;
-    const mockAdvertiserId = document.getElementById('mock_advertiser_id').value.trim();
-    const mockEnabled = document.getElementById('mock_enabled').checked;
+    const activeAdapter = '{{ active_adapter }}';
 
     // Build platform mappings object
     const platformMappings = {};
 
-    // Add GAM if enabled or has values
-    if (gamEnabled || gamCompanyId || gamTraffickerId) {
-        platformMappings.google_ad_manager = {
-            enabled: gamEnabled
-        };
-        if (gamCompanyId) {
-            platformMappings.google_ad_manager.advertiser_id = gamCompanyId;
-            platformMappings.google_ad_manager.company_id = gamCompanyId; // Both for compatibility
-        }
-        if (gamTraffickerId) {
-            platformMappings.google_ad_manager.trafficker_id = gamTraffickerId;
-        }
-    }
+    if (activeAdapter === 'google_ad_manager') {
+        // GAM tenant - save GAM fields
+        const gamCompanyId = document.getElementById('gam_company_id')?.value.trim();
+        const gamTraffickerId = document.getElementById('gam_trafficker_id')?.value.trim();
 
-    // Add mock if enabled or has values
-    if (mockEnabled || mockAdvertiserId) {
-        platformMappings.mock = {
-            enabled: mockEnabled,
-            advertiser_id: mockAdvertiserId || 'default'
-        };
+        if (gamCompanyId || gamTraffickerId) {
+            platformMappings.google_ad_manager = {
+                enabled: true  // Always enabled for GAM tenants
+            };
+            if (gamCompanyId) {
+                platformMappings.google_ad_manager.advertiser_id = gamCompanyId;
+                platformMappings.google_ad_manager.company_id = gamCompanyId; // Both for compatibility
+            }
+            if (gamTraffickerId) {
+                platformMappings.google_ad_manager.trafficker_id = gamTraffickerId;
+            }
+        }
+    } else {
+        // Mock tenant - save mock fields
+        const mockAdvertiserId = document.getElementById('mock_advertiser_id')?.value.trim();
+
+        if (mockAdvertiserId) {
+            platformMappings.mock = {
+                enabled: true,  // Always enabled for mock tenants
+                advertiser_id: mockAdvertiserId
+            };
+        }
     }
 
     // Show saving state


### PR DESCRIPTION
## Summary
Removes confusing and unnecessary "Enable GAM/Mock for this advertiser" checkboxes from the advertiser edit modal.

## Changes
- Removed "Enable GAM for this advertiser" checkbox
- Removed "Enable Mock for this advertiser" checkbox  
- Updated `savePrincipalMappings()` to always set `enabled=true`
- Simplified the form - if you're editing an advertiser, it's enabled

## Rationale

The "enable" checkboxes were confusing and served no purpose:

1. **Adapters are tenant-level**: Since adapters are configured at the tenant level (not per-advertiser), there's no concept of selectively enabling/disabling an adapter for specific advertisers
2. **No use case for "disabled" advertisers**: If an advertiser exists and has configuration, they should be active. To deactivate, delete them.
3. **Reduces confusion**: One less thing to explain or get wrong

## Before/After

### Before
```
GAM Advertiser: [Dropdown]
Trafficker ID: [Input]
☑️ Enable GAM for this advertiser  ← Confusing!
```

### After
```
GAM Advertiser: [Dropdown]
Trafficker ID: [Input]
```

Much cleaner and clearer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)