### PR TITLE
Fix settings page errors in production

### DIFF
--- a/src/admin/blueprints/tenants.py
+++ b/src/admin/blueprints/tenants.py
@@ -233,8 +233,13 @@ def tenant_settings(tenant_id, section=None):
             # Get creative formats
             from src.core.database.models import CreativeFormat
 
-            stmt = select(CreativeFormat).filter_by(tenant_id=tenant_id)
-            creative_formats = db_session.scalars(stmt).all()
+            try:
+                stmt = select(CreativeFormat).filter_by(tenant_id=tenant_id)
+                creative_formats = db_session.scalars(stmt).all()
+            except Exception as e:
+                # Table may not exist in older databases - gracefully handle
+                logger.warning(f"Could not load creative formats: {e}")
+                creative_formats = []
 
             # Get inventory counts
             from src.core.database.models import GAMInventory

--- a/src/admin/utils.py
+++ b/src/admin/utils.py
@@ -94,8 +94,8 @@ def get_tenant_config_from_db(tenant_id):
                 config["adapters"] = adapter_config
 
             # Build features config from individual columns
+            # Note: max_daily_budget moved to currency_limits table (per-currency limits)
             config["features"] = {
-                "max_daily_budget": tenant.max_daily_budget,
                 "enable_axe_signals": tenant.enable_axe_signals,
             }
 


### PR DESCRIPTION
## Summary
Fixes two critical errors preventing the settings page from loading in production:

1. **AttributeError: 'Tenant' object has no attribute 'max_daily_budget'**
   - The `max_daily_budget` field was moved to the `currency_limits` table in previous migrations
   - Removed reference from `utils.py` that was still trying to access it

2. **ProgrammingError: relation 'creative_formats' does not exist**
   - Production database may not have the `creative_formats` table yet
   - Added graceful error handling to return empty list if table is missing

## Changes
- **src/admin/utils.py**: Remove `max_daily_budget` from features config
- **src/admin/blueprints/tenants.py**: Wrap `creative_formats` query in try-except

## Testing
- ✅ Unit tests pass
- ✅ Integration tests pass  
- ✅ Imports validate successfully
- ✅ No regressions in other functionality

## Impact
- Settings page will now load successfully in production
- No functionality is lost (max_daily_budget is in currency_limits table)
- Graceful degradation if creative_formats table doesn't exist yet

Fixes the production error reported by user.