### PR TITLE
Fix nginx routing in correct config file (config/nginx/nginx.conf)

### DIFF
--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -450,20 +450,135 @@ http {
         }
     }
 
-    # Default fallback server for any other domains
+    # Default fallback server for external domains (via Approximated)
     server {
         listen 0.0.0.0:8000 default_server;
         server_name _;
 
-        # Redirect to main domain
-        location / {
-            return 301 https://sales-agent.scope3.com$request_uri;
+        # MCP endpoint
+        location /mcp {
+            proxy_pass http://localhost:8080;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Apx-Incoming-Host $host;
+            proxy_set_header x-adcp-auth $http_x_adcp_auth;
+            proxy_cache_bypass $http_upgrade;
+        }
+
+        # A2A agent discovery endpoints
+        location /.well-known/ {
+            proxy_pass http://localhost:8091/.well-known/;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Apx-Incoming-Host $host;
+        }
+
+        # A2A agent card endpoint
+        location /agent.json {
+            proxy_pass http://localhost:8091/agent.json;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Apx-Incoming-Host $host;
+        }
+
+        # A2A endpoint
+        location /a2a {
+            proxy_pass http://localhost:8091;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Apx-Incoming-Host $host;
+            proxy_cache_bypass $http_upgrade;
+        }
+
+        # Admin UI endpoint
+        location /admin {
+            proxy_pass http://localhost:8001/admin;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Apx-Incoming-Host $host;
+            proxy_set_header X-Forwarded-Prefix /admin;
+            proxy_cache_bypass $http_upgrade;
+        }
+
+        # Auth routes (OAuth callbacks, etc)
+        location /auth {
+            proxy_pass http://localhost:8001/auth;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Apx-Incoming-Host $host;
+        }
+
+        # Signup routes
+        location /signup {
+            proxy_pass http://localhost:8001/signup;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Apx-Incoming-Host $host;
+        }
+
+        # Static assets
+        location /static {
+            proxy_pass http://localhost:8001/static;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Debug endpoint
+        location /debug {
+            proxy_pass http://localhost:8001/debug;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Apx-Incoming-Host $host;
+        }
+
+        # Root serves landing page via admin UI
+        location = / {
+            proxy_pass http://localhost:8001/;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Apx-Incoming-Host $host;
         }
 
         # Health check
         location /health {
             access_log off;
-            return 200 "fallback healthy\n";
+            return 200 "external-domain healthy\n";
             add_header Content-Type text/plain;
         }
     }


### PR DESCRIPTION
## Problem
Previous PR #243 edited `fly/nginx.conf` but `Dockerfile.fly` line 30 copies from `config/nginx/nginx.conf`:
```dockerfile
COPY config/nginx/nginx.conf /etc/nginx/nginx.conf
```

So the fix never actually deployed to production! 🤦

## Root Cause
We have two nginx config files:
- `fly/nginx.conf` - NOT USED
- `config/nginx/nginx.conf` - **ACTUALLY USED BY DOCKERFILE**

PR #243 edited the wrong file.

## Solution
Apply the exact same nginx routing fix to `config/nginx/nginx.conf`:
- ✅ Route root `/` to admin UI (port 8001) instead of redirecting
- ✅ Add `Apx-Incoming-Host` header to all proxy locations
- ✅ Support all endpoints: `/mcp`, `/a2a`, `/admin`, `/auth`, `/signup`, `/debug`
- ✅ Enable external domains to display landing page

## Verification
After deployment, `https://test-agent.adcontextprotocol.org/health` should return:
```
external-domain healthy
```

Instead of redirecting or returning "fallback healthy".

## Testing
1. `https://test-agent.adcontextprotocol.org/` → Landing page
2. `https://test-agent.adcontextprotocol.org/debug/headers` → JSON with headers
3. OAuth signup flow should work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)