### PR TITLE
Fix list_creative_formats A2A handler dict/object response handling

### DIFF
--- a/tests/e2e/schemas/v1/_schemas_v1_media-buy_create-media-buy-request_json.json
+++ b/tests/e2e/schemas/v1/_schemas_v1_media-buy_create-media-buy-request_json.json
@@ -19,58 +19,7 @@
       "type": "array",
       "description": "Array of package configurations",
       "items": {
-        "type": "object",
-        "properties": {
-          "buyer_ref": {
-            "type": "string",
-            "description": "Buyer's reference identifier for this package"
-          },
-          "products": {
-            "type": "array",
-            "description": "Array of product IDs to include in this package",
-            "items": {
-              "type": "string"
-            }
-          },
-          "format_ids": {
-            "type": "array",
-            "description": "Array of format IDs that will be used for this package - must be supported by all products",
-            "items": {
-              "type": "string",
-              "description": "Format ID referencing a format from list_creative_formats"
-            }
-          },
-          "budget": {
-            "$ref": "/schemas/v1/core/budget.json"
-          },
-          "targeting_overlay": {
-            "$ref": "/schemas/v1/core/targeting.json"
-          },
-          "creative_ids": {
-            "type": "array",
-            "description": "Creative IDs to assign to this package at creation time",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "anyOf": [
-          {
-            "required": [
-              "buyer_ref",
-              "products",
-              "format_ids"
-            ]
-          },
-          {
-            "required": [
-              "buyer_ref",
-              "products",
-              "format_selection"
-            ]
-          }
-        ],
-        "additionalProperties": false
+        "$ref": "/schemas/v1/media-buy/package-request.json"
       }
     },
     "promoted_offering": {


### PR DESCRIPTION
## Summary

Fixes the `list_creative_formats` A2A skill handler to properly handle both dict and object response types from the shared implementation.

## Root Cause

The `_list_creative_formats_impl()` function returns different types based on the `INCLUDE_SCHEMAS_IN_RESPONSES` configuration:
- **When enabled**: Returns enhanced dict (main.py:1138)
- **When disabled**: Returns `ListCreativeFormatsResponse` object (main.py:1140)

The A2A handler (`_handle_list_creative_formats_skill`) assumed the response was always an object with a `.formats` attribute, causing:
```
'dict' object has no attribute 'formats'
```

## Solution

Updated `_handle_list_creative_formats_skill()` to:
1. Check response type with `isinstance(response, dict)`
2. Handle dict responses (formats already serialized)
3. Handle object responses (serialize Format objects to dicts)
4. Both paths produce identical A2A response format

## Testing

✅ Existing AdCP contract tests pass  
✅ Unit tests for `list_creative_formats` pass  
✅ No behavioral changes for clients  
✅ Pre-commit hooks pass

## Technical Details

This fix follows the established pattern where shared implementations may return different types based on configuration flags. The A2A server now handles both cases gracefully without duplicating business logic.

## Additional Changes

- Updated AdCP schema: `create-media-buy-request.json` (routine sync with registry)

## Related

- AdCP v2.4 protocol compliance
- Shared implementation pattern (MCP/A2A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>