### PR TITLE
Fix 'dict' object has no attribute 'model_dump' error in A2A create_media_buy

### DIFF
--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -1056,13 +1056,24 @@ class AdCPRequestHandler(RequestHandler):
                     "next_steps": response.get("next_steps", []),
                 }
             else:
-                # Response is a Pydantic object
+                # Response is a Pydantic object - but packages might be dicts or objects
+                # Handle packages list safely - check first element to determine type
+                packages_list = []
+                if response.packages:
+                    first_package = response.packages[0]
+                    if isinstance(first_package, dict):
+                        # Packages are already dicts
+                        packages_list = response.packages
+                    else:
+                        # Packages are Pydantic objects - serialize them
+                        packages_list = [pkg.model_dump() for pkg in response.packages]
+
                 return {
                     "success": True,
                     "media_buy_id": response.media_buy_id,
                     "status": response.status,
                     "message": response.message or "Media buy created successfully",
-                    "packages": [package.model_dump() for package in response.packages] if response.packages else [],
+                    "packages": packages_list,
                     "next_steps": response.next_steps if hasattr(response, "next_steps") else [],
                 }
 


### PR DESCRIPTION
## Summary
Fixes the production bug reported at https://test-agent.adcontextprotocol.org where `create_media_buy` was failing with `'dict' object has no attribute 'model_dump'`.

## Problem
The A2A server's `_handle_create_media_buy_skill` function (line 1065) was attempting to call `.model_dump()` on package objects that were already serialized to dicts.

**Root Cause**: The `_create_media_buy_impl` function returns `CreateMediaBuyResponse` with `packages` as a list of dicts (built at `main.py:3032-3050`), but the A2A handler assumed they were Pydantic objects.

## Solution
Added defensive type checking to handle both formats:
- Check if first package is a dict or Pydantic object
- Only call `.model_dump()` if packages are Pydantic objects
- Pass through packages directly if already dicts

## Testing
✅ All integration tests pass:
- `test_create_media_buy_with_package_budget_mcp` - MCP path
- `test_create_media_buy_with_package_budget_a2a` - A2A path (the buggy one)
- `test_explicit_skill_create_media_buy` - A2A skill invocation

✅ All 5 v2.4 format tests pass

## Production Impact
This fixes the blocking issue preventing end-to-end testing of the test agent at https://test-agent.adcontextprotocol.org

## References
- Production error documented in `/Users/brianokelley/conductor/adcp-client-1/.conductor/nairobi-v1/TEST_AGENT_ISSUES.md`
- Similar fix was attempted before (commits 5ddb8ca, abcc3fe) but this completes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>