### PR TITLE
Fix A2A create_media_buy response serialization

### DIFF
--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -1050,7 +1050,7 @@ class AdCPRequestHandler(RequestHandler):
                 "media_buy_id": response.media_buy_id,
                 "status": response.status,
                 "message": response.message or "Media buy created successfully",
-                "packages": [package.model_dump() for package in response.packages] if response.packages else [],
+                "packages": response.packages if response.packages else [],  # Already list of dicts
                 "next_steps": response.next_steps if hasattr(response, "next_steps") else [],
             }
 


### PR DESCRIPTION
## Problem
The A2A server's `create_media_buy` endpoint was failing with:
```
'dict' object has no attribute 'model_dump'
```

## Root Cause
The `CreateMediaBuyResponse.packages` field is defined as `list[dict[str, Any]]` (already dicts), but the A2A handler was incorrectly trying to call `.model_dump()` on these dict objects.

## Solution
Changed line 1053 in `src/a2a_server/adcp_a2a_server.py` to pass `response.packages` directly without calling `.model_dump()`.

## Testing
- ✅ All 24 A2A skill invocation tests pass
- ✅ All other A2A integration tests pass
- ✅ Pre-commit hooks pass

## Why Tests Didn't Catch This Initially
The integration test (`test_explicit_skill_create_media_buy`) mocked the adapter, bypassing the entire `_create_media_buy_impl` function. The e2e test that would have caught this (`tests/e2e/test_a2a_adcp_compliance.py`) is not run in CI.

## Related
- Aligns with schema definition in `src/core/schemas.py` line 2261
- Follows AdCP v2.4 protocol specification