### PR TITLE
Fix NameError: undefined webhook_url in sync_creatives

### DIFF
--- a/src/core/main.py
+++ b/src/core/main.py
@@ -1528,6 +1528,12 @@ def _sync_creatives_impl(
     # Track creatives requiring approval for workflow creation
     creatives_needing_approval = []
 
+    # Extract webhook URL from push_notification_config for AI review callbacks
+    webhook_url = None
+    if push_notification_config:
+        webhook_url = push_notification_config.get("url")
+        logger.info(f"[sync_creatives] Push notification webhook URL: {webhook_url}")
+
     # Get tenant creative approval settings
     # approval_mode: "auto-approve", "require-human", "ai-powered"
     logger.info(f"[sync_creatives] Tenant dict keys: {list(tenant.keys())}")


### PR DESCRIPTION
## Problem

The `sync_creatives` function was referencing `webhook_url` without defining it, causing a NameError when AI review mode (`approval_mode='ai-powered'`) is triggered. This prevented creatives from being properly synced for tenants using AI-powered approval.

## Root Cause

The function accepts a `push_notification_config` parameter but never extracted the `webhook_url` from it before passing it to the AI review callback submission (lines 1677 and 1859).

## Solution

Added extraction of `webhook_url` from `push_notification_config` parameter:
```python
webhook_url = None
if push_notification_config:
    webhook_url = push_notification_config.get("url")
```

## Testing

- Unit tests: ✅ All passing (593 passed)
- Integration tests: ✅ All passing (192 passed)
- No new test failures introduced

## Impact

- Fixes creative sync for tenants using `ai-powered` approval mode
- No impact on `auto-approve` or `require-human` modes (they don't use webhook_url)
- Production bug fix - should be deployed ASAP