### PR TITLE
Fix missing params in log_tool_activity

### DIFF
--- a/src/core/main.py
+++ b/src/core/main.py
@@ -899,6 +899,8 @@ def log_tool_activity(context: Context, tool_name: str, start_time: float = None
         audit_logger.log_operation(
             operation=tool_name,
             principal_name=principal_name,
+            principal_id=principal_id or "anonymous",
+            adapter_id="mcp_server",
             success=True,
             details=details,
         )


### PR DESCRIPTION
## Background
The "Recent Activity" dashboard and "Workflows -> Audit Logs" were not displaying any information because `log_tool_activity` was missing required parameters for `audit_logger.log_operation`.

## Changes
- Modified `src/core/main.py` to pass `principal_id` and `adapter_id` to `audit_logger.log_operation`.
  - `principal_id` is now set to `principal_id or "anonymous"`.
  - `adapter_id` is now set to `"mcp_server"`.

## Testing
- [ ] Verify "Recent Activity" dashboard populates with MCP tool invocations.
- [ ] Verify "Workflows -> Audit Logs" page populates with operation logs.
- [ ] Check that activity tracking for new MCP tool calls is functioning.
