### PR TITLE
Fix typo: addagents.json → adagents.json

### DIFF
--- a/src/services/setup_checklist_service.py
+++ b/src/services/setup_checklist_service.py
@@ -149,7 +149,7 @@ class SetupChecklistService:
             SetupTask(
                 key="authorized_properties",
                 name="Authorized Properties",
-                description="Configure properties with addagents.json for verification",
+                description="Configure properties with adagents.json for verification",
                 is_complete=property_count > 0,
                 action_url=f"/tenant/{self.tenant_id}/authorized-properties",
                 details=f"{property_count} properties configured" if property_count > 0 else "No properties configured",


### PR DESCRIPTION
## Summary
- Fixed typo in authorized properties setup checklist description
- Changed `addagents.json` to correct spelling `adagents.json`
- Single-line string fix in `src/services/setup_checklist_service.py:152`

## Test plan
- [x] Unit tests pass
- [x] Integration tests pass
- [x] No functional changes, string-only correction

🤖 Generated with [Claude Code](https://claude.com/claude-code)