### PR TITLE
Fix: Add await to core_create_media_buy_tool call

### DIFF
--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -1164,7 +1164,7 @@ class AdCPRequestHandler(RequestHandler):
                 }
 
             # Call core function with AdCP spec-compliant parameters
-            response = core_create_media_buy_tool(
+            response = await core_create_media_buy_tool(
                 promoted_offering=parameters["promoted_offering"],
                 po_number=parameters.get("po_number", f"A2A-{uuid.uuid4().hex[:8]}"),
                 buyer_ref=parameters.get("buyer_ref", f"A2A-{tool_context.principal_id}"),


### PR DESCRIPTION
## Background
The `_handle_create_media_buy_skill` method was calling the asynchronous `core_create_media_buy_tool` function without `await`, leading to a `RuntimeWarning: coroutine 'create_media_buy_raw' was never awaited` and subsequent `AttributeError: 'coroutine' object has no attribute 'model_dump'`.

## Changes
- **`src/a2a_server/adcp_a2a_server.py`**: Added `await` keyword to the call of `core_create_media_buy_tool` on line 1167.

## Testing
- [ ] Manually verify that the `create_media_buy` functionality in A2A no longer produces the `RuntimeWarning` or `AttributeError`.
