### PR TITLE
Fix external domain landing page and OAuth signup flow

### DIFF
--- a/src/admin/blueprints/auth.py
+++ b/src/admin/blueprints/auth.py
@@ -378,7 +378,15 @@ def google_callback():
         tenant_access = get_user_tenant_access(email)
 
         if tenant_access["total_access"] == 0:
-            # No access
+            # No access - check if this was from an external domain (should trigger signup)
+            if external_domain and not external_domain.endswith(".sales-agent.scope3.com"):
+                logger.info(
+                    f"User {email} has no access but came from external domain {external_domain}, redirecting to signup"
+                )
+                session["signup_flow"] = True
+                return redirect(url_for("public.signup_onboarding"))
+
+            # Regular flow - no access
             flash("You don't have access to any tenants. Please contact your administrator.", "error")
             session.clear()
             return redirect(url_for("auth.login"))

--- a/src/admin/blueprints/core.py
+++ b/src/admin/blueprints/core.py
@@ -55,16 +55,17 @@ def index():
         if (approximated_host and approximated_host.startswith("admin.")) or host.startswith("admin."):
             return redirect(url_for("auth.login"))
 
-        # Check if we're on a tenant-specific subdomain (not main domain)
+        # Check if we're on an external virtual host (via Approximated)
+        # External domains should always show landing page for signup
+        if approximated_host and not approximated_host.endswith(".sales-agent.scope3.com"):
+            logger.info(f"External domain detected: {approximated_host}, showing landing page")
+            return render_template("landing.html")
+
+        # Check if we're on a tenant-specific subdomain (*.sales-agent.scope3.com)
         tenant = get_tenant_from_hostname()
         if tenant:
-            # Tenant subdomain - show landing page if it's a virtual host, otherwise login
-            # Virtual hosts (like test-agent.adcontextprotocol.org) should show landing
-            if tenant.virtual_host:
-                return render_template("landing.html")
-            else:
-                # Regular subdomain routing - go to login
-                return redirect(url_for("auth.login"))
+            # Subdomain tenants redirect to login
+            return redirect(url_for("auth.login"))
 
         # Main domain (sales-agent.scope3.com) - show signup landing
         return redirect(url_for("public.landing"))

--- a/tests/e2e/schemas/v1/_schemas_v1_media-buy_create-media-buy-request_json.json
+++ b/tests/e2e/schemas/v1/_schemas_v1_media-buy_create-media-buy-request_json.json
@@ -19,58 +19,7 @@
       "type": "array",
       "description": "Array of package configurations",
       "items": {
-        "type": "object",
-        "properties": {
-          "buyer_ref": {
-            "type": "string",
-            "description": "Buyer's reference identifier for this package"
-          },
-          "products": {
-            "type": "array",
-            "description": "Array of product IDs to include in this package",
-            "items": {
-              "type": "string"
-            }
-          },
-          "format_ids": {
-            "type": "array",
-            "description": "Array of format IDs that will be used for this package - must be supported by all products",
-            "items": {
-              "type": "string",
-              "description": "Format ID referencing a format from list_creative_formats"
-            }
-          },
-          "budget": {
-            "$ref": "/schemas/v1/core/budget.json"
-          },
-          "targeting_overlay": {
-            "$ref": "/schemas/v1/core/targeting.json"
-          },
-          "creative_ids": {
-            "type": "array",
-            "description": "Creative IDs to assign to this package at creation time",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "anyOf": [
-          {
-            "required": [
-              "buyer_ref",
-              "products",
-              "format_ids"
-            ]
-          },
-          {
-            "required": [
-              "buyer_ref",
-              "products",
-              "format_selection"
-            ]
-          }
-        ],
-        "additionalProperties": false
+        "$ref": "/schemas/v1/media-buy/package-request.json"
       }
     },
     "promoted_offering": {


### PR DESCRIPTION
## Summary
Fixes landing page display and OAuth signup for external domains like `test-agent.adcontextprotocol.org`.

## Changes

### 1. Simplified Landing Page Logic (`src/admin/blueprints/core.py`)
- Any external domain (not `*.sales-agent.scope3.com`) now shows the landing page
- Check `Apx-Incoming-Host` header to detect external domains
- No longer requires `tenant.virtual_host` database field to be set
- Works seamlessly with any custom domain routed through Approximated

### 2. Fix OAuth for New Users (`src/admin/blueprints/auth.py`)
- Users from external domains with no tenant access are treated as signups
- Detect `external_domain` in OAuth callback
- Redirect to signup onboarding instead of showing "no access" error
- Enables true self-service signup from custom domains

### 3. Schema Updates
- Synced `create-media-buy-request` schema with latest from AdCP registry

## Problem
1. `https://test-agent.adcontextprotocol.org` was redirecting to admin login instead of showing landing page
2. OAuth was failing with "no access" error for new users trying to sign up
3. Required database configuration (`virtual_host`) that wasn't set

## Solution
- Detect external domains purely from HTTP headers (no database lookup needed)
- Treat OAuth from external domains as signup flow when user has no existing access

## Testing
1. Visit `https://test-agent.adcontextprotocol.org`
   - ✅ Should show landing page with "Get Started with Google" button
2. Click "Get Started with Google"
   - ✅ Should complete OAuth successfully
   - ✅ Should redirect to signup onboarding wizard
3. Complete onboarding to create new tenant
   - ✅ Should provision tenant and redirect to dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)