### PR TITLE
Fix SQLAlchemy relationship overlap warnings

### DIFF
--- a/src/core/database/models.py
+++ b/src/core/database/models.py
@@ -1171,7 +1171,9 @@ class PushNotificationConfig(Base, JSONValidatorMixin):
 
     # Relationships
     tenant = relationship("Tenant", backref="push_notification_configs")
-    principal = relationship("Principal", backref="push_notification_configs", overlaps="push_notification_configs")
+    principal = relationship(
+        "Principal", backref="push_notification_configs", overlaps="push_notification_configs,tenant"
+    )
 
     __table_args__ = (
         ForeignKeyConstraint(["tenant_id"], ["tenants.tenant_id"], ondelete="CASCADE"),


### PR DESCRIPTION
## Summary
Fixes SQLAlchemy warnings about overlapping `tenant_id` column references in PushNotificationConfig relationships.

## Problem
Production logs show warnings:
```
SAWarning: relationship 'Principal.push_notification_configs' will copy column principals.tenant_id 
to column push_notification_configs.tenant_id, which conflicts with relationship(s): 
'PushNotificationConfig.tenant' (copies tenants.tenant_id to push_notification_configs.tenant_id)
```

## Root Cause
Both `tenant` and `principal` relationships copy `tenant_id` to the same column due to the composite foreign key structure. This is expected behavior but generates warnings.

## Solution
Added `overlaps="push_notification_configs,tenant"` parameter to the `principal` relationship to silence the warning.

## Testing
- ✅ Unit tests pass
- ✅ Integration tests pass
- ⚠️ Warning may still appear in some test contexts (backref behavior)

## Notes
May need follow-up to use explicit relationships instead of backref for full warning elimination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)