### PR TITLE
Fix packages_ready KeyError in media buys list

### DIFF
--- a/src/admin/blueprints/tenants.py
+++ b/src/admin/blueprints/tenants.py
@@ -914,7 +914,7 @@ def media_buys_list(tenant_id):
                         "is_ready": readiness["is_ready_to_activate"],
                         "principal_name": principal.name if principal else "Unknown",
                         "product_names": product_names,
-                        "packages_ready": readiness["packages_ready"],
+                        "packages_ready": readiness["packages_with_creatives"],
                         "packages_total": readiness["packages_total"],
                         "blocking_issues": readiness.get("blocking_issues", []),
                     }


### PR DESCRIPTION
## Summary
- Fixed KeyError when loading media buys in 'Needs attention' view
- Changed `tenants.py` to use correct field name from ReadinessDetails

## Problem
The media buys list was failing with `KeyError: 'packages_ready'` because the code was accessing a non-existent field in the ReadinessDetails dictionary.

## Solution  
Changed line 917 in `src/admin/blueprints/tenants.py` from:
```python
"packages_ready": readiness["packages_ready"],
```

to:
```python
"packages_ready": readiness["packages_with_creatives"],
```

The `MediaBuyReadinessService.get_readiness_state()` returns `packages_with_creatives` which is semantically identical - it's the count of packages that have creative assignments (are "ready").

## Testing
- ✅ Unit tests passed (611 passed)
- ✅ Integration tests passed (192 passed)
- ✅ No new mypy errors introduced in changed code

🤖 Generated with [Claude Code](https://claude.com/claude-code)