### PR TITLE
Add creative format preview popup with info icon

### DIFF
--- a/templates/add_product.html
+++ b/templates/add_product.html
@@ -66,6 +66,14 @@
         <!-- Hidden input to store selected format data -->
         <input type="hidden" id="formats-data" name="formats" value="">
 
+        <!-- Format Preview Modal -->
+        <div id="format-preview-modal" style="display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 1000; align-items: center; justify-content: center;">
+            <div style="background: white; border-radius: 8px; max-width: 600px; max-height: 80vh; overflow-y: auto; padding: 2rem; position: relative; box-shadow: 0 4px 20px rgba(0,0,0,0.3);">
+                <button onclick="closeFormatPreview()" style="position: absolute; top: 1rem; right: 1rem; background: none; border: none; font-size: 1.5rem; cursor: pointer; color: #666;">&times;</button>
+                <div id="format-preview-content"></div>
+            </div>
+        </div>
+
         <script>
         // Format selection state
         let selectedFormats = new Set();
@@ -154,12 +162,18 @@
                     const bgColor = isSelected ? '#f0f7ff' : '#f9f9f9';
                     const checkIcon = isSelected ? '✓ ' : '';
 
+                    // Check if format has preview info
+                    const hasPreview = format.preview_image || format.example_url || format.description;
+
                     html += `
                         <div style="border: 2px solid ${borderColor}; border-radius: 4px; padding: 0.75rem; background: ${bgColor}; min-height: 120px; cursor: pointer; transition: all 0.2s;"
                              onclick="toggleFormat('${format.format_id}', '${format.name}', '${format.agent_url || ''}')">
                             <div style="display: flex; gap: 0.5rem;">
                                 <div style="flex: 1;">
-                                    <div style="font-weight: 600; color: #333;">${checkIcon}${format.name}</div>
+                                    <div style="display: flex; align-items: center; gap: 0.5rem;">
+                                        <div style="font-weight: 600; color: #333;">${checkIcon}${format.name}</div>
+                                        ${hasPreview ? `<span class="info-icon" onclick="event.stopPropagation(); showFormatPreview('${format.format_id}')" style="cursor: pointer; color: #0066cc; font-size: 1rem;" title="Show preview">ℹ️</span>` : ''}
+                                    </div>
                                     ${format.description ? `<div style="color: #777; font-size: 0.85rem; margin-top: 0.25rem; line-height: 1.3;">${format.description}</div>` : ''}
                                     ${format.category === 'generative' ? '<span style="background: #9b59b6; color: white; font-size: 0.75rem; padding: 0.2rem 0.5rem; border-radius: 3px; margin-top: 0.5rem; display: inline-block;">AI Generated</span>' : ''}
                                 </div>
@@ -229,6 +243,82 @@
 
             document.getElementById('formats-data').value = JSON.stringify(formatRefs);
         }
+
+        function showFormatPreview(formatId) {
+            const format = allFormats.find(f => f.format_id === formatId);
+            if (!format) return;
+
+            const modal = document.getElementById('format-preview-modal');
+            const content = document.getElementById('format-preview-content');
+
+            let html = `
+                <h3 style="margin-top: 0; margin-bottom: 1rem; color: #333;">${format.name}</h3>
+            `;
+
+            // Description
+            if (format.description) {
+                html += `
+                    <div style="margin-bottom: 1rem;">
+                        <strong style="display: block; margin-bottom: 0.5rem; color: #555;">Description:</strong>
+                        <p style="margin: 0; color: #666; line-height: 1.5;">${format.description}</p>
+                    </div>
+                `;
+            }
+
+            // Preview Image (400x300 per AdCP spec)
+            if (format.preview_image) {
+                html += `
+                    <div style="margin-bottom: 1rem;">
+                        <strong style="display: block; margin-bottom: 0.5rem; color: #555;">Preview:</strong>
+                        <img src="${format.preview_image}" alt="${format.name} preview" style="max-width: 100%; height: auto; border: 1px solid #ddd; border-radius: 4px;">
+                    </div>
+                `;
+            }
+
+            // Example URL
+            if (format.example_url) {
+                html += `
+                    <div style="margin-bottom: 1rem;">
+                        <a href="${format.example_url}" target="_blank" class="btn btn-primary" style="display: inline-block;">
+                            View Interactive Demo →
+                        </a>
+                    </div>
+                `;
+            }
+
+            // Format details
+            html += `
+                <div style="margin-top: 1.5rem; padding: 1rem; background: #f8f9fa; border-radius: 4px;">
+                    <strong style="display: block; margin-bottom: 0.5rem; color: #555;">Format Details:</strong>
+                    <div style="font-size: 0.9rem; color: #666;">
+                        <div><strong>Format ID:</strong> <code>${format.format_id}</code></div>
+                        <div><strong>Type:</strong> ${format.type}</div>
+                        ${format.agent_url ? `<div><strong>Agent:</strong> ${format.agent_url}</div>` : ''}
+                    </div>
+                </div>
+            `;
+
+            content.innerHTML = html;
+            modal.style.display = 'flex';
+        }
+
+        function closeFormatPreview() {
+            document.getElementById('format-preview-modal').style.display = 'none';
+        }
+
+        // Close modal when clicking outside
+        document.getElementById('format-preview-modal').addEventListener('click', function(e) {
+            if (e.target === this) {
+                closeFormatPreview();
+            }
+        });
+
+        // Close modal on Escape key
+        document.addEventListener('keydown', function(e) {
+            if (e.key === 'Escape') {
+                closeFormatPreview();
+            }
+        });
         </script>
 
         <h3 style="margin-top: 2rem;">Pricing & Delivery</h3>

--- a/tests/e2e/schemas/v1/_schemas_v1_core_format_json.json
+++ b/tests/e2e/schemas/v1/_schemas_v1_core_format_json.json
@@ -25,7 +25,7 @@
     "preview_image": {
       "type": "string",
       "format": "uri",
-      "description": "Optional preview image URL for format browsing/discovery UI"
+      "description": "Optional preview image URL for format browsing/discovery UI. Should be 400x300px (4:3 aspect ratio) PNG or JPG. Used as thumbnail/card image in format browsers."
     },
     "example_url": {
       "type": "string",

--- a/tests/e2e/schemas/v1/_schemas_v1_media-buy_list-creative-formats-request_json.json
+++ b/tests/e2e/schemas/v1/_schemas_v1_media-buy_list-creative-formats-request_json.json
@@ -40,19 +40,19 @@
     },
     "max_width": {
       "type": "integer",
-      "description": "Maximum width in pixels (inclusive). Returns formats with width <= this value. Omit for responsive/fluid formats."
+      "description": "Maximum width in pixels (inclusive). Returns formats where ANY render has width <= this value. For multi-render formats, matches if at least one render fits."
     },
     "max_height": {
       "type": "integer",
-      "description": "Maximum height in pixels (inclusive). Returns formats with height <= this value. Omit for responsive/fluid formats."
+      "description": "Maximum height in pixels (inclusive). Returns formats where ANY render has height <= this value. For multi-render formats, matches if at least one render fits."
     },
     "min_width": {
       "type": "integer",
-      "description": "Minimum width in pixels (inclusive). Returns formats with width >= this value."
+      "description": "Minimum width in pixels (inclusive). Returns formats where ANY render has width >= this value."
     },
     "min_height": {
       "type": "integer",
-      "description": "Minimum height in pixels (inclusive). Returns formats with height >= this value."
+      "description": "Minimum height in pixels (inclusive). Returns formats where ANY render has height >= this value."
     },
     "is_responsive": {
       "type": "boolean",


### PR DESCRIPTION
## Summary
Adds an info icon (ℹ️) next to creative format names in the product creation flow. Clicking the icon displays a modal popup with format details without interfering with format selection.

## Changes
- **Info Icon**: Added next to format names when preview data is available (`preview_image`, `example_url`, or `description`)
- **Preview Modal**: Shows format name, description, 400×300px preview image, and link to interactive demo
- **Format Details**: Displays format ID, type, and agent URL
- **UX Improvements**: Modal closes via X button, clicking outside, or Escape key

## References
- Follows AdCP PR #121 spec for format visual presentation
- Implements `preview_image` (400×300px) and `example_url` fields per AdCP v2.4
- Updates cached schemas to match latest AdCP registry

## Testing
- ✅ Unit tests pass (716 passed, 38 skipped)
- ✅ Integration tests pass (192 passed, 250 skipped)
- ✅ Pre-commit hooks pass (AdCP schema sync, validation)

## Screenshots
The info icon appears next to format names and opens a modal with preview information:
- Preview image (400×300px per spec)
- Description and format details
- Link to interactive demo if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)