### PR TITLE
Fix nginx routing for external domains to show landing page

### DIFF
--- a/fly/nginx.conf
+++ b/fly/nginx.conf
@@ -300,20 +300,124 @@ http {
         }
     }
 
-    # Default fallback server for any other domains
+    # Default fallback server for external domains (via Approximated)
     server {
         listen 8000 default_server;
         server_name _;
 
-        # Redirect to main domain
-        location / {
-            return 301 https://sales-agent.scope3.com$request_uri;
+        # MCP endpoint
+        location /mcp {
+            proxy_pass http://localhost:8080;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Apx-Incoming-Host $host;
+            proxy_set_header x-adcp-auth $http_x_adcp_auth;
+            proxy_cache_bypass $http_upgrade;
+        }
+
+        # A2A agent discovery endpoints
+        location /.well-known/ {
+            proxy_pass http://localhost:8091/.well-known/;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Apx-Incoming-Host $host;
+        }
+
+        # A2A agent card endpoint
+        location /agent.json {
+            proxy_pass http://localhost:8091/agent.json;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Apx-Incoming-Host $host;
+        }
+
+        # A2A endpoint
+        location /a2a {
+            proxy_pass http://localhost:8091;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Apx-Incoming-Host $host;
+            proxy_cache_bypass $http_upgrade;
+        }
+
+        # Admin UI endpoint
+        location /admin {
+            proxy_pass http://localhost:8001/admin;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Apx-Incoming-Host $host;
+            proxy_set_header X-Forwarded-Prefix /admin;
+            proxy_cache_bypass $http_upgrade;
+        }
+
+        # Auth routes (OAuth callbacks, etc)
+        location /auth {
+            proxy_pass http://localhost:8001/auth;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Apx-Incoming-Host $host;
+        }
+
+        # Signup routes
+        location /signup {
+            proxy_pass http://localhost:8001/signup;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Apx-Incoming-Host $host;
+        }
+
+        # Static assets
+        location /static {
+            proxy_pass http://localhost:8001/static;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Root serves landing page via admin UI
+        location = / {
+            proxy_pass http://localhost:8001/;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Apx-Incoming-Host $host;
         }
 
         # Health check
         location /health {
             access_log off;
-            return 200 "fallback healthy\n";
+            return 200 "external-domain healthy\n";
             add_header Content-Type text/plain;
         }
     }


### PR DESCRIPTION
## Problem
External domains like `test-agent.adcontextprotocol.org` were hitting the default nginx server which redirected ALL requests to `sales-agent.scope3.com`, completely bypassing the admin UI landing page logic.

## Root Cause
The nginx default server block was configured to redirect unknown domains:
```nginx
location / {
    return 301 https://sales-agent.scope3.com$request_uri;
}
```

This meant any external domain would be redirected before the Python application could handle the request.

## Solution
Updated the default server block to properly route external domains through Approximated:
- ✅ Route root `/` to admin UI (port 8001) to show landing page
- ✅ Add `Apx-Incoming-Host` header to all proxied requests
- ✅ Support all required endpoints: `/mcp`, `/a2a`, `/admin`, `/auth`, `/signup`
- ✅ Enable external domains to use full application functionality

## Testing
1. Visit `https://test-agent.adcontextprotocol.org`
   - ✅ Should show landing page (not redirect to sales-agent.scope3.com)
2. Click "Get Started with Google"
   - ✅ OAuth flow should work
3. Complete signup
   - ✅ Should provision tenant successfully

## Technical Details
- External domains now properly proxy to admin UI instead of redirecting
- `Apx-Incoming-Host` header enables Python code to detect external domains
- Landing page template can render correctly from admin UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)