### PR TITLE
Add creative_ids support to create_media_buy packages

### DIFF
--- a/src/core/schemas.py
+++ b/src/core/schemas.py
@@ -1779,6 +1779,7 @@ class Package(BaseModel):
     budget: Budget | None = Field(None, description="Package-specific budget")
     impressions: float | None = Field(None, description="Impression goal for this package", gt=-1)
     targeting_overlay: Targeting | None = Field(None, description="Package-specific targeting")
+    creative_ids: list[str] | None = Field(None, description="Creative IDs to assign to this package")
     creative_assignments: list[dict[str, Any]] | None = Field(
         None, description="Creative assets assigned to this package"
     )

--- a/tests/e2e/schemas/v1/_schemas_v1_media-buy_create-media-buy-request_json.json
+++ b/tests/e2e/schemas/v1/_schemas_v1_media-buy_create-media-buy-request_json.json
@@ -45,6 +45,13 @@
           },
           "targeting_overlay": {
             "$ref": "/schemas/v1/core/targeting.json"
+          },
+          "creative_ids": {
+            "type": "array",
+            "description": "Creative IDs to assign to this package at creation time",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "anyOf": [


### PR DESCRIPTION
## Summary
Implements [AdCP PR #87](https://github.com/adcontextprotocol/adcp/pull/87) to allow buyers to assign creative IDs to packages at media buy creation time, enabling a more streamlined workflow.

## Changes
- **Add `creative_ids` field to Package schema** - Optional array field for backward compatibility
- **Process `creative_ids` in create_media_buy** - Validates creatives exist and creates assignments
- **Update response building** - Includes `creative_ids` in package response when provided
- **Comprehensive integration test** - Validates full workflow from sync to assignment
- **Update AdCP schema cache** - Synced with latest create-media-buy-request schema

## Benefits
- ✅ Creatives can be specified upfront during media buy creation
- ✅ Eliminates need for separate `update_media_buy` call to assign creatives
- ✅ Maintains consistency with existing `update_media_buy` creative_ids support
- ✅ Fully backward compatible (field is optional)

## Test Plan
- [x] New integration test: `test_create_media_buy_with_creative_ids`
- [x] All creative lifecycle tests pass (17/17)
- [x] All unit tests pass (422/422)
- [x] Pre-commit hooks pass (AdCP compliance, schema sync)

## Example Usage
```python
from src.core.schemas import Package, Budget

# Create packages with creative_ids
packages = [
    Package(
        buyer_ref="pkg_1",
        products=["prod_1"],
        creative_ids=["creative_123", "creative_456"]  # NEW
    )
]

# Create media buy with creatives assigned upfront
response = await client.tools.create_media_buy(
    promoted_offering="Spring Campaign",
    packages=packages,
    start_time="2025-03-01T00:00:00Z",
    end_time="2025-03-31T23:59:59Z",
    budget=Budget(total=5000.0, currency="USD")
)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)