### PR TITLE
Fix landing page redirect and cross-domain OAuth for virtual hosts

### DIFF
--- a/src/admin/blueprints/auth.py
+++ b/src/admin/blueprints/auth.py
@@ -181,8 +181,21 @@ def google_auth():
     if tenant_context:
         session["oauth_tenant_context"] = tenant_context
 
-    # Let Authlib manage the state parameter for CSRF protection
-    return oauth.google.authorize_redirect(redirect_uri)
+    # Build custom state parameter to handle cross-domain scenarios
+    # For cross-domain OAuth (virtual hosts), session cookies won't work
+    import base64
+
+    state_data = {
+        "signup_flow": session.get("signup_flow", False),
+        "external_domain": approximated_host
+        or (host if host != "sales-agent.scope3.com" and not host.startswith("admin.") else None),
+        "tenant_context": tenant_context,
+    }
+    state_json = json.dumps(state_data)
+    state_encoded = base64.urlsafe_b64encode(state_json.encode()).decode()
+
+    # Let Authlib manage the state parameter for CSRF protection, but pass our custom data
+    return oauth.google.authorize_redirect(redirect_uri, state=state_encoded)
 
 
 @auth_bp.route("/tenant/<tenant_id>/auth/google")
@@ -254,19 +267,35 @@ def google_callback():
         session["user_name"] = user.get("name", email)
         session["user_picture"] = user.get("picture", "")
 
-        # Check if this is a signup flow
-        if session.get("signup_flow"):
+        # Try to decode state parameter for cross-domain OAuth context
+        import base64
+
+        state_param = request.args.get("state")
+        state_data = {}
+        if state_param:
+            try:
+                state_json = base64.urlsafe_b64decode(state_param.encode()).decode()
+                state_data = json.loads(state_json)
+                logger.info(f"OAuth callback - decoded state: {state_data}")
+            except Exception as e:
+                logger.warning(f"Could not decode OAuth state parameter: {e}")
+
+        # Check if this is a signup flow (from state or session)
+        is_signup_flow = state_data.get("signup_flow") or session.get("signup_flow")
+        if is_signup_flow:
             logger.info(f"OAuth callback - signup flow detected for {email}")
+            # Set signup flow in session for onboarding
+            session["signup_flow"] = True
             # Redirect to onboarding wizard
             return redirect(url_for("public.signup_onboarding"))
 
         # Debug session state before popping values
         logger.info(f"OAuth callback - full session: {dict(session)}")
 
-        # Get originating host and tenant context from session
+        # Get originating host and tenant context from state parameter (preferred) or session (fallback)
         originating_host = session.pop("oauth_originating_host", None)
-        external_domain = session.pop("oauth_external_domain", None)
-        tenant_id = session.pop("oauth_tenant_context", None)
+        external_domain = state_data.get("external_domain") or session.pop("oauth_external_domain", None)
+        tenant_id = state_data.get("tenant_context") or session.pop("oauth_tenant_context", None)
 
         # Debug logging for OAuth redirect
         logger.info(f"OAuth callback debug - originating_host: {originating_host}")

--- a/src/admin/blueprints/core.py
+++ b/src/admin/blueprints/core.py
@@ -58,8 +58,13 @@ def index():
         # Check if we're on a tenant-specific subdomain (not main domain)
         tenant = get_tenant_from_hostname()
         if tenant:
-            # Tenant subdomain - go to login (no signup on tenant domains)
-            return redirect(url_for("auth.login"))
+            # Tenant subdomain - show landing page if it's a virtual host, otherwise login
+            # Virtual hosts (like test-agent.adcontextprotocol.org) should show landing
+            if tenant.virtual_host:
+                return render_template("landing.html")
+            else:
+                # Regular subdomain routing - go to login
+                return redirect(url_for("auth.login"))
 
         # Main domain (sales-agent.scope3.com) - show signup landing
         return redirect(url_for("public.landing"))


### PR DESCRIPTION
## Summary
Fixes two issues with virtual host handling:
1. Landing page now displays instead of redirecting to admin login
2. OAuth authentication works across different domains

## Changes
### Landing Page Routing (`src/admin/blueprints/core.py`)
- Check if tenant has `virtual_host` configured
- Display landing page for virtual hosts, redirect to login for subdomain-based tenants

### Cross-Domain OAuth (`src/admin/blueprints/auth.py`)
- Encode signup flow context in OAuth state parameter
- State parameter carries: `signup_flow`, `external_domain`, `tenant_context`
- OAuth callback decodes state parameter for cross-domain scenarios

## Problem
Session cookies don't work across domains (e.g., `test-agent.adcontextprotocol.org` → `sales-agent.scope3.com`), causing OAuth authentication failures.

## Solution
Use OAuth state parameter instead of session cookies for cross-domain context.

## Testing
1. Visit `http://test-agent.adcontextprotocol.org`
2. Should show landing page (not redirect)
3. Click "Get Started with Google"
4. OAuth flow should complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)