### PR TITLE
Fix migration: remove non-existent timestamp columns

### DIFF
--- a/alembic/versions/5d949a78d36f_migrate_legacy_pricing_to_pricing_.py
+++ b/alembic/versions/5d949a78d36f_migrate_legacy_pricing_to_pricing_.py
@@ -54,8 +54,8 @@ def upgrade() -> None:
                 text(
                     """
                 INSERT INTO pricing_options
-                (tenant_id, product_id, pricing_model, rate, currency, is_fixed, created_at, updated_at)
-                VALUES (:tenant_id, :product_id, 'cpm', :rate, :currency, true, NOW(), NOW())
+                (tenant_id, product_id, pricing_model, rate, currency, is_fixed)
+                VALUES (:tenant_id, :product_id, 'cpm', :rate, :currency, true)
             """
                 ),
                 {"tenant_id": tenant_id, "product_id": product_id, "rate": float(cpm), "currency": currency_code},
@@ -92,8 +92,8 @@ def upgrade() -> None:
                     text(
                         """
                     INSERT INTO pricing_options
-                    (tenant_id, product_id, pricing_model, currency, is_fixed, price_guidance, created_at, updated_at)
-                    VALUES (:tenant_id, :product_id, 'cpm', :currency, false, :price_guidance, NOW(), NOW())
+                    (tenant_id, product_id, pricing_model, currency, is_fixed, price_guidance)
+                    VALUES (:tenant_id, :product_id, 'cpm', :currency, false, :price_guidance)
                 """
                     ),
                     {


### PR DESCRIPTION
## Summary
Fixes production crash loop by removing references to non-existent `created_at` and `updated_at` columns in pricing_options migration.

## Problem
Production failing with:
```
column "created_at" of relation "pricing_options" does not exist
```

The migration `5d949a78d36f` was trying to INSERT into `created_at` and `updated_at` columns, but the `pricing_options` table (created in `c3b75d304773`) doesn't have those columns.

## Root Cause
- Table created without timestamp columns
- Data migration assumed they existed
- PricingOption model also doesn't define these columns

## Solution
Removed `created_at` and `updated_at` from both INSERT statements in the migration, matching the actual table schema.

## Testing
- ✅ Unit tests pass
- ✅ Integration tests pass
- ✅ Migration syntax validated

## Impact
🚨 **CRITICAL** - Unblocks production deployment (currently stopped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)