### PR TITLE
Add MCP config copy and fix delete

### DIFF
--- a/templates/tenant_settings.html
+++ b/templates/tenant_settings.html
@@ -1425,8 +1425,13 @@ REJECT - Creative cannot be approved:
                                         <div class="btn-group btn-group-sm">
                                             <button class="btn btn-outline-primary btn-sm"
                                                     onclick="copyA2AConfig('{{ principal.principal_id }}', '{{ principal.name }}', '{{ principal.access_token }}')"
-                                                    title="Copy API Configuration">
-                                                📋 API
+                                                    title="Copy A2A Configuration">
+                                                📋 A2A
+                                            </button>
+                                            <button class="btn btn-outline-primary btn-sm"
+                                                    onclick="copyMCPConfig('{{ principal.principal_id }}', '{{ principal.name }}', '{{ principal.access_token }}')"
+                                                    title="Copy MCP Configuration">
+                                                📋 MCP
                                             </button>
                                             <button class="btn btn-outline-secondary btn-sm"
                                                     onclick="editPrincipalMappings('{{ principal.principal_id }}', '{{ principal.name }}')"


### PR DESCRIPTION
## Background
- The A2A copy button was failing with an error when trying to copy clipboard content.
- The delete principal functionality was incorrectly using POST instead of DELETE and lacked proper error handling for non-JSON responses.
- Users require the ability to copy MCP configurations in JSON format, similar to A2A configurations.

## Changes
- `static/js/tenant_settings.js`:
    - Modified `copyA2AConfig` to capture the button element at the function's start and store original text for stable async operation.
    - Introduced `copyMCPConfig` function to generate and copy MCP configuration JSON, including `mcpUrl` based on environment.
    - Changed `deletePrincipal` method from `POST` to `DELETE`.
    - Added `principalName` to `deletePrincipal` confirmation prompt.
    - Improved error handling in `deletePrincipal` to parse JSON error responses and throw custom errors.
- `templates/tenant_settings.html`:
    - Added a new "📋 MCP" button next to the "📋 A2A" button, which calls `copyMCPConfig`.
    - Updated the "📋 API" button's title to "Copy A2A Configuration".

## Testing
- [ ] Verify that clicking "📋 A2A" copies the A2A configuration JSON correctly.
- [ ] Verify that clicking "📋 MCP" copies the MCP configuration JSON correctly.
- [ ] Test the delete principal functionality with a principal that exists and one that does not (to check error handling).
- [ ] Confirm the confirmation prompt in `deletePrincipal` shows the principal's name.
