### PR TITLE
Fix creative sync audit log error messages

### DIFF
--- a/src/core/main.py
+++ b/src/core/main.py
@@ -2086,12 +2086,26 @@ def _sync_creatives_impl(
 
     # Audit logging
     audit_logger = get_audit_logger("AdCP", tenant["tenant_id"])
+
+    # Build error message from failed creatives
+    error_message = None
+    if failed_creatives:
+        error_lines = []
+        for fc in failed_creatives[:5]:  # Limit to first 5 errors to avoid huge messages
+            creative_id = fc.get("creative_id", "unknown")
+            error_text = fc.get("error", "Unknown error")
+            error_lines.append(f"{creative_id}: {error_text}")
+        error_message = "; ".join(error_lines)
+        if len(failed_creatives) > 5:
+            error_message += f" (and {len(failed_creatives) - 5} more)"
+
     audit_logger.log_operation(
         operation="sync_creatives",
         principal_name=principal_id,
         principal_id=principal_id,
         adapter_id="N/A",
         success=len(failed_creatives) == 0,
+        error=error_message,
         details={
             "synced_count": len(synced_creatives),
             "failed_count": len(failed_creatives),


### PR DESCRIPTION
## Summary
Fixes the issue where creative sync failures show "Unknown error" in the activity feed and audit logs instead of the actual validation errors.

## Problem
When `sync_creatives` fails validation, the audit log was being written with `success=False` but WITHOUT an `error` parameter containing the actual validation error messages. This caused:
- Activity feed showing "Failed: Unknown error"
- Audit log tab potentially empty or missing error details
- No visibility into why creatives failed validation

## Solution
1. **Extract error details** from `failed_creatives` list
2. **Build human-readable error message** with creative_id and error text
3. **Pass error parameter** to `audit_logger.log_operation()` when creatives fail
4. **Add debug logging** to workflows page to diagnose empty audit log tab issues

## Changes
- `src/core/main.py`: Added error message construction before audit logging (lines 2090-2116)
- `src/admin/blueprints/workflows.py`: Added debug logging to understand audit log query behavior (lines 81-96)

## Example Output
Instead of:
```
Failed: Unknown error
```

You'll now see:
```
Failed: creative_123: Creative name cannot be empty; creative_456: Creative format is required
```

## Testing
- ✅ All unit tests passed (610 passed, 26 skipped)
- ✅ All integration tests passed (192 passed, 174 skipped)
- ✅ Pre-commit hooks passed (excluding pre-existing mypy errors in branch)

## Related
Addresses the issue shown in the screenshot where creative sync shows "Failed: Unknown error" in the workflows dashboard.