### PR TITLE
Remove format_ids backward compatibility

### DIFF
--- a/src/core/schemas.py
+++ b/src/core/schemas.py
@@ -915,25 +915,20 @@ class ProductFilters(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def upgrade_legacy_format_ids(cls, values: dict) -> dict:
-        """Upgrade legacy string format_ids to FormatId objects for backward compatibility."""
+        """Convert dict format_ids to FormatId objects (AdCP v2.4 compliance)."""
         if not isinstance(values, dict):
             return values
 
         format_ids = values.get("format_ids")
         if format_ids and isinstance(format_ids, list):
-            from src.core.format_cache import upgrade_legacy_format_id
-
-            # Upgrade any string format_ids to FormatId objects
+            # Convert any dict format_ids to FormatId objects
             upgraded = []
             for fmt_id in format_ids:
-                if isinstance(fmt_id, str):
-                    # Legacy string format_id - upgrade to FormatId object
-                    upgraded.append(upgrade_legacy_format_id(fmt_id))
-                elif isinstance(fmt_id, dict) and "agent_url" in fmt_id and "id" in fmt_id:
+                if isinstance(fmt_id, dict) and "agent_url" in fmt_id and "id" in fmt_id:
                     # Dict with FormatId structure - convert to FormatId object
                     upgraded.append(FormatId(**fmt_id))
                 else:
-                    # Already a FormatId object or other type - pass through
+                    # Already a FormatId object - pass through
                     upgraded.append(fmt_id)
             values["format_ids"] = upgraded
 
@@ -1110,25 +1105,20 @@ class ListCreativeFormatsRequest(AdCPBaseModel):
     @model_validator(mode="before")
     @classmethod
     def upgrade_legacy_format_ids(cls, values: dict) -> dict:
-        """Upgrade legacy string format_ids to FormatId objects for backward compatibility."""
+        """Convert dict format_ids to FormatId objects (AdCP v2.4 compliance)."""
         if not isinstance(values, dict):
             return values
 
         format_ids = values.get("format_ids")
         if format_ids and isinstance(format_ids, list):
-            from src.core.format_cache import upgrade_legacy_format_id
-
-            # Upgrade any string format_ids to FormatId objects
+            # Convert any dict format_ids to FormatId objects
             upgraded = []
             for fmt_id in format_ids:
-                if isinstance(fmt_id, str):
-                    # Legacy string format_id - upgrade to FormatId object
-                    upgraded.append(upgrade_legacy_format_id(fmt_id))
-                elif isinstance(fmt_id, dict) and "agent_url" in fmt_id and "id" in fmt_id:
+                if isinstance(fmt_id, dict) and "agent_url" in fmt_id and "id" in fmt_id:
                     # Dict with FormatId structure - convert to FormatId object
                     upgraded.append(FormatId(**fmt_id))
                 else:
-                    # Already a FormatId object or other type - pass through
+                    # Already a FormatId object - pass through
                     upgraded.append(fmt_id)
             values["format_ids"] = upgraded
 
@@ -2034,10 +2024,10 @@ class Package(BaseModel):
     creative_assignments: list[dict[str, Any]] | None = Field(
         None, description="Creative assets assigned to this package"
     )
-    # AdCP v2.4 request field (input) - array of FormatId objects (or legacy strings)
-    format_ids: list[FormatId | str] | None = Field(
+    # AdCP v2.4 request field (input) - array of FormatId objects
+    format_ids: list[FormatId] | None = Field(
         None,
-        description="Format IDs for this package (array of FormatId objects with agent_url and id, or legacy string format_ids)",
+        description="Format IDs for this package (array of FormatId objects with agent_url and id per AdCP v2.4)",
     )
 
     # AdCP v2.4 response field (output) - array of FormatId objects
@@ -2068,25 +2058,20 @@ class Package(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def upgrade_legacy_format_ids(cls, values: dict) -> dict:
-        """Upgrade legacy string format_ids to FormatId objects for backward compatibility."""
+        """Convert dict format_ids to FormatId objects (AdCP v2.4 compliance)."""
         if not isinstance(values, dict):
             return values
 
         format_ids = values.get("format_ids")
         if format_ids and isinstance(format_ids, list):
-            from src.core.format_cache import upgrade_legacy_format_id
-
-            # Upgrade any string format_ids to FormatId objects
+            # Convert any dict format_ids to FormatId objects
             upgraded = []
             for fmt_id in format_ids:
-                if isinstance(fmt_id, str):
-                    # Legacy string format_id - upgrade to FormatId object
-                    upgraded.append(upgrade_legacy_format_id(fmt_id))
-                elif isinstance(fmt_id, dict) and "agent_url" in fmt_id and "id" in fmt_id:
+                if isinstance(fmt_id, dict) and "agent_url" in fmt_id and "id" in fmt_id:
                     # Dict with FormatId structure - convert to FormatId object
                     upgraded.append(FormatId(**fmt_id))
                 else:
-                    # Already a FormatId object or other type - pass through
+                    # Already a FormatId object - pass through
                     upgraded.append(fmt_id)
             values["format_ids"] = upgraded
 

--- a/tests/integration/test_list_creative_formats_params.py
+++ b/tests/integration/test_list_creative_formats_params.py
@@ -120,6 +120,8 @@ def test_filtering_by_standard_only(integration_db, sample_tenant):
 
 def test_filtering_by_format_ids(integration_db, sample_tenant):
     """Test that format_ids filter works correctly."""
+    from src.core.schemas import FormatId
+
     # Create real ToolContext
     context = ToolContext(
         context_id="test",
@@ -133,9 +135,12 @@ def test_filtering_by_format_ids(integration_db, sample_tenant):
 
     # Mock tenant resolution to return our test tenant
     with patch("src.core.main.get_current_tenant", return_value=sample_tenant):
-        # Test filtering by specific format IDs
-        target_ids = ["display_300x250", "display_728x90"]
-        req = ListCreativeFormatsRequest(format_ids=target_ids)
+        # Test filtering by specific format IDs (using FormatId objects per AdCP v2.4)
+        target_format_ids = [
+            FormatId(agent_url="https://creative.adcontextprotocol.org", id="display_300x250"),
+            FormatId(agent_url="https://creative.adcontextprotocol.org", id="display_728x90"),
+        ]
+        req = ListCreativeFormatsRequest(format_ids=target_format_ids)
         response = list_creative_formats_raw(req, context)
 
         # Handle both dict and object responses
@@ -147,6 +152,7 @@ def test_filtering_by_format_ids(integration_db, sample_tenant):
             formats = response.formats
 
         # Should only return the requested formats (that exist)
+        target_ids = ["display_300x250", "display_728x90"]
         returned_ids = [f.format_id for f in formats]
         assert all(f.format_id in target_ids for f in formats), "All formats should be in target list"
         # At least one of the target formats should exist


### PR DESCRIPTION
## Summary

Removes string format_ids backward compatibility, focusing solely on AdCP v2.4 compliance (FormatId objects with `agent_url` + `id`).

## Changes

### Code Changes
- **src/core/schemas.py**: Simplified `upgrade_legacy_format_ids` validator in 3 classes:
  - `Package`
  - `ProductFilters` 
  - `ListCreativeFormatsRequest`
  - Removed string → FormatId conversion (legacy path)
  - Kept dict → FormatId conversion (AdCP v2.4 spec)
  - Updated type hint: `list[FormatId | str]` → `list[FormatId]`

### Test Changes
- **tests/integration/test_list_creative_formats_params.py**:
  - Updated `test_filtering_by_format_ids` to use FormatId objects
  - Changed from: `["display_300x250"]` (legacy strings)
  - Changed to: `[FormatId(agent_url="...", id="display_300x250")]` (AdCP v2.4)

## Why This Change?

### Original Issue
The validator was handling:
1. ✅ String format_ids (backward compatibility)
2. ❌ **Dict format_ids (AdCP v2.4 spec)** - Missing this case caused validation errors
3. ✅ FormatId objects (already upgraded)

Previous fix added dict handling. This PR removes the unnecessary string handling entirely.

### Why Tests Didn't Catch This

**Test Coverage Gap:**
- Tests validated backward compatibility (strings → FormatId)
- Never tested actual AdCP v2.4 format (dicts → FormatId)
- Integration tests used legacy string format for convenience

**Key Insight:** We tested that legacy formats worked, but never tested that the **modern format** worked!

## Testing

✅ All unit tests pass (775 tests)
✅ All integration tests pass (193 tests in quick mode)
✅ All pre-commit hooks pass

## Breaking Changes

⚠️ **Potentially breaking for internal code:**
- String format_ids are no longer accepted
- Must use FormatId objects: `FormatId(agent_url="...", id="...")`

**Impact:** Low - AdCP v2.4 clients already send FormatId objects. This only affects legacy internal code (if any).

## Next Steps (Future Work)

To prevent similar issues:
1. Add contract tests for all AdCP structured types
2. Schema validation against official AdCP spec (pre-commit hook)
3. Audit integration tests for production format usage
4. Update documentation with AdCP v2.4 examples

---

Related to #[previous PR number if applicable]