### PR TITLE
Fix A2A create_media_buy to accept AdCP v2.4 spec-compliant format

### DIFF
--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -1012,37 +1012,69 @@ class AdCPRequestHandler(RequestHandler):
                 tool_name="create_media_buy",
             )
 
-            # Map A2A parameters to CreateMediaBuyRequest
-            # Required parameters per AdCP spec
-            required_params = [
-                "promoted_offering",
-                "product_ids",
-                "total_budget",
-                "flight_start_date",
-                "flight_end_date",
-            ]
-            missing_params = [param for param in required_params if param not in parameters]
-
-            if missing_params:
+            # Validate required parameter: promoted_offering
+            if "promoted_offering" not in parameters:
                 return {
                     "success": False,
-                    "message": f"Missing required parameters: {missing_params}",
-                    "required_parameters": required_params,
+                    "message": "Missing required parameter: 'promoted_offering'",
+                    "required_parameters": ["promoted_offering"],
                     "received_parameters": list(parameters.keys()),
                 }
 
-            # Call core function directly with AdCP-compliant parameters
-            response = core_create_media_buy_tool(
-                promoted_offering=parameters["promoted_offering"],
-                po_number=f"A2A-{uuid.uuid4().hex[:8]}",  # Generate PO number
-                product_ids=parameters["product_ids"],
-                total_budget=float(parameters["total_budget"]),
-                start_date=parameters["flight_start_date"],
-                end_date=parameters["flight_end_date"],
-                targeting_overlay=parameters.get("custom_targeting", {}),
-                buyer_ref=f"A2A-{tool_context.principal_id}",
-                context=tool_context,
-            )
+            # Check if using AdCP spec format (packages, budget, start_time, end_time)
+            # or legacy format (product_ids, total_budget, flight_start_date, flight_end_date)
+            has_packages = "packages" in parameters
+            has_budget_obj = "budget" in parameters
+            has_start_time = "start_time" in parameters
+            has_end_time = "end_time" in parameters
+
+            has_product_ids = "product_ids" in parameters
+            has_total_budget = "total_budget" in parameters
+            has_flight_start = "flight_start_date" in parameters
+            has_flight_end = "flight_end_date" in parameters
+
+            # Determine which format is being used
+            if has_packages and has_budget_obj:
+                # AdCP spec format - pass through to core function
+                response = core_create_media_buy_tool(
+                    promoted_offering=parameters["promoted_offering"],
+                    po_number=parameters.get("po_number", f"A2A-{uuid.uuid4().hex[:8]}"),
+                    buyer_ref=parameters.get("buyer_ref", f"A2A-{tool_context.principal_id}"),
+                    packages=parameters["packages"],
+                    start_time=parameters.get("start_time"),
+                    end_time=parameters.get("end_time"),
+                    budget=parameters.get("budget"),
+                    targeting_overlay=parameters.get("custom_targeting", {}),
+                    context=tool_context,
+                )
+            elif has_product_ids and has_total_budget:
+                # Legacy flat format - convert to spec format
+                response = core_create_media_buy_tool(
+                    promoted_offering=parameters["promoted_offering"],
+                    po_number=parameters.get("po_number", f"A2A-{uuid.uuid4().hex[:8]}"),
+                    product_ids=parameters["product_ids"],
+                    total_budget=float(parameters["total_budget"]),
+                    start_date=parameters.get("flight_start_date"),
+                    end_date=parameters.get("flight_end_date"),
+                    targeting_overlay=parameters.get("custom_targeting", {}),
+                    buyer_ref=parameters.get("buyer_ref", f"A2A-{tool_context.principal_id}"),
+                    context=tool_context,
+                )
+            else:
+                # Missing required parameters for both formats
+                return {
+                    "success": False,
+                    "message": "Invalid parameters. Must provide either AdCP spec format (packages, budget, start_time, end_time) or legacy format (product_ids, total_budget, flight_start_date, flight_end_date)",
+                    "required_parameters_spec": ["promoted_offering", "packages", "budget", "start_time", "end_time"],
+                    "required_parameters_legacy": [
+                        "promoted_offering",
+                        "product_ids",
+                        "total_budget",
+                        "flight_start_date",
+                        "flight_end_date",
+                    ],
+                    "received_parameters": list(parameters.keys()),
+                }
 
             # Handle both dict and object responses (defensive pattern)
             if isinstance(response, dict):


### PR DESCRIPTION
## Problem

The Wonderstruck A2A agent was rejecting valid AdCP v2.4 spec-compliant requests with:
```
Missing required parameters: ['product_ids', 'total_budget', 'flight_start_date', 'flight_end_date']
```

When clients sent the correct format:
```json
{
  "packages": [{"products": [...], ...}],
  "budget": {"total": 5000, "currency": "USD"},
  "start_time": "2025-10-07T00:00:00Z",
  "end_time": "2025-11-06T00:00:00Z"
}
```

## Root Cause

The A2A server validation logic only accepted the legacy flat format and didn't recognize the AdCP v2.4 spec format with `packages[]`, `budget{}`, `start_time`, `end_time`.

## Fix

Updated `_handle_create_media_buy_skill` to accept **BOTH** formats:
- ✅ AdCP spec format: `packages[]`, `budget{total, currency}`, `start_time`, `end_time`  
- ✅ Legacy format: `product_ids[]`, `total_budget`, `flight_start_date`, `flight_end_date`

The core implementation already supported both formats - this was purely a validation layer issue.

## Testing

- ✅ `tests/integration/test_a2a_skill_invocation.py` (legacy format)
- ✅ `tests/integration/test_create_media_buy_v24.py` (AdCP spec format)

## Impact

This fixes the issue preventing AdCP-compliant clients from creating media buys via A2A protocol on Wonderstruck.