### PR TITLE
Add Inventory menu item to tenant settings

### DIFF
--- a/src/admin/blueprints/tenants.py
+++ b/src/admin/blueprints/tenants.py
@@ -197,6 +197,24 @@ def tenant_settings(tenant_id, section=None):
             stmt = select(CreativeFormat).filter_by(tenant_id=tenant_id)
             creative_formats = db_session.scalars(stmt).all()
 
+            # Get inventory counts
+            from src.core.database.models import GAMInventory
+
+            stmt = select(func.count()).select_from(GAMInventory).filter_by(tenant_id=tenant_id)
+            inventory_count = db_session.scalar(stmt) or 0
+
+            stmt = (
+                select(func.count()).select_from(GAMInventory).filter_by(tenant_id=tenant_id, inventory_type="ad_unit")
+            )
+            ad_units_count = db_session.scalar(stmt) or 0
+
+            stmt = (
+                select(func.count())
+                .select_from(GAMInventory)
+                .filter_by(tenant_id=tenant_id, inventory_type="placement")
+            )
+            placements_count = db_session.scalar(stmt) or 0
+
             # Get admin port
             admin_port = int(os.environ.get("ADMIN_UI_PORT", 8001))
 
@@ -221,6 +239,9 @@ def tenant_settings(tenant_id, section=None):
                 active_products=active_products,
                 draft_products=draft_products,
                 creative_formats=creative_formats,
+                inventory_count=inventory_count,
+                ad_units_count=ad_units_count,
+                placements_count=placements_count,
             )
 
     except Exception as e:

--- a/templates/tenant_settings.html
+++ b/templates/tenant_settings.html
@@ -354,6 +354,46 @@
         background: #dc2626;
     }
 
+    .alert {
+        padding: 1rem;
+        border-radius: 8px;
+        margin-bottom: 1rem;
+        border: 1px solid;
+    }
+
+    .alert-warning {
+        background: #fffbeb;
+        border-color: #fde047;
+        color: #92400e;
+    }
+
+    .alert-info {
+        background: #eff6ff;
+        border-color: #93c5fd;
+        color: #1e40af;
+    }
+
+    .stat-card {
+        background: white;
+        border: 1px solid #e5e7eb;
+        border-radius: 8px;
+        padding: 1rem;
+        text-align: center;
+    }
+
+    .stat-value {
+        font-size: 2rem;
+        font-weight: 700;
+        color: #111827;
+        margin-bottom: 0.25rem;
+    }
+
+    .stat-label {
+        font-size: 0.875rem;
+        color: #6b7280;
+        font-weight: 500;
+    }
+
     @media (max-width: 768px) {
         .settings-layout {
             grid-template-columns: 1fr;
@@ -365,6 +405,10 @@
 
         .form-grid {
             grid-template-columns: 1fr;
+        }
+
+        .stats-grid {
+            grid-template-columns: 1fr !important;
         }
     }
 
@@ -395,6 +439,11 @@
         <a class="settings-nav-item" data-section="adserver">
             <span class="settings-nav-icon">🖥️</span>
             <span>Ad Server</span>
+        </a>
+
+        <a class="settings-nav-item" data-section="inventory">
+            <span class="settings-nav-icon">📊</span>
+            <span>Inventory</span>
         </a>
 
         <a class="settings-nav-item" data-section="products">
@@ -811,6 +860,71 @@
                 </div>
                 {% endif %}
             </div>
+        </div>
+
+        <!-- Inventory Settings -->
+        <div id="inventory" class="settings-section">
+            <div class="settings-header">
+                <h2>Inventory Management</h2>
+                <p>Sync and manage ad units, placements, and targeting options from your ad server</p>
+            </div>
+
+            {% if active_adapter == 'google_ad_manager' %}
+            <div class="form-section">
+                <h3>Inventory Sync Status</h3>
+
+                <div class="stats-grid" style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; margin-bottom: 1.5rem;">
+                    <div class="stat-card">
+                        <div class="stat-value">{{ inventory_count|default(0) }}</div>
+                        <div class="stat-label">Total Items</div>
+                    </div>
+                    <div class="stat-card">
+                        <div class="stat-value">{{ ad_units_count|default(0) }}</div>
+                        <div class="stat-label">Ad Units</div>
+                    </div>
+                    <div class="stat-card">
+                        <div class="stat-value">{{ placements_count|default(0) }}</div>
+                        <div class="stat-label">Placements</div>
+                    </div>
+                </div>
+
+                <div class="status-card {% if last_sync_time %}success{% else %}warning{% endif %}">
+                    <div style="display: flex; justify-content: space-between; align-items: center;">
+                        <div>
+                            <strong>{% if last_sync_time %}Last synced: {{ last_sync_time }}{% else %}No sync performed yet{% endif %}</strong>
+                            <p style="margin: 0.5rem 0 0 0; font-size: 0.875rem;">
+                                Syncing imports ad units, placements, and targeting options from Google Ad Manager.
+                            </p>
+                        </div>
+                        <button onclick="syncGAMInventory()" class="btn btn-primary" style="white-space: nowrap;">
+                            <span id="sync-icon">🔄</span> Sync Now
+                        </button>
+                    </div>
+                </div>
+
+                <div class="form-section" style="margin-top: 1.5rem;">
+                    <h3>Actions</h3>
+                    <div style="display: flex; gap: 1rem;">
+                        <a href="/admin/tenant/{{ tenant_id }}/inventory?type=all" class="btn btn-secondary">
+                            📊 Browse Inventory
+                        </a>
+                        <a href="/admin/tenant/{{ tenant_id }}/targeting" class="btn btn-secondary">
+                            🎯 Browse Targeting
+                        </a>
+                    </div>
+                </div>
+            </div>
+            {% else %}
+            <div class="alert alert-warning">
+                <strong>Ad Server Required</strong>
+                <p style="margin: 0.25rem 0 0 0; font-size: 0.875rem;">
+                    Connect to Google Ad Manager in the Ad Server settings to enable inventory sync.
+                </p>
+                <a href="#" onclick="event.preventDefault(); switchSettingsSection('adserver')" class="btn btn-primary" style="margin-top: 1rem;">
+                    Configure Ad Server
+                </a>
+            </div>
+            {% endif %}
         </div>
 
         <!-- Products Settings -->
@@ -1387,6 +1501,14 @@ window.addEventListener('load', function() {
         }
     }
 });
+
+// Helper function to switch to a specific section
+function switchSettingsSection(sectionId) {
+    const navItem = document.querySelector(`[data-section="${sectionId}"]`);
+    if (navItem) {
+        navItem.click();
+    }
+}
 
 // Copy to clipboard
 function copyToClipboard(buttonOrText) {


### PR DESCRIPTION
## Summary
Added a dedicated **Inventory** section to the tenant settings navigation menu, making inventory sync functionality much more discoverable.

## Changes
- ✨ Added new "Inventory" menu item (📊 icon) in settings navigation
- 📊 Created dedicated Inventory section showing:
  - Sync status with inventory counts (Total Items, Ad Units, Placements)
  - Last sync timestamp
  - Prominent "Sync Now" button for GAM inventory sync
  - Quick action links to Browse Inventory and Browse Targeting
  - Warning message when GAM is not configured
- 🔧 Added inventory count queries to backend (`tenants.py`)
- 🎨 Added CSS styles for stat cards and alerts
- 🔄 Added helper function to programmatically switch between settings sections

## Navigation Structure (Updated)
1. General ⚙️
2. Ad Server 🖥️
3. **Inventory 📊** ← **NEW!**
4. Products 📦
5. Creative Formats 🎨
6. Advertisers 👥

## Before
- Inventory sync button was hidden inside the Ad Server section
- Only visible when GAM was connected
- Easy to miss for new users

## After
- Dedicated Inventory menu item in main settings navigation
- Clear sync status display with counts
- Prominent "Sync Now" button
- Quick links to inventory browser and targeting browser

## Test Plan
- [x] Verify menu item appears in navigation
- [x] Verify section displays correctly when GAM is configured
- [x] Verify warning displays when GAM is not configured
- [x] Verify inventory counts display correctly
- [x] Verify "Sync Now" button calls correct function
- [x] Verify links to inventory browser work
- [x] Code passes pre-commit hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)