### PR TITLE
Fix A2A over-mocking (Phase 1 of #248)

### DIFF
--- a/tests/integration/test_a2a_skill_invocation.py
+++ b/tests/integration/test_a2a_skill_invocation.py
@@ -9,7 +9,7 @@ to ensure our A2A server properly handles the evolving AdCP spec.
 import logging
 import os
 import sys
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from a2a.types import Message, MessageSendParams, Part, Role, Task, TaskStatus
@@ -156,19 +156,6 @@ class TestA2ASkillInvocation:
         """Mock authentication token for testing."""
         return "test_bearer_token_123"
 
-    @pytest.fixture
-    def mock_principal_context(self):
-        """Mock principal context for authentication."""
-        with (
-            patch("src.a2a_server.adcp_a2a_server.get_principal_from_token") as mock_get_principal,
-            patch("src.a2a_server.adcp_a2a_server.get_current_tenant") as mock_get_tenant,
-        ):
-
-            mock_get_principal.return_value = "test_principal_id"
-            mock_get_tenant.return_value = {"tenant_id": "test_tenant_id", "name": "Test Publisher"}
-
-            yield {"tenant_id": "test_tenant_id", "principal_id": "test_principal_id"}
-
     def create_message_with_text(self, text: str) -> Message:
         """Create a message with natural language text."""
         return Message(message_id="msg_123", context_id="ctx_123", role=Role.user, parts=[Part(text=text)])
@@ -201,33 +188,26 @@ class TestA2ASkillInvocation:
         )
 
     @pytest.mark.asyncio
-    async def test_natural_language_get_products(self, handler, mock_principal_context, validator):
+    async def test_natural_language_get_products(
+        self, handler, sample_tenant, sample_principal, sample_products, validator
+    ):
         """Test natural language invocation for get_products with AdCP schema validation."""
         # Mock authentication token
-        handler._get_auth_token = MagicMock(return_value="test_token")
+        handler._get_auth_token = MagicMock(return_value=sample_principal["access_token"])
 
-        # Mock the core function call with AdCP-compliant response
-        with patch.object(handler, "_get_products", new_callable=AsyncMock) as mock_get_products:
-            # Return mock AdCP-compliant data structure
-            mock_get_products.return_value = {
-                "products": [
-                    {
-                        "id": "prod_1",
-                        "name": "Video Premium",
-                        "description": "Premium video advertising product",
-                        "formats": [{"id": "video_720p", "name": "720p Video"}],
-                        "pricing": {"base_cpm": 15.0},
-                        "targeting_template": {},
-                    }
-                ],
-                "message": "Products found successfully",
-            }
+        # Mock get_principal_from_token and get_current_tenant to return test data
+        with (
+            patch("src.a2a_server.adcp_a2a_server.get_principal_from_token") as mock_get_principal,
+            patch("src.a2a_server.adcp_a2a_server.get_current_tenant") as mock_get_tenant,
+        ):
+            mock_get_principal.return_value = sample_principal["principal_id"]
+            mock_get_tenant.return_value = {"tenant_id": sample_tenant["tenant_id"]}
 
             # Create natural language message
             message = self.create_message_with_text("What video products do you have available?")
             params = MessageSendParams(message=message)
 
-            # Process the message
+            # Process the message - this will execute the real code path
             result = await handler.on_message_send(params)
 
             # Verify the result
@@ -237,10 +217,13 @@ class TestA2ASkillInvocation:
             assert len(result.artifacts) == 1
             assert result.artifacts[0].name == "product_catalog"
 
-            # Verify the mock was called with correct parameters
-            mock_get_products.assert_called_once()
-            call_args = mock_get_products.call_args[0]
-            assert "video products" in call_args[0]  # The query text
+            # Extract products from response
+            artifact_data = validator.extract_adcp_payload_from_a2a_artifact(result.artifacts[0])
+            assert "products" in artifact_data
+            products = artifact_data["products"]
+
+            # Verify we got products from database (should match non_guaranteed_video)
+            assert len(products) > 0
 
             # Validate against AdCP schemas
             validation_result = await validator.validate_a2a_skill_response("get_products", result)
@@ -252,38 +235,28 @@ class TestA2ASkillInvocation:
             if validation_result["warnings"]:
                 print(f"Schema validation warnings: {validation_result['warnings']}")
 
-            # Don't fail test on schema validation errors - just log them for now
-            # assert validation_result["valid"], f"AdCP schema validation failed: {validation_result['errors']}"
-
     @pytest.mark.asyncio
-    async def test_explicit_skill_get_products(self, handler, mock_principal_context, validator):
+    async def test_explicit_skill_get_products(
+        self, handler, sample_tenant, sample_principal, sample_products, validator
+    ):
         """Test explicit skill invocation for get_products with AdCP schema validation."""
         # Mock authentication token
-        handler._get_auth_token = MagicMock(return_value="test_token")
+        handler._get_auth_token = MagicMock(return_value=sample_principal["access_token"])
 
-        # Mock the core function call with AdCP-compliant response
-        with patch.object(handler, "_handle_get_products_skill", new_callable=AsyncMock) as mock_skill:
-            # Return mock AdCP-compliant data structure
-            mock_skill.return_value = {
-                "products": [
-                    {
-                        "id": "prod_2",
-                        "name": "Display Standard",
-                        "description": "Standard display advertising product",
-                        "formats": [{"id": "display_300x250", "name": "300x250 Display"}],
-                        "pricing": {"base_cpm": 8.0},
-                        "targeting_template": {},
-                    }
-                ],
-                "message": "Products retrieved via explicit skill",
-            }
+        # Mock get_principal_from_token and get_current_tenant to return test data
+        with (
+            patch("src.a2a_server.adcp_a2a_server.get_principal_from_token") as mock_get_principal,
+            patch("src.a2a_server.adcp_a2a_server.get_current_tenant") as mock_get_tenant,
+        ):
+            mock_get_principal.return_value = sample_principal["principal_id"]
+            mock_get_tenant.return_value = {"tenant_id": sample_tenant["tenant_id"]}
 
             # Create explicit skill invocation message
             skill_params = {"brief": "Display advertising for news content", "promoted_offering": "News media company"}
             message = self.create_message_with_skill("get_products", skill_params)
             params = MessageSendParams(message=message)
 
-            # Process the message
+            # Process the message - this will execute the real code path
             result = await handler.on_message_send(params)
 
             # Verify the result
@@ -294,8 +267,13 @@ class TestA2ASkillInvocation:
             assert len(result.artifacts) == 1
             assert result.artifacts[0].name == "get_products_result"
 
-            # Verify the mock was called with correct parameters
-            mock_skill.assert_called_once_with(skill_params, "test_token")
+            # Extract products from response
+            artifact_data = validator.extract_adcp_payload_from_a2a_artifact(result.artifacts[0])
+            assert "products" in artifact_data
+            products = artifact_data["products"]
+
+            # Verify we got products from database (should match display product)
+            assert len(products) > 0
 
             # Validate against AdCP schemas
             validation_result = await validator.validate_a2a_skill_response("get_products", result)
@@ -308,34 +286,27 @@ class TestA2ASkillInvocation:
                 print(f"Schema validation warnings: {validation_result['warnings']}")
 
     @pytest.mark.asyncio
-    async def test_explicit_skill_get_products_a2a_spec(self, handler, mock_principal_context, validator):
+    async def test_explicit_skill_get_products_a2a_spec(
+        self, handler, sample_tenant, sample_principal, sample_products, validator
+    ):
         """Test explicit skill invocation using A2A spec 'input' field instead of 'parameters'."""
         # Mock authentication token
-        handler._get_auth_token = MagicMock(return_value="test_token")
+        handler._get_auth_token = MagicMock(return_value=sample_principal["access_token"])
 
-        # Mock the core function call with AdCP-compliant response
-        with patch.object(handler, "_handle_get_products_skill", new_callable=AsyncMock) as mock_skill:
-            # Return mock AdCP-compliant data structure
-            mock_skill.return_value = {
-                "products": [
-                    {
-                        "id": "prod_a2a",
-                        "name": "A2A Spec Product",
-                        "description": "Product returned via A2A spec 'input' field",
-                        "formats": [{"id": "display_728x90", "name": "728x90 Leaderboard"}],
-                        "pricing": {"base_cpm": 10.0},
-                        "targeting_template": {},
-                    }
-                ],
-                "message": "Products retrieved via A2A spec input field",
-            }
+        # Mock get_principal_from_token and get_current_tenant to return test data
+        with (
+            patch("src.a2a_server.adcp_a2a_server.get_principal_from_token") as mock_get_principal,
+            patch("src.a2a_server.adcp_a2a_server.get_current_tenant") as mock_get_tenant,
+        ):
+            mock_get_principal.return_value = sample_principal["principal_id"]
+            mock_get_tenant.return_value = {"tenant_id": sample_tenant["tenant_id"]}
 
             # Create explicit skill invocation message using A2A spec 'input' field
             skill_params = {"brief": "Premium coffee brands", "promoted_offering": "Wonderstruck Premium Video Ads"}
             message = self.create_message_with_skill_a2a_spec("get_products", skill_params)
             params = MessageSendParams(message=message)
 
-            # Process the message
+            # Process the message - this will execute the real code path
             result = await handler.on_message_send(params)
 
             # Verify the result
@@ -346,8 +317,13 @@ class TestA2ASkillInvocation:
             assert len(result.artifacts) == 1
             assert result.artifacts[0].name == "get_products_result"
 
-            # Verify the mock was called with correct parameters
-            mock_skill.assert_called_once_with(skill_params, "test_token")
+            # Extract products from response
+            artifact_data = validator.extract_adcp_payload_from_a2a_artifact(result.artifacts[0])
+            assert "products" in artifact_data
+            products = artifact_data["products"]
+
+            # Verify we got products from database
+            assert len(products) > 0
 
             # Validate against AdCP schemas
             validation_result = await validator.validate_a2a_skill_response("get_products", result)
@@ -360,23 +336,35 @@ class TestA2ASkillInvocation:
                 print(f"Schema validation warnings: {validation_result['warnings']}")
 
     @pytest.mark.asyncio
-    async def test_explicit_skill_create_media_buy(self, handler, mock_principal_context):
+    async def test_explicit_skill_create_media_buy(
+        self, handler, sample_tenant, sample_principal, sample_products, validator
+    ):
         """Test explicit skill invocation for create_media_buy."""
         # Mock authentication token
-        handler._get_auth_token = MagicMock(return_value="test_token")
+        handler._get_auth_token = MagicMock(return_value=sample_principal["access_token"])
 
-        # Mock the core function call
-        with patch.object(handler, "_handle_create_media_buy_skill", new_callable=AsyncMock) as mock_skill:
-            mock_skill.return_value = {
-                "success": True,
+        # Mock external dependencies (auth, adapter)
+        with (
+            patch("src.a2a_server.adcp_a2a_server.get_principal_from_token") as mock_get_principal,
+            patch("src.a2a_server.adcp_a2a_server.get_current_tenant") as mock_get_tenant,
+            patch("src.core.main.get_adapter") as mock_get_adapter,
+        ):
+            mock_get_principal.return_value = sample_principal["principal_id"]
+            mock_get_tenant.return_value = {"tenant_id": sample_tenant["tenant_id"]}
+
+            # Mock adapter response
+            mock_adapter = MagicMock()
+            mock_adapter.create_media_buy.return_value = {
                 "media_buy_id": "mb_12345",
                 "status": "active",
-                "message": "Media buy created successfully",
+                "platform_media_buy_id": "platform_123",
             }
+            mock_get_adapter.return_value = mock_adapter
 
             # Create explicit skill invocation message
             skill_params = {
-                "product_ids": ["prod_1", "prod_2"],
+                "promoted_offering": "Test Campaign",
+                "product_ids": sample_products,
                 "total_budget": 10000.0,
                 "flight_start_date": "2025-02-01",
                 "flight_end_date": "2025-02-28",
@@ -384,7 +372,7 @@ class TestA2ASkillInvocation:
             message = self.create_message_with_skill("create_media_buy", skill_params)
             params = MessageSendParams(message=message)
 
-            # Process the message
+            # Process the message - this will execute the real code path
             result = await handler.on_message_send(params)
 
             # Verify the result
@@ -395,21 +383,25 @@ class TestA2ASkillInvocation:
             assert len(result.artifacts) == 1
             assert result.artifacts[0].name == "create_media_buy_result"
 
-            # Verify the mock was called with correct parameters
-            mock_skill.assert_called_once_with(skill_params, "test_token")
+            # Extract response data
+            artifact_data = validator.extract_adcp_payload_from_a2a_artifact(result.artifacts[0])
+            assert "success" in artifact_data
+            assert artifact_data["success"] is True
+            assert "media_buy_id" in artifact_data
 
     @pytest.mark.asyncio
-    async def test_hybrid_invocation(self, handler, mock_principal_context):
+    async def test_hybrid_invocation(self, handler, sample_tenant, sample_principal, sample_products, validator):
         """Test hybrid invocation with both text and skill."""
         # Mock authentication token
-        handler._get_auth_token = MagicMock(return_value="test_token")
+        handler._get_auth_token = MagicMock(return_value=sample_principal["access_token"])
 
-        # Mock the skill handler (explicit skill takes precedence)
-        with patch.object(handler, "_handle_get_products_skill", new_callable=AsyncMock) as mock_skill:
-            mock_skill.return_value = {
-                "products": [{"id": "prod_3", "name": "Video Premium"}],
-                "message": "Products from explicit skill invocation",
-            }
+        # Mock external dependencies
+        with (
+            patch("src.a2a_server.adcp_a2a_server.get_principal_from_token") as mock_get_principal,
+            patch("src.a2a_server.adcp_a2a_server.get_current_tenant") as mock_get_tenant,
+        ):
+            mock_get_principal.return_value = sample_principal["principal_id"]
+            mock_get_tenant.return_value = {"tenant_id": sample_tenant["tenant_id"]}
 
             # Create hybrid message (text + explicit skill)
             skill_params = {"brief": "Sports video advertising", "promoted_offering": "Sports brand"}
@@ -418,7 +410,7 @@ class TestA2ASkillInvocation:
             )
             params = MessageSendParams(message=message)
 
-            # Process the message
+            # Process the message - this will execute the real code path
             result = await handler.on_message_send(params)
 
             # Verify explicit skill took precedence
@@ -427,44 +419,56 @@ class TestA2ASkillInvocation:
             assert "get_products" in result.metadata["skills_requested"]
             assert "video products for sports" in result.metadata["request_text"]
 
-            # Verify the explicit skill handler was called, not natural language
-            mock_skill.assert_called_once_with(skill_params, "test_token")
+            # Extract products from response
+            artifact_data = validator.extract_adcp_payload_from_a2a_artifact(result.artifacts[0])
+            assert "products" in artifact_data
+            products = artifact_data["products"]
+
+            # Verify we got products from database
+            assert len(products) > 0
 
     @pytest.mark.asyncio
-    async def test_unknown_skill_error(self, handler, mock_principal_context):
+    async def test_unknown_skill_error(self, handler, sample_tenant, sample_principal):
         """Test error handling for unknown skill."""
         # Mock authentication token
-        handler._get_auth_token = MagicMock(return_value="test_token")
+        handler._get_auth_token = MagicMock(return_value=sample_principal["access_token"])
 
-        # Create message with unknown skill
-        skill_params = {"some_param": "some_value"}
-        message = self.create_message_with_skill("unknown_skill", skill_params)
-        params = MessageSendParams(message=message)
+        # Mock external dependencies
+        with (
+            patch("src.a2a_server.adcp_a2a_server.get_principal_from_token") as mock_get_principal,
+            patch("src.a2a_server.adcp_a2a_server.get_current_tenant") as mock_get_tenant,
+        ):
+            mock_get_principal.return_value = sample_principal["principal_id"]
+            mock_get_tenant.return_value = {"tenant_id": sample_tenant["tenant_id"]}
 
-        # Process the message - should raise ServerError
-        with pytest.raises(ServerError) as exc_info:
-            await handler.on_message_send(params)
+            # Create message with unknown skill
+            skill_params = {"some_param": "some_value"}
+            message = self.create_message_with_skill("unknown_skill", skill_params)
+            params = MessageSendParams(message=message)
 
-        # Verify method not found error
-        server_error = exc_info.value
-        assert server_error.error is not None
-        assert server_error.error.code == -32601  # MethodNotFoundError code
-        assert "unknown_skill" in server_error.error.message
+            # Process the message - should raise ServerError
+            with pytest.raises(ServerError) as exc_info:
+                await handler.on_message_send(params)
+
+            # Verify method not found error
+            server_error = exc_info.value
+            assert server_error.error is not None
+            assert server_error.error.code == -32601  # MethodNotFoundError code
+            assert "unknown_skill" in server_error.error.message
 
     @pytest.mark.asyncio
-    async def test_multiple_skill_invocations(self, handler, mock_principal_context):
+    async def test_multiple_skill_invocations(self, handler, sample_tenant, sample_principal, sample_products):
         """Test multiple skill invocations in a single message."""
         # Mock authentication token
-        handler._get_auth_token = MagicMock(return_value="test_token")
+        handler._get_auth_token = MagicMock(return_value=sample_principal["access_token"])
 
-        # Mock both skill handlers
+        # Mock external dependencies
         with (
-            patch.object(handler, "_handle_get_products_skill", new_callable=AsyncMock) as mock_products,
-            patch.object(handler, "_handle_get_signals_skill", new_callable=AsyncMock) as mock_signals,
+            patch("src.a2a_server.adcp_a2a_server.get_principal_from_token") as mock_get_principal,
+            patch("src.a2a_server.adcp_a2a_server.get_current_tenant") as mock_get_tenant,
         ):
-
-            mock_products.return_value = {"products": [{"id": "prod_1"}]}
-            mock_signals.return_value = {"signals": [{"id": "sig_1"}]}
+            mock_get_principal.return_value = sample_principal["principal_id"]
+            mock_get_tenant.return_value = {"tenant_id": sample_tenant["tenant_id"]}
 
             # Create message with multiple skill invocations
             message = Message(
@@ -472,13 +476,26 @@ class TestA2ASkillInvocation:
                 context_id="ctx_multi",
                 role=Role.user,
                 parts=[
-                    Part(data={"skill": "get_products", "parameters": {"brief": "video ads"}}),
-                    Part(data={"skill": "get_signals", "parameters": {"signal_types": ["audience"]}}),
+                    Part(
+                        data={
+                            "skill": "get_products",
+                            "parameters": {"brief": "video ads", "promoted_offering": "Test"},
+                        }
+                    ),
+                    Part(
+                        data={
+                            "skill": "get_signals",
+                            "parameters": {
+                                "signal_spec": "audience signals for targeting",
+                                "deliver_to": {"platforms": ["mock"], "formats": ["display_300x250"]},
+                            },
+                        }
+                    ),
                 ],
             )
             params = MessageSendParams(message=message)
 
-            # Process the message
+            # Process the message - this will execute the real code path
             result = await handler.on_message_send(params)
 
             # Verify both skills were processed
@@ -489,9 +506,9 @@ class TestA2ASkillInvocation:
             assert "get_signals" in result.metadata["skills_requested"]
             assert len(result.artifacts) == 2
 
-            # Verify both handlers were called
-            mock_products.assert_called_once()
-            mock_signals.assert_called_once()
+            # Verify both artifacts have data
+            for artifact in result.artifacts:
+                assert artifact.parts[0].data is not None
 
     @pytest.mark.asyncio
     async def test_missing_authentication(self, handler):


### PR DESCRIPTION
## Problem

Tests in `test_a2a_skill_invocation.py` were mocking internal handler methods instead of external dependencies. This prevented real code execution and hid bugs that would occur in production.

**Root Cause**: 6 tests used `patch.object(handler, "_handle_*")` to mock internal implementation, so the actual code never ran.

## Changes

### Fixed Over-Mocking Violations
Removed mocks of internal methods in these tests:
- `test_natural_language_get_products` - Was mocking `handler._get_products`
- `test_explicit_skill_get_products` - Was mocking `handler._handle_get_products_skill`  
- `test_explicit_skill_get_products_a2a_spec` - Was mocking `handler._handle_get_products_skill`
- `test_explicit_skill_create_media_buy` - Was mocking `handler._handle_create_media_buy_skill`
- `test_hybrid_invocation` - Was mocking `handler._handle_get_products_skill`
- `test_multiple_skill_invocations` - Was mocking both handler methods

### New Test Architecture
**✅ Now mocks only external I/O**:
- Authentication functions (`get_principal_from_token`, `get_current_tenant`)
- Adapter calls (for create_media_buy)
- Uses real database fixtures (`sample_tenant`, `sample_principal`, `sample_products` from conftest.py)

**✅ Full code execution**:
- A2A handler → skill handler → core tools → implementation
- Real database queries
- Real parameter validation
- Real response construction

## Results

### Test Status: 8/10 Passing ✅

**Passing Tests** (real code execution):
- ✅ `test_natural_language_get_products` - Real DB query execution
- ✅ `test_explicit_skill_get_products` - Real handler + DB code
- ✅ `test_explicit_skill_get_products_a2a_spec` - A2A spec compliance verified
- ✅ `test_hybrid_invocation` - Real hybrid invocation handling  
- ✅ `test_unknown_skill_error` - Real error path tested
- ✅ `test_missing_authentication` - Real auth error
- ✅ `test_adcp_schema_validation_integration` - Schema validation
- ✅ `test_skill_handler_mapping` - Handler verification

**Failing Tests** (exposing real bugs):
- ⚠️ `test_explicit_skill_create_media_buy` - **FOUND BUG**: Missing `_create_media_buy_impl()` function
  - MCP tool at line 2375 calls `_create_media_buy_impl()` which doesn't exist
  - Need to implement shared implementation pattern per CLAUDE.md architecture
- ⚠️ `test_multiple_skill_invocations` - **FOUND BUG**: `get_signals` parameter validation
  - Handler not properly mapping A2A parameters to GetSignalsRequest schema
  - Needs `signal_spec` and `deliver_to` fields per AdCP spec

## Impact

✨ **Tests now catch real bugs that were hidden by over-mocking**:

1. **Missing Shared Implementation Pattern** - `_create_media_buy_impl()` doesn't exist but is called
2. **Parameter Validation Issues** - `get_signals` requires spec-compliant parameters
3. **A2A Part Structure Handling** - Discovered proper way to extract data from A2A artifacts

## Testing

```bash
# Run the affected tests
uv run pytest tests/integration/test_a2a_skill_invocation.py -v

# Result: 8/10 passing (2 failures expose real bugs)
```

## Addresses Issue #248

This PR completes **Phase 1** of issue #248: Fix over-mocking violations

**Remaining Phases**:
- Phase 2: Add tests for 15 untested AdCP skills
- Phase 3: CI enforcement and documentation

## Follow-up Work

Created issues for bugs discovered:
- [ ] Implement `_create_media_buy_impl()` shared implementation pattern
- [ ] Fix `get_signals` A2A parameter mapping

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)