### PR TITLE
Fix A2A create_media_buy to handle both dict and Pydantic responses

### DIFF
--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -1044,15 +1044,27 @@ class AdCPRequestHandler(RequestHandler):
                 context=tool_context,
             )
 
-            # Convert response to A2A format
-            return {
-                "success": True,
-                "media_buy_id": response.media_buy_id,
-                "status": response.status,
-                "message": response.message or "Media buy created successfully",
-                "packages": [package.model_dump() for package in response.packages] if response.packages else [],
-                "next_steps": response.next_steps if hasattr(response, "next_steps") else [],
-            }
+            # Handle both dict and object responses (defensive pattern)
+            if isinstance(response, dict):
+                # Response is already a dict (schema enhancement enabled)
+                return {
+                    "success": True,
+                    "media_buy_id": response.get("media_buy_id"),
+                    "status": response.get("status"),
+                    "message": response.get("message") or "Media buy created successfully",
+                    "packages": response.get("packages", []),
+                    "next_steps": response.get("next_steps", []),
+                }
+            else:
+                # Response is a Pydantic object
+                return {
+                    "success": True,
+                    "media_buy_id": response.media_buy_id,
+                    "status": response.status,
+                    "message": response.message or "Media buy created successfully",
+                    "packages": [package.model_dump() for package in response.packages] if response.packages else [],
+                    "next_steps": response.next_steps if hasattr(response, "next_steps") else [],
+                }
 
         except Exception as e:
             logger.error(f"Error in create_media_buy skill: {e}")


### PR DESCRIPTION
## Problem
The A2A server's `create_media_buy` skill handler was failing with:
```
'dict' object has no attribute 'model_dump'
```

This occurred when trying to call `.model_dump()` on package objects within the response, but the response was a dict (with dict packages) rather than a Pydantic object (with Pydantic package objects).

## Root Cause
The `create_media_buy_raw` function can return either:
1. A `CreateMediaBuyResponse` Pydantic object (normal path)
2. A dict (when schema enhancement is enabled via `INCLUDE_SCHEMAS_IN_RESPONSES`)

The A2A handler was only handling the Pydantic object case, causing failures when schema enhancement was active.

## Solution
Add defensive coding to handle both response types:
- Check if response is `dict` or Pydantic object using `isinstance()`
- For dicts: use `.get()` for safe field access, packages are already dicts
- For Pydantic objects: access attributes directly, call `.model_dump()` on package objects

## Testing
- ✅ Pre-commit hooks pass
- ✅ Follows defensive pattern from `_handle_get_products_skill` and `_handle_list_creatives_skill`
- ✅ Handles both execution paths safely
- ⚠️ Integration test failure is pre-existing (PostgreSQL not running on test port 5516)

## Impact
- Fixes A2A `create_media_buy` failures in production
- Makes code more robust against schema enhancement variations
- No breaking changes to API contract
- Consistent with other skill handlers in the codebase