### PR TITLE
Remove deprecated creative_formats table logic

### DIFF
--- a/src/core/format_resolver.py
+++ b/src/core/format_resolver.py
@@ -4,61 +4,15 @@ Provides layered format lookup:
 1. Product-level overrides (from product.implementation_config.format_overrides)
 2. Dynamic format discovery from creative agents (via CreativeAgentRegistry)
 
-Note: Tenant custom formats (creative_formats table) are deprecated in favor of
+Note: Tenant custom formats (creative_formats table) were removed in favor of
 creative agent-based format discovery per AdCP v2.4.
 """
 
 import asyncio
 import json
-from collections.abc import Sequence
-from typing import Any
 
 from src.core.database.database_session import get_db_session
 from src.core.schemas import Format
-
-
-def _parse_format_from_db_row(row: Sequence[Any]) -> Format:
-    """Extract Format object from database row.
-
-    Args:
-        row: Database tuple with format fields:
-            (format_id, name, type, description, width, height,
-             duration_seconds, max_file_size_kb, specs, is_standard, platform_config)
-
-    Returns:
-        Format object constructed from database row
-    """
-    # Parse JSON fields (handle both string and dict from SQLite vs PostgreSQL)
-    specs = json.loads(row[8]) if isinstance(row[8], str) else row[8]
-    platform_config_data: dict[str, Any] | None = None
-    if row[10]:
-        platform_config_data = json.loads(row[10]) if isinstance(row[10], str) else row[10]
-
-    # Build requirements dict from database columns
-    requirements: dict[str, Any] = {}
-    if row[4]:  # width
-        requirements["width"] = row[4]
-    if row[5]:  # height
-        requirements["height"] = row[5]
-    if row[6]:  # duration_seconds
-        requirements["duration_max"] = row[6]
-    if row[7]:  # max_file_size_kb
-        requirements["max_file_size_kb"] = row[7]
-
-    # Merge with specs JSON
-    if specs:
-        requirements.update(specs)
-
-    return Format(
-        format_id=row[0],
-        name=row[1],
-        type=row[2],
-        is_standard=bool(row[9]),
-        iab_specification=None,  # Not stored in creative_formats table
-        assets_required=None,  # Not stored in creative_formats table
-        requirements=requirements if requirements else None,
-        platform_config=platform_config_data,
-    )
 
 
 def get_format(
@@ -198,41 +152,6 @@ def _get_product_format_override(tenant_id: str, product_id: str, format_id: str
             format_dict["platform_config"] = merged_platform_config
 
         return Format(**format_dict)
-
-
-def _get_tenant_custom_format(tenant_id: str, format_id: str) -> Format | None:
-    """Get tenant-specific custom format from database.
-
-    Tenants can define custom formats in the creative_formats table.
-    Useful for non-standard sizes or platform-specific configurations.
-
-    Args:
-        tenant_id: Tenant identifier
-        format_id: Format to look up
-
-    Returns:
-        Custom Format object, or None if not found
-    """
-    from sqlalchemy import text
-
-    with get_db_session() as session:
-        result = session.execute(
-            text(
-                """
-                SELECT format_id, name, type, description, width, height,
-                       duration_seconds, max_file_size_kb, specs, is_standard,
-                       platform_config
-                FROM creative_formats
-                WHERE tenant_id = :tenant_id AND format_id = :format_id
-            """
-            ),
-            {"tenant_id": tenant_id, "format_id": format_id},
-        )
-        row = result.fetchone()
-        if not row:
-            return None
-
-        return _parse_format_from_db_row(row)
 
 
 def list_available_formats(

--- a/tests/integration/test_database_integration.py
+++ b/tests/integration/test_database_integration.py
@@ -54,42 +54,22 @@ def test_settings_queries():
             print(f"   ❌ ERROR: {e}")
             errors.append(f"Products query: {e}")
 
-        # Test 3: Creative formats query (the problematic one)
-        print("\n3. Testing creative formats query...")
+        # Test 3: Creatives query (creative_formats table was dropped in migration f2addf453200)
+        print("\n3. Testing creatives query...")
         try:
-            # First check what columns actually exist
             cursor.execute(
                 """
-                SELECT column_name
-                FROM information_schema.columns
-                WHERE table_name = 'creative_formats'
-            """
-            )
-            columns = [row[0] for row in cursor.fetchall()]
-            print(f"   Available columns: {', '.join(columns)}")
-
-            # Try the query that was failing
-            cursor.execute(
-                """
-                SELECT format_id, name, width, height
-                FROM creative_formats
-                WHERE tenant_id = %s OR tenant_id IS NULL
-                ORDER BY name
+                SELECT COUNT(*)
+                FROM creatives
+                WHERE tenant_id = %s
             """,
                 (tenant_id,),
             )
-            formats = cursor.fetchall()
-            print(f"   ✓ Creative formats found: {len(formats)}")
-
-            # Check if auto_approve column exists
-            if "auto_approve" in columns:
-                print("   ✓ auto_approve column exists")
-            else:
-                print("   ⚠️  auto_approve column DOES NOT exist (this was the bug!)")
-
+            count = cursor.fetchone()[0]
+            print(f"   ✓ Creatives count: {count}")
         except Exception as e:
             print(f"   ❌ ERROR: {e}")
-            errors.append(f"Creative formats query: {e}")
+            errors.append(f"Creatives query: {e}")
 
         # Test 4: Media buys with date query
         print("\n4. Testing media buys date query...")


### PR DESCRIPTION
## Background
The `creative_formats` table was deprecated and removed in favor of creative agent-based format discovery. The integration tests and format resolver were still referencing this removed table, causing CI failures.

## Changes
- **`src/core/format_resolver.py`**:
    - Removed the `_parse_format_from_db_row` function.
    - Removed the `_get_tenant_custom_format` function.
    - Updated the module docstring to reflect that tenant custom formats are removed.
- **`tests/integration/test_database_integration.py`**:
    - Modified the integration test to query the `creatives` table instead of the removed `creative_formats` table.
    - Simplified the test to a count query on the `creatives` table.

## Testing
- [ ] Verify CI passes without SQL errors related to `creative_formats`.
- [ ] Manually confirm that `list_available_formats` and related logic function correctly without the deprecated table.
