### PR TITLE
Fix get_products A2A error: remove adcp_version from schema helper call

### DIFF
--- a/src/core/tools.py
+++ b/src/core/tools.py
@@ -119,7 +119,6 @@ async def get_products_raw(
         brief=brief or "",
         promoted_offering=promoted_offering,
         brand_manifest=brand_manifest,
-        adcp_version=adcp_version,
         filters=filters,
     )
 


### PR DESCRIPTION
## Problem
A2A clients calling `get_products` were getting this error:
```
create_get_products_request() got an unexpected keyword argument 'adcp_version'
```

## Root Cause
The `get_products_raw` function in `src/core/tools.py` was passing `adcp_version` to `create_get_products_request`, but the schema helper doesn't accept this parameter.

## Solution
- Removed `adcp_version` from the `create_get_products_request` call
- Kept the `adcp_version` parameter in `get_products_raw` signature for backward compatibility (callers may still pass it)
- The parameter is vestigial - it's not needed for request construction

## Testing
- All unit tests pass (697 passed)
- All integration tests pass (192 passed)
- Pre-commit hooks verified (including AdCP contract tests)

## Impact
- ✅ Fixes A2A `get_products` calls
- ✅ No breaking changes to API
- ✅ Backward compatible