### PR TITLE
Auto-add creator email to authorized list on tenant creation

### DIFF
--- a/src/admin/blueprints/core.py
+++ b/src/admin/blueprints/core.py
@@ -254,10 +254,15 @@ def create_tenant():
 
             # Set authorization settings
             authorized_emails = request.form.get("authorized_emails", "")
-            if authorized_emails:
-                new_tenant.authorized_emails = json.dumps(
-                    [e.strip() for e in authorized_emails.split(",") if e.strip()]
-                )
+            email_list = [e.strip() for e in authorized_emails.split(",") if e.strip()]
+
+            # Automatically add the creator's email to authorized list
+            creator_email = session.get("user")
+            if creator_email and creator_email not in email_list:
+                email_list.append(creator_email)
+
+            if email_list:
+                new_tenant.authorized_emails = json.dumps(email_list)
 
             authorized_domains = request.form.get("authorized_domains", "")
             if authorized_domains:

--- a/src/admin/tenant_management_api.py
+++ b/src/admin/tenant_management_api.py
@@ -131,6 +131,12 @@ def create_tenant():
             tenant_id = f"tenant_{uuid.uuid4().hex[:8]}"
             admin_token = secrets.token_urlsafe(32)
 
+            # Handle authorized emails - automatically add creator's email
+            email_list = data.get("authorized_emails", [])
+            creator_email = data.get("creator_email")
+            if creator_email and creator_email not in email_list:
+                email_list.append(creator_email)
+
             # Create tenant
             new_tenant = Tenant(
                 tenant_id=tenant_id,
@@ -142,7 +148,7 @@ def create_tenant():
                 billing_contact=data.get("billing_contact"),
                 max_daily_budget=data.get("max_daily_budget", 10000),
                 enable_axe_signals=data.get("enable_axe_signals", True),
-                authorized_emails=json.dumps(data.get("authorized_emails", [])),
+                authorized_emails=json.dumps(email_list),
                 authorized_domains=json.dumps(data.get("authorized_domains", [])),
                 slack_webhook_url=data.get("slack_webhook_url"),
                 slack_audit_webhook_url=data.get("slack_audit_webhook_url"),


### PR DESCRIPTION
## Summary
Automatically adds the tenant creator's email to the authorized emails list when a new tenant is created, preventing lockout scenarios and improving UX.

## Changes

### Admin UI (`src/admin/blueprints/core.py`)
- Retrieves creator email from `session['user']`
- Automatically adds to `authorized_emails` list if not already present
- Works seamlessly with existing authorization flow

### Tenant Management API (`src/admin/tenant_management_api.py`)
- Accepts optional `creator_email` field in request body
- Automatically adds to `authorized_emails` list if provided
- Backward compatible - works without `creator_email` field

## Testing
- ✅ All tenant management API integration tests pass (8/8)
- ✅ Logic validated for multiple scenarios:
  - Creator email not in list
  - Creator email already in list (no duplicates)
  - Empty authorized list
  - No creator email provided

## Benefits
- Tenant creators no longer need to manually add themselves
- Prevents lockout scenarios
- Maintains backward compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)