### PR TITLE
Fix Product model to exclude null optional fields in AdCP responses

### DIFF
--- a/src/core/schemas.py
+++ b/src/core/schemas.py
@@ -970,11 +970,9 @@ class Product(BaseModel):
         if "formats" in data:
             data["format_ids"] = data.pop("formats")
 
-        # Remove null fields per AdCP spec but keep core pricing fields
-        # Core fields that should be present even if None for AdCP compliance
+        # Remove null fields per AdCP spec
+        # Only truly required fields should always be present
         core_fields = {
-            "cpm",
-            "min_spend",
             "product_id",
             "name",
             "description",

--- a/tests/integration/test_get_products_database_integration.py
+++ b/tests/integration/test_get_products_database_integration.py
@@ -672,7 +672,9 @@ class TestDatabaseSchemaEvolution:
         product_dict = product.model_dump()
         assert "product_id" in product_dict
         assert "name" in product_dict
-        assert "cpm" in product_dict  # Should be present even if None
+        # Per AdCP spec and issue #289: optional null fields should be omitted, not included
+        assert "cpm" not in product_dict  # Optional field should be omitted when None
+        assert "min_spend" not in product_dict  # Optional field should be omitted when None
 
 
 class TestParallelTestExecution:


### PR DESCRIPTION
## Problem

Product model included null values for optional fields like `cpm`, `min_spend`, and `measurement` in AdCP responses, causing schema validation failures.

Example issue:
```json
{
  "product_id": "prod-1",
  "name": "Premium Display",
  "min_spend": null,  // ❌ Schema expects number or field omitted
  "measurement": null, // ❌ Schema expects object or field omitted
}
```

Schema error: `None is not of type 'number'`

## Root Cause

In `src/core/schemas.py` (lines 975-986), the `Product.model_dump()` method included `cpm` and `min_spend` in the `core_fields` set, which meant they were always included even if None.

Per AdCP spec, optional fields should be omitted entirely if they have no value, not set to null.

## Solution

Updated `Product.model_dump()` to only include truly required fields in `core_fields`:

```python
# Only truly required fields should always be present
core_fields = {
    "product_id",
    "name",
    "description",
    "format_ids",
    "delivery_type",
    "is_fixed_price",
    "is_custom",
    "currency",  # PR #79: Always include currency
}
```

Now optional fields like `cpm`, `min_spend`, `measurement`, etc. are:
- ✅ **Omitted** when they're None
- ✅ **Included** when they have values

## Testing

- ✅ All 38 AdCP contract tests pass
- ✅ All 38 product-related unit tests pass
- ✅ Verified optional fields are omitted when null and included when present
- ✅ No null values in AdCP responses
- ✅ Schema validation now passes

## Impact

- Fixes subset of E2E schema validation failures
- Makes Product responses strictly AdCP spec-compliant
- Cleaner API responses (no null noise)

Fixes #289