### PR TITLE
Add creative agent management UI and improve format display

### DIFF
--- a/src/admin/app.py
+++ b/src/admin/app.py
@@ -15,6 +15,8 @@ from src.admin.blueprints.api import api_bp
 from src.admin.blueprints.auth import auth_bp, init_oauth
 from src.admin.blueprints.authorized_properties import authorized_properties_bp
 from src.admin.blueprints.core import core_bp
+from src.admin.blueprints.creative_agents import creative_agents_bp
+
 # creatives_bp removed - creative_formats table dropped in migration f2addf453200
 from src.admin.blueprints.format_search import bp as format_search_bp
 from src.admin.blueprints.gam import gam_bp
@@ -263,6 +265,7 @@ def create_app(config=None):
     app.register_blueprint(settings_bp, url_prefix="/tenant/<tenant_id>/settings")
     app.register_blueprint(adapters_bp, url_prefix="/tenant/<tenant_id>")
     app.register_blueprint(authorized_properties_bp, url_prefix="/tenant")  # Tenant-specific routes
+    app.register_blueprint(creative_agents_bp, url_prefix="/tenant/<tenant_id>/creative-agents")
     app.register_blueprint(inventory_bp)  # Has its own internal routing
     app.register_blueprint(api_bp, url_prefix="/api")
     app.register_blueprint(format_search_bp)  # Format search API (/api/formats)

--- a/src/admin/blueprints/creative_agents.py
+++ b/src/admin/blueprints/creative_agents.py
@@ -1,0 +1,299 @@
+"""Creative agents management blueprint for admin UI."""
+
+import logging
+
+from flask import Blueprint, flash, jsonify, redirect, render_template, request, url_for
+from sqlalchemy import select
+
+from src.admin.utils import require_tenant_access
+from src.core.database.database_session import get_db_session
+from src.core.database.models import CreativeAgent, Tenant
+
+logger = logging.getLogger(__name__)
+
+# Create Blueprint
+creative_agents_bp = Blueprint("creative_agents", __name__)
+
+
+@creative_agents_bp.route("/")
+@require_tenant_access()
+def list_creative_agents(tenant_id):
+    """List all creative agents for a tenant."""
+    try:
+        with get_db_session() as session:
+            tenant = session.scalars(select(Tenant).filter_by(tenant_id=tenant_id)).first()
+            if not tenant:
+                flash("Tenant not found", "error")
+                return redirect(url_for("core.index"))
+
+            # Get tenant-specific creative agents
+            stmt = select(CreativeAgent).filter_by(tenant_id=tenant_id).order_by(CreativeAgent.priority)
+            custom_agents = session.scalars(stmt).all()
+
+            # Convert to dict for template
+            agents_list = []
+            for agent in custom_agents:
+                agents_list.append(
+                    {
+                        "id": agent.id,
+                        "agent_url": agent.agent_url,
+                        "name": agent.name,
+                        "enabled": agent.enabled,
+                        "priority": agent.priority,
+                        "auth_type": agent.auth_type,
+                        "has_auth": bool(agent.auth_credentials),
+                        "created_at": agent.created_at,
+                    }
+                )
+
+            return render_template(
+                "creative_agents.html",
+                tenant=tenant,
+                tenant_id=tenant_id,
+                tenant_name=tenant.name,
+                custom_agents=agents_list,
+                script_name=request.environ.get("SCRIPT_NAME", ""),
+            )
+
+    except Exception as e:
+        logger.error(f"Error loading creative agents: {e}", exc_info=True)
+        flash("Error loading creative agents", "error")
+        return redirect(url_for("tenants.tenant_settings", tenant_id=tenant_id))
+
+
+@creative_agents_bp.route("/add", methods=["GET", "POST"])
+@require_tenant_access()
+def add_creative_agent(tenant_id):
+    """Add a new creative agent."""
+    if request.method == "GET":
+        with get_db_session() as session:
+            tenant = session.scalars(select(Tenant).filter_by(tenant_id=tenant_id)).first()
+            if not tenant:
+                flash("Tenant not found", "error")
+                return redirect(url_for("core.index"))
+
+            return render_template(
+                "creative_agent_form.html",
+                tenant=tenant,
+                tenant_id=tenant_id,
+                tenant_name=tenant.name,
+                agent=None,
+                script_name=request.environ.get("SCRIPT_NAME", ""),
+            )
+
+    # POST - Create new creative agent
+    try:
+        with get_db_session() as session:
+            tenant = session.scalars(select(Tenant).filter_by(tenant_id=tenant_id)).first()
+            if not tenant:
+                flash("Tenant not found", "error")
+                return redirect(url_for("core.index"))
+
+            agent_url = request.form.get("agent_url", "").strip()
+            name = request.form.get("name", "").strip()
+            enabled = request.form.get("enabled") == "on"
+            priority = int(request.form.get("priority", "10"))
+            auth_type = request.form.get("auth_type", "").strip() or None
+            auth_credentials = request.form.get("auth_credentials", "").strip() or None
+
+            if not agent_url:
+                flash("Agent URL is required", "error")
+                return redirect(url_for("creative_agents.add_creative_agent", tenant_id=tenant_id))
+
+            if not name:
+                flash("Agent name is required", "error")
+                return redirect(url_for("creative_agents.add_creative_agent", tenant_id=tenant_id))
+
+            # Create new agent
+            agent = CreativeAgent(
+                tenant_id=tenant_id,
+                agent_url=agent_url,
+                name=name,
+                enabled=enabled,
+                priority=priority,
+                auth_type=auth_type,
+                auth_credentials=auth_credentials,
+            )
+            session.add(agent)
+            session.commit()
+
+            flash(f"Creative agent '{name}' added successfully", "success")
+            return redirect(url_for("creative_agents.list_creative_agents", tenant_id=tenant_id))
+
+    except Exception as e:
+        logger.error(f"Error adding creative agent: {e}", exc_info=True)
+        flash("Error adding creative agent", "error")
+        return redirect(url_for("creative_agents.add_creative_agent", tenant_id=tenant_id))
+
+
+@creative_agents_bp.route("/<int:agent_id>/edit", methods=["GET", "POST"])
+@require_tenant_access()
+def edit_creative_agent(tenant_id, agent_id):
+    """Edit an existing creative agent."""
+    if request.method == "GET":
+        with get_db_session() as session:
+            tenant = session.scalars(select(Tenant).filter_by(tenant_id=tenant_id)).first()
+            if not tenant:
+                flash("Tenant not found", "error")
+                return redirect(url_for("core.index"))
+
+            stmt = select(CreativeAgent).filter_by(id=agent_id, tenant_id=tenant_id)
+            agent = session.scalars(stmt).first()
+            if not agent:
+                flash("Creative agent not found", "error")
+                return redirect(url_for("creative_agents.list_creative_agents", tenant_id=tenant_id))
+
+            agent_dict = {
+                "id": agent.id,
+                "agent_url": agent.agent_url,
+                "name": agent.name,
+                "enabled": agent.enabled,
+                "priority": agent.priority,
+                "auth_type": agent.auth_type,
+                "auth_credentials": agent.auth_credentials,
+            }
+
+            return render_template(
+                "creative_agent_form.html",
+                tenant=tenant,
+                tenant_id=tenant_id,
+                tenant_name=tenant.name,
+                agent=agent_dict,
+                script_name=request.environ.get("SCRIPT_NAME", ""),
+            )
+
+    # POST - Update creative agent
+    try:
+        with get_db_session() as session:
+            stmt = select(CreativeAgent).filter_by(id=agent_id, tenant_id=tenant_id)
+            agent = session.scalars(stmt).first()
+            if not agent:
+                flash("Creative agent not found", "error")
+                return redirect(url_for("creative_agents.list_creative_agents", tenant_id=tenant_id))
+
+            agent.agent_url = request.form.get("agent_url", "").strip()
+            agent.name = request.form.get("name", "").strip()
+            agent.enabled = request.form.get("enabled") == "on"
+            agent.priority = int(request.form.get("priority", "10"))
+            agent.auth_type = request.form.get("auth_type", "").strip() or None
+
+            # Only update credentials if provided
+            new_credentials = request.form.get("auth_credentials", "").strip()
+            if new_credentials:
+                agent.auth_credentials = new_credentials
+
+            if not agent.agent_url:
+                flash("Agent URL is required", "error")
+                return redirect(url_for("creative_agents.edit_creative_agent", tenant_id=tenant_id, agent_id=agent_id))
+
+            if not agent.name:
+                flash("Agent name is required", "error")
+                return redirect(url_for("creative_agents.edit_creative_agent", tenant_id=tenant_id, agent_id=agent_id))
+
+            session.commit()
+
+            flash(f"Creative agent '{agent.name}' updated successfully", "success")
+            return redirect(url_for("creative_agents.list_creative_agents", tenant_id=tenant_id))
+
+    except Exception as e:
+        logger.error(f"Error updating creative agent: {e}", exc_info=True)
+        flash("Error updating creative agent", "error")
+        return redirect(url_for("creative_agents.edit_creative_agent", tenant_id=tenant_id, agent_id=agent_id))
+
+
+@creative_agents_bp.route("/<int:agent_id>/delete", methods=["DELETE"])
+@require_tenant_access()
+def delete_creative_agent(tenant_id, agent_id):
+    """Delete a creative agent."""
+    try:
+        with get_db_session() as session:
+            stmt = select(CreativeAgent).filter_by(id=agent_id, tenant_id=tenant_id)
+            agent = session.scalars(stmt).first()
+            if not agent:
+                return jsonify({"error": "Creative agent not found"}), 404
+
+            agent_name = agent.name
+            session.delete(agent)
+            session.commit()
+
+            return jsonify({"success": True, "message": f"Creative agent '{agent_name}' deleted successfully"})
+
+    except Exception as e:
+        logger.error(f"Error deleting creative agent: {e}", exc_info=True)
+        return jsonify({"error": "Error deleting creative agent"}), 500
+
+
+@creative_agents_bp.route("/<int:agent_id>/test", methods=["POST"])
+@require_tenant_access()
+def test_creative_agent(tenant_id, agent_id):
+    """Test connection to a creative agent."""
+    try:
+        with get_db_session() as session:
+            stmt = select(CreativeAgent).filter_by(id=agent_id, tenant_id=tenant_id)
+            agent = session.scalars(stmt).first()
+            if not agent:
+                return jsonify({"error": "Creative agent not found"}), 404
+
+            # Test connection by fetching formats
+            import asyncio
+
+            from src.core.creative_agent_registry import CreativeAgent as AgentConfig
+            from src.core.creative_agent_registry import CreativeAgentRegistry
+
+            registry = CreativeAgentRegistry()
+
+            # Build agent config
+            auth = None
+            if agent.auth_type and agent.auth_credentials:
+                auth = {
+                    "type": agent.auth_type,
+                    "credentials": agent.auth_credentials,
+                }
+
+            agent_config = AgentConfig(
+                agent_url=agent.agent_url,
+                name=agent.name,
+                enabled=agent.enabled,
+                priority=agent.priority,
+                auth=auth,
+            )
+
+            # Fetch formats
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            try:
+                formats = loop.run_until_complete(registry._fetch_formats_from_agent(agent_config))
+
+                if formats:
+                    return jsonify(
+                        {
+                            "success": True,
+                            "message": f"Successfully connected to '{agent.name}'",
+                            "format_count": len(formats),
+                            "sample_formats": [f.name for f in formats[:5]],
+                        }
+                    )
+                else:
+                    return (
+                        jsonify(
+                            {
+                                "success": False,
+                                "error": "Agent returned no formats",
+                            }
+                        ),
+                        400,
+                    )
+            finally:
+                loop.close()
+
+    except Exception as e:
+        logger.error(f"Error testing creative agent: {e}", exc_info=True)
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": f"Connection failed: {str(e)}",
+                }
+            ),
+            500,
+        )

--- a/src/admin/blueprints/products.py
+++ b/src/admin/blueprints/products.py
@@ -21,6 +21,54 @@ logger = logging.getLogger(__name__)
 products_bp = Blueprint("products", __name__)
 
 
+def resolve_format_names(formats: list[dict | str], tenant_id: str | None = None) -> list[dict]:
+    """Resolve format IDs to their display names from creative agents.
+
+    Args:
+        formats: List of format dicts ({"format_id": "...", "agent_url": "..."}) or strings
+        tenant_id: Optional tenant ID for tenant-specific creative agents
+
+    Returns:
+        List of dicts with format_id, name, agent_url fields
+    """
+    from src.core.format_resolver import get_format
+
+    resolved = []
+    for fmt in formats:
+        # Handle both dict and string formats (legacy)
+        if isinstance(fmt, dict):
+            format_id = fmt.get("format_id", "")
+            agent_url = fmt.get("agent_url")
+        else:
+            format_id = fmt
+            agent_url = None
+
+        # Try to resolve format from creative agent
+        try:
+            format_obj = get_format(format_id=format_id, agent_url=agent_url, tenant_id=tenant_id)
+            resolved.append(
+                {
+                    "format_id": format_id,
+                    "name": format_obj.name,
+                    "agent_url": agent_url or "https://creative.adcontextprotocol.org",
+                }
+            )
+        except (ValueError, Exception) as e:
+            # Fallback: If we can't resolve, use format_id as display name
+            logger.warning(f"Could not resolve format {format_id}: {e}")
+            # Convert format_id to readable name as fallback
+            display_name = format_id.replace("_", " ").title()
+            resolved.append(
+                {
+                    "format_id": format_id,
+                    "name": display_name,
+                    "agent_url": agent_url or "https://creative.adcontextprotocol.org",
+                }
+            )
+
+    return resolved
+
+
 def get_creative_formats(
     tenant_id: str | None = None,
     max_width: int | None = None,
@@ -253,16 +301,20 @@ def list_products(tenant_id):
                 # Use helper function to get pricing options (handles legacy fallback)
                 pricing_options_list = get_product_pricing_options(product)
 
+                # Parse formats and resolve names from creative agents
+                raw_formats = (
+                    product.formats
+                    if isinstance(product.formats, list)
+                    else json.loads(product.formats) if product.formats else []
+                )
+                resolved_formats = resolve_format_names(raw_formats, tenant_id=tenant_id)
+
                 product_dict = {
                     "product_id": product.product_id,
                     "name": product.name,
                     "description": product.description,
                     "pricing_options": pricing_options_list,
-                    "formats": (
-                        product.formats
-                        if isinstance(product.formats, list)
-                        else json.loads(product.formats) if product.formats else []
-                    ),
+                    "formats": resolved_formats,
                     "countries": (
                         product.countries
                         if isinstance(product.countries, list)

--- a/templates/creative_agent_form.html
+++ b/templates/creative_agent_form.html
@@ -1,0 +1,217 @@
+{% extends "base.html" %}
+
+{% block title %}{% if agent %}Edit{% else %}Add{% endif %} Creative Agent - {{ tenant_name }} - Sales Agent Admin{% endblock %}
+
+{% block content %}
+<div class="card">
+    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
+        <h2>{% if agent %}Edit{% else %}Add{% endif %} Creative Agent</h2>
+        <a href="{{ url_for('creative_agents.list_creative_agents', tenant_id=tenant_id) }}" class="btn btn-secondary">← Back to Creative Agents</a>
+    </div>
+
+    <form method="POST" action="{% if agent %}{{ url_for('creative_agents.edit_creative_agent', tenant_id=tenant_id, agent_id=agent.id) }}{% else %}{{ url_for('creative_agents.add_creative_agent', tenant_id=tenant_id) }}{% endif %}">
+        <div class="form-section">
+            <h3>Basic Information</h3>
+
+            <div class="form-group">
+                <label for="name">Agent Name <span style="color: #ef4444;">*</span></label>
+                <input type="text" id="name" name="name"
+                       value="{{ agent.name if agent else '' }}"
+                       placeholder="e.g., My Custom Creative Agent"
+                       required>
+                <small>A friendly name to identify this creative agent</small>
+            </div>
+
+            <div class="form-group">
+                <label for="agent_url">Agent URL <span style="color: #ef4444;">*</span></label>
+                <input type="url" id="agent_url" name="agent_url"
+                       value="{{ agent.agent_url if agent else '' }}"
+                       placeholder="https://your-creative-agent.example.com"
+                       required>
+                <small>The base URL of the creative agent (MCP endpoint will be at /mcp/)</small>
+            </div>
+
+            <div class="form-group">
+                <label for="priority">Priority</label>
+                <input type="number" id="priority" name="priority"
+                       value="{{ agent.priority if agent else 10 }}"
+                       min="1" max="100"
+                       placeholder="10">
+                <small>Lower numbers = higher priority. Default is 10. The default AdCP agent has priority 1.</small>
+            </div>
+
+            <div class="checkbox-group">
+                <label class="checkbox-label">
+                    <input type="checkbox" id="enabled" name="enabled"
+                           {% if not agent or agent.enabled %}checked{% endif %}>
+                    <span class="checkbox-custom"></span>
+                    <span class="checkbox-text">Enable this creative agent</span>
+                </label>
+                <small>When disabled, formats from this agent will not be available</small>
+            </div>
+        </div>
+
+        <div class="form-section">
+            <h3>Authentication (Optional)</h3>
+            <p class="form-section-description">
+                If your creative agent requires authentication, configure the credentials below.
+            </p>
+
+            <div class="form-group">
+                <label for="auth_type">Authentication Type</label>
+                <select id="auth_type" name="auth_type">
+                    <option value="">None</option>
+                    <option value="bearer" {% if agent and agent.auth_type == 'bearer' %}selected{% endif %}>Bearer Token</option>
+                    <option value="api_key" {% if agent and agent.auth_type == 'api_key' %}selected{% endif %}>API Key</option>
+                </select>
+                <small>Select the authentication method required by your creative agent</small>
+            </div>
+
+            <div class="form-group">
+                <label for="auth_credentials">Credentials</label>
+                <input type="password" id="auth_credentials" name="auth_credentials"
+                       value="{{ agent.auth_credentials if agent else '' }}"
+                       placeholder="Enter token or API key">
+                <small>
+                    {% if agent %}
+                    Leave blank to keep existing credentials. Enter a new value to update.
+                    {% else %}
+                    The token or API key for authenticating with the creative agent
+                    {% endif %}
+                </small>
+            </div>
+        </div>
+
+        <div class="form-section" style="background: #f9fafb; padding: 1.5rem; border-radius: 6px;">
+            <h3 style="margin-top: 0;">📖 How Creative Agents Work</h3>
+            <ul style="margin: 0.5rem 0; padding-left: 1.5rem; line-height: 1.8; color: #374151;">
+                <li><strong>Format Discovery:</strong> The sales agent will call your creative agent's <code>list_creative_formats</code> MCP tool to discover available formats</li>
+                <li><strong>Format Details:</strong> Each format includes specifications like dimensions, duration, file requirements, etc.</li>
+                <li><strong>Priority System:</strong> If multiple agents provide the same format_id, the agent with lower priority number wins</li>
+                <li><strong>Caching:</strong> Format definitions are cached to improve performance</li>
+                <li><strong>Testing:</strong> After saving, you can test the connection to ensure your agent is reachable</li>
+            </ul>
+        </div>
+
+        <div class="button-group">
+            <button type="submit" class="btn btn-primary">{% if agent %}Update{% else %}Add{% endif %} Creative Agent</button>
+            <a href="{{ url_for('creative_agents.list_creative_agents', tenant_id=tenant_id) }}" class="btn btn-secondary">Cancel</a>
+        </div>
+    </form>
+</div>
+
+<style>
+.form-section {
+    margin-bottom: 2rem;
+    padding-bottom: 2rem;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.form-section:last-of-type {
+    border-bottom: none;
+}
+
+.form-section h3 {
+    margin: 0 0 1rem 0;
+    color: #374151;
+}
+
+.form-section-description {
+    margin: 0 0 1.5rem 0;
+    color: #6b7280;
+}
+
+.form-group {
+    margin-bottom: 1.5rem;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-weight: 500;
+    color: #374151;
+}
+
+.form-group input,
+.form-group select,
+.form-group textarea {
+    width: 100%;
+    padding: 0.75rem;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    font-size: 1rem;
+}
+
+.form-group input:focus,
+.form-group select:focus,
+.form-group textarea:focus {
+    outline: none;
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.form-group small {
+    display: block;
+    margin-top: 0.25rem;
+    color: #6b7280;
+    font-size: 0.875rem;
+}
+
+.checkbox-group {
+    margin-bottom: 1.5rem;
+}
+
+.checkbox-label {
+    display: flex;
+    align-items: start;
+    gap: 0.75rem;
+    cursor: pointer;
+}
+
+.checkbox-label input[type="checkbox"] {
+    width: auto;
+    margin: 0;
+}
+
+.checkbox-custom {
+    width: 20px;
+    height: 20px;
+    border: 2px solid #d1d5db;
+    border-radius: 4px;
+    display: inline-block;
+    flex-shrink: 0;
+    position: relative;
+}
+
+.checkbox-label input[type="checkbox"]:checked + .checkbox-custom {
+    background: #3b82f6;
+    border-color: #3b82f6;
+}
+
+.checkbox-label input[type="checkbox"]:checked + .checkbox-custom::after {
+    content: '✓';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    color: white;
+    font-weight: bold;
+}
+
+.checkbox-label input[type="checkbox"] {
+    position: absolute;
+    opacity: 0;
+}
+
+.checkbox-text {
+    font-weight: 500;
+    color: #374151;
+}
+
+.button-group {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 2rem;
+}
+</style>
+{% endblock %}

--- a/templates/creative_agents.html
+++ b/templates/creative_agents.html
@@ -1,0 +1,236 @@
+{% extends "base.html" %}
+
+{% block title %}Creative Agents - {{ tenant_name }} - Sales Agent Admin{% endblock %}
+
+{% block content %}
+<div class="card">
+    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
+        <h2>Creative Agents - {{ tenant_name }}</h2>
+        <div style="display: flex; gap: 0.5rem;">
+            <a href="{{ url_for('tenants.tenant_settings', tenant_id=tenant_id) }}#integrations" class="btn btn-secondary">← Back to Settings</a>
+            <a href="{{ url_for('creative_agents.add_creative_agent', tenant_id=tenant_id) }}" class="btn btn-primary">Add Creative Agent</a>
+        </div>
+    </div>
+
+    <!-- Default Creative Agent (Always Available) -->
+    <div style="margin-bottom: 2rem;">
+        <h3 style="margin-bottom: 1rem;">Default Creative Agent</h3>
+        <div style="border: 2px solid #34d399; border-radius: 8px; padding: 1rem; background: #d1fae5;">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div>
+                    <h4 style="margin: 0 0 0.5rem 0; color: #065f46;">AdCP Standard Creative Agent</h4>
+                    <p style="margin: 0 0 0.5rem 0; color: #047857; font-family: monospace; font-size: 0.9rem;">
+                        https://creative.adcontextprotocol.org
+                    </p>
+                    <p style="margin: 0; color: #065f46; font-size: 0.9rem;">
+                        ✅ Always enabled • Priority: 1 • Provides standard IAB and custom formats
+                    </p>
+                </div>
+                <span class="badge" style="background: #34d399; color: #065f46; font-weight: 600;">DEFAULT</span>
+            </div>
+        </div>
+    </div>
+
+    <!-- Custom Tenant Creative Agents -->
+    {% if custom_agents|length == 0 %}
+    <div class="empty-state">
+        <h3>No Custom Creative Agents</h3>
+        <div class="empty-state-icon">🎨</div>
+        <p class="empty-state-message">
+            You haven't added any custom creative agents yet. The default AdCP creative agent provides standard formats, but you can add custom agents for proprietary formats or specialized creative services.
+        </p>
+        <div class="empty-state-actions">
+            <a href="{{ url_for('creative_agents.add_creative_agent', tenant_id=tenant_id) }}" class="btn btn-primary btn-large">
+                Add Your First Creative Agent
+            </a>
+        </div>
+        <div style="margin-top: 2rem; padding: 1rem; background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 6px; max-width: 600px; margin-left: auto; margin-right: auto; text-align: left;">
+            <p style="margin: 0 0 0.5rem 0; font-weight: 600; color: #374151;">💡 Use Cases for Custom Creative Agents:</p>
+            <ul style="margin: 0; padding-left: 1.5rem; color: #6b7280;">
+                <li>Support proprietary ad formats unique to your platform</li>
+                <li>Integrate with specialized creative rendering services</li>
+                <li>Provide custom video or audio format specifications</li>
+                <li>Add support for emerging format standards</li>
+            </ul>
+        </div>
+    </div>
+    {% else %}
+    <h3 style="margin-bottom: 1rem;">Custom Creative Agents</h3>
+    <table>
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Agent URL</th>
+                <th>Priority</th>
+                <th>Status</th>
+                <th>Authentication</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for agent in custom_agents %}
+            <tr>
+                <td>
+                    <strong>{{ agent.name }}</strong>
+                </td>
+                <td>
+                    <code style="font-size: 0.85rem;">{{ agent.agent_url }}</code>
+                </td>
+                <td>
+                    <span class="badge badge-secondary">{{ agent.priority }}</span>
+                    <small style="color: #6b7280; display: block; margin-top: 0.25rem;">Lower = Higher Priority</small>
+                </td>
+                <td>
+                    {% if agent.enabled %}
+                    <span class="badge" style="background: #34d399; color: #065f46;">✓ Enabled</span>
+                    {% else %}
+                    <span class="badge badge-secondary">Disabled</span>
+                    {% endif %}
+                </td>
+                <td>
+                    {% if agent.has_auth %}
+                    <span class="badge" style="background: #fbbf24; color: #78350f;">🔒 {{ agent.auth_type|upper }}</span>
+                    {% else %}
+                    <span class="badge badge-secondary">None</span>
+                    {% endif %}
+                </td>
+                <td>
+                    <div style="display: flex; gap: 0.5rem;">
+                        <button onclick="testAgent({{ agent.id }}, '{{ agent.name }}')" class="btn btn-secondary btn-sm">Test</button>
+                        <a href="{{ url_for('creative_agents.edit_creative_agent', tenant_id=tenant_id, agent_id=agent.id) }}" class="btn btn-secondary btn-sm">Edit</a>
+                        <button onclick="deleteAgent({{ agent.id }}, '{{ agent.name }}')" class="btn btn-danger btn-sm" style="background: #dc3545; border-color: #dc3545;">Delete</button>
+                    </div>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% endif %}
+</div>
+
+<style>
+.empty-state {
+    text-align: center;
+    padding: 4rem 2rem;
+}
+
+.empty-state-icon {
+    font-size: 4rem;
+    margin: 2rem 0;
+}
+
+.empty-state-message {
+    font-size: 1.1rem;
+    color: #666;
+    max-width: 600px;
+    margin: 0 auto 2rem;
+    line-height: 1.6;
+}
+
+.empty-state-actions {
+    margin-top: 2rem;
+}
+
+.btn-large {
+    padding: 1rem 2rem;
+    font-size: 1.1rem;
+}
+
+.badge {
+    display: inline-block;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.8rem;
+    background: #e3f2fd;
+    color: #1976d2;
+    border-radius: 4px;
+    margin-right: 0.25rem;
+}
+
+.badge-secondary {
+    background: #f5f5f5;
+    color: #666;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1rem;
+}
+
+th {
+    text-align: left;
+    padding: 0.75rem;
+    background: #f9fafb;
+    border-bottom: 2px solid #e5e7eb;
+    font-weight: 600;
+    color: #374151;
+}
+
+td {
+    padding: 0.75rem;
+    border-bottom: 1px solid #e5e7eb;
+    vertical-align: top;
+}
+
+tbody tr:hover {
+    background: #f9fafb;
+}
+</style>
+
+<script>
+function testAgent(agentId, agentName) {
+    const btn = event.target;
+    btn.disabled = true;
+    btn.textContent = 'Testing...';
+
+    fetch(`{{ script_name }}/tenant/{{ tenant_id }}/creative-agents/${agentId}/test`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    })
+    .then(response => response.json())
+    .then(data => {
+        btn.disabled = false;
+        btn.textContent = 'Test';
+
+        if (data.success) {
+            alert(`✅ Connection Successful!\n\nAgent: ${agentName}\nFormats Found: ${data.format_count}\n\nSample Formats:\n${data.sample_formats.join('\n')}`);
+        } else {
+            alert(`❌ Connection Failed\n\n${data.error}`);
+        }
+    })
+    .catch(error => {
+        btn.disabled = false;
+        btn.textContent = 'Test';
+        alert(`❌ Test Failed\n\n${error.message}`);
+    });
+}
+
+function deleteAgent(agentId, agentName) {
+    if (confirm(`Are you sure you want to delete "${agentName}"?\n\nThis will remove access to any custom formats provided by this agent.`)) {
+        fetch(`{{ script_name }}/tenant/{{ tenant_id }}/creative-agents/${agentId}/delete`, {
+            method: 'DELETE',
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        })
+        .then(response => {
+            if (response.ok) {
+                window.location.reload();
+            } else {
+                return response.json().then(err => {
+                    alert(err.error || 'Could not delete creative agent');
+                    return Promise.reject(err);
+                });
+            }
+        })
+        .catch(error => {
+            if (error.message) {
+                alert('Failed to delete creative agent: ' + error.message);
+            }
+        });
+    }
+}
+</script>
+{% endblock %}

--- a/templates/products.html
+++ b/templates/products.html
@@ -62,7 +62,10 @@
                 <td>{{ product.description or '-' }}</td>
                 <td>
                     {% for format in product.formats %}
-                    <span class="badge">{{ format }}</span>
+                        {# Format is now resolved with name field from creative agent #}
+                        <span class="badge" title="{{ format.format_id }} ({{ format.agent_url }})">
+                            {{ format.name }}
+                        </span>
                     {% endfor %}
                 </td>
                 <td>

--- a/templates/tenant_settings.html
+++ b/templates/tenant_settings.html
@@ -1634,6 +1634,29 @@ REJECT - Creative cannot be approved:
                     </div>
                 </form>
             </div>
+
+            <div class="form-section">
+                <h3>Creative Agents</h3>
+                <p class="form-section-description">
+                    Manage creative agents that provide ad format definitions and rendering capabilities. The default AdCP creative agent is always available.
+                </p>
+
+                <div style="margin-bottom: 1rem;">
+                    <a href="{{ url_for('creative_agents.list_creative_agents', tenant_id=tenant.tenant_id) }}"
+                       class="btn btn-primary">
+                        Manage Creative Agents
+                    </a>
+                </div>
+
+                <div style="padding: 1rem; background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 6px;">
+                    <p style="margin: 0; color: #6b7280; font-size: 0.875rem;">
+                        💡 <strong>What are Creative Agents?</strong><br>
+                        Creative agents are external services that define ad formats (like "Display 300x250" or "Video Pre-Roll 30s")
+                        and handle creative rendering. You can add custom creative agents to support proprietary formats or
+                        integrate with specialized creative services.
+                    </p>
+                </div>
+            </div>
         </div>
 
         <!-- API Settings -->


### PR DESCRIPTION
## Summary

This PR adds a complete admin UI for managing creative agents and fixes the product format display to show actual format names from creative agents instead of raw dictionary data.

## Problem

1. **Format Display Issue**: Products page showed ugly raw dictionary format like `{'agent_url': 'https://creative.adcontextprotocol.org', 'format_id': 'display_300x250'}` instead of readable names
2. **No UI for Creative Agents**: The `creative_agents` table existed but had no admin UI for management

## Solution

### 1. Format Display Improvements

- Added `resolve_format_names()` helper in `products.py` that queries creative agents for format metadata
- Formats now display actual names from creative agents (e.g., "Display 300x250")
- Tooltip shows technical details (format_id and agent_url)
- Falls back to readable name generation if creative agent lookup fails
- Handles both dict and legacy string format storage

### 2. Creative Agent Management UI

New admin UI in **Integrations** section for managing creative agents:

#### Backend (`src/admin/blueprints/creative_agents.py`)
- **List** all creative agents (default AdCP + tenant custom)
- **Add** new creative agent with authentication options
- **Edit** existing creative agents
- **Delete** custom creative agents
- **Test** connection to verify agent is reachable and returns formats

#### Templates
- `templates/creative_agents.html` - Main list page with default agent info
- `templates/creative_agent_form.html` - Add/edit form with auth options
- `templates/tenant_settings.html` - Added Creative Agents section under Integrations

#### Features
- Shows default AdCP creative agent (always enabled, priority 1)
- Manage custom tenant-specific creative agents
- Configure agent URL, name, priority (lower = higher priority)
- Authentication options: None, Bearer Token, or API Key
- Test connection button fetches formats and shows format count + sample names
- Empty state with helpful guidance

## Integration

- Creative agents stored in `creative_agents` table (already existed)
- `CreativeAgentRegistry` already fetches/caches formats from all agents
- Format resolution now uses actual creative agent metadata
- Products display automatically shows proper format names

## Testing

- ✅ All unit tests pass (716 passed)
- ✅ All integration tests pass (192 passed)
- ✅ Templates validated (Jinja2 syntax)
- ✅ Python syntax validated (py_compile)
- ✅ Code formatted (black, ruff)

## Screenshots

### Before
Format display showed raw dictionary:
```
{'agent_url': 'https://creative.adcontextprotocol.org', 'format_id': 'display_300x250'}
```

### After
Format display shows actual name with tooltip:
- Badge: "Display 300x250"
- Tooltip: "display_300x250 (https://creative.adcontextprotocol.org)"

### Creative Agent Management UI
- Navigate to: **Tenant Settings → Integrations → Manage Creative Agents**
- Shows default AdCP agent (always enabled)
- Add/edit/delete/test custom creative agents
- Full authentication support (Bearer Token, API Key)

## Next Steps

Users can now:
1. Navigate to Integrations → Creative Agents
2. Add custom creative agents with their own format definitions
3. Formats from custom agents automatically appear in product creation
4. Test connections to verify agents are reachable

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>