### PR TITLE
Display all workflow steps in tasks tab

### DIFF
--- a/src/admin/blueprints/workflows.py
+++ b/src/admin/blueprints/workflows.py
@@ -30,14 +30,17 @@ def list_workflows(tenant_id, **kwargs):
         if not tenant:
             return "Tenant not found", 404
 
-        # Get all workflow steps that need attention
+        # Get all workflow steps (not just pending approval)
         stmt = (
             select(WorkflowStep)
             .join(Context, WorkflowStep.context_id == Context.context_id)
-            .filter(Context.tenant_id == tenant_id, WorkflowStep.status == "pending_approval")
+            .filter(Context.tenant_id == tenant_id)
             .order_by(WorkflowStep.created_at.desc())
         )
-        pending_steps = db.scalars(stmt).all()
+        all_steps = db.scalars(stmt).all()
+
+        # Separate pending approval steps for summary
+        pending_steps = [s for s in all_steps if s.status == "pending_approval"]
 
         # Get media buys for context
         stmt = select(MediaBuy).filter_by(tenant_id=tenant_id).order_by(MediaBuy.created_at.desc())
@@ -51,9 +54,9 @@ def list_workflows(tenant_id, **kwargs):
             "total_spend": sum(mb.budget or 0 for mb in media_buys if mb.status == "active"),
         }
 
-        # Format workflow steps for display
+        # Format all workflow steps for display in tasks tab
         workflows_list = []
-        for step in pending_steps:
+        for step in all_steps:
             context = db.scalars(select(Context).filter_by(context_id=step.context_id)).first()
             principal = None
             if context and context.principal_id:
@@ -66,9 +69,13 @@ def list_workflows(tenant_id, **kwargs):
                     "step_id": step.step_id,
                     "workflow_id": step.workflow_id,
                     "step_name": step.step_name,
+                    "step_type": step.step_type,
                     "status": step.status,
                     "created_at": step.created_at,
+                    "completed_at": step.completed_at,
                     "principal_name": principal.name if principal else "Unknown",
+                    "assigned_to": step.assigned_to,
+                    "error_message": step.error_message,
                     "request_data": step.request_data,
                 }
             )
@@ -102,7 +109,7 @@ def list_workflows(tenant_id, **kwargs):
             summary=summary,
             workflows=workflows_list,
             media_buys=media_buys,
-            tasks=[],  # Deprecated - using workflow_steps now
+            tasks=workflows_list,  # Using workflow_steps as tasks
             audit_logs=audit_logs,
         )
 

--- a/templates/workflows.html
+++ b/templates/workflows.html
@@ -138,23 +138,23 @@
                     <tr>
                         <th>ID</th>
                         <th>Type</th>
-                        <th>Title</th>
-                        <th>Media Buy</th>
+                        <th>Step Name</th>
+                        <th>Workflow</th>
                         <th>Status</th>
-                        <th>Due Date</th>
                         <th>Assigned To</th>
                         <th>Created</th>
+                        <th>Completed</th>
                     </tr>
                 </thead>
                 <tbody>
                     {% for task in tasks %}
-                    <tr data-status="{{ task.status }}" data-overdue="{{ 'yes' if task.is_overdue else 'no' }}">
-                        <td><code>{{ task.task_id }}</code></td>
-                        <td>{{ task.task_type }}</td>
-                        <td>{{ task.title }}</td>
+                    <tr data-status="{{ task.status }}">
+                        <td><code>{{ task.step_id }}</code></td>
+                        <td>{{ task.step_type or 'workflow' }}</td>
+                        <td>{{ task.step_name or task.step_id }}</td>
                         <td>
-                            {% if task.media_buy_id %}
-                            <code>{{ task.media_buy_id }}</code>
+                            {% if task.workflow_id %}
+                            <code>{{ task.workflow_id }}</code>
                             {% else %}
                             -
                             {% endif %}
@@ -162,21 +162,19 @@
                         <td>
                             {% if task.status == 'completed' %}
                             <span class="status status-completed">Completed</span>
-                            {% elif task.is_overdue %}
-                            <span class="status status-error">Overdue</span>
+                            {% elif task.status == 'failed' %}
+                            <span class="status status-error">Failed</span>
+                            {% elif task.status == 'pending_approval' %}
+                            <span class="status status-pending">Pending Approval</span>
+                            {% elif task.status == 'in_progress' %}
+                            <span class="status status-pending">In Progress</span>
                             {% else %}
-                            <span class="status status-pending">Pending</span>
+                            <span class="status status-pending">{{ task.status }}</span>
                             {% endif %}
                         </td>
-                        <td>
-                            {% if task.due_date %}
-                            {{ task.due_date.strftime('%Y-%m-%d %H:%M') }}
-                            {% else %}
-                            -
-                            {% endif %}
-                        </td>
-                        <td>{{ task.assigned_to or 'Unassigned' }}</td>
+                        <td>{{ task.assigned_to or task.principal_name or 'Unassigned' }}</td>
                         <td>{{ task.created_at.strftime('%Y-%m-%d %H:%M') if task.created_at else 'N/A' }}</td>
+                        <td>{{ task.completed_at.strftime('%Y-%m-%d %H:%M') if task.completed_at else '-' }}</td>
                     </tr>
                     {% endfor %}
                 </tbody>
@@ -375,11 +373,16 @@ function filterTasks() {
 
     rows.forEach(row => {
         let show = false;
+        const status = row.dataset.status;
+
         if (filter === 'all') {
             show = true;
-        } else if (filter === 'overdue' && row.dataset.overdue === 'yes') {
+        } else if (filter === 'pending' && (status === 'pending' || status === 'pending_approval' || status === 'in_progress')) {
             show = true;
-        } else if (filter === row.dataset.status) {
+        } else if (filter === 'completed' && status === 'completed') {
+            show = true;
+        } else if (filter === 'overdue' && status === 'failed') {
+            // Map failed tasks to "overdue" filter for now
             show = true;
         }
         row.style.display = show ? '' : 'none';


### PR DESCRIPTION
## Background
The Tasks tab was not displaying completed workflow steps or all relevant tasks, leading to confusion about system progress.

## Changes
- **`src/admin/blueprints/workflows.py`**:
    - Modified the `list_workflows` function to retrieve all `WorkflowStep` records for a given tenant, not just those with a status of "pending_approval".
    - Introduced logic to separate "pending_approval" steps for summary statistics while ensuring all steps are processed for the main list.
    - Added more fields to the `workflows_list` data structure, including `step_type`, `completed_at`, `error_message`, and `assigned_to`, to provide a more comprehensive view of each step.
    - Replaced the deprecated `tasks=[]` with `tasks=workflows_list`, effectively mapping the retrieved workflow steps to the tasks variable used in the template.

- **`templates/workflows.html`**:
    - Updated the "Tasks" table headers and data bindings to correctly display fields from the `WorkflowStep` model (e.g., `step_id`, `step_type`, `step_name`, `workflow_id`, `completed_at`).
    - Refined status badge logic to accurately reflect various `WorkflowStep` statuses like 'completed', 'failed', 'pending_approval', and 'in_progress'.
    - Adjusted the JavaScript `filterTasks` function to correctly filter workflow steps based on their actual statuses rather than deprecated 'overdue' and 'pending' states. Mapped 'failed' status to the 'overdue' filter for backward compatibility in filtering options.

## Testing
- [ ] Verify that the "Tasks" tab now displays all workflow steps, including completed and failed ones.
- [ ] Confirm that the task details, such as completion timestamps and error messages, are correctly rendered.
- [ ] Test the "All", "Pending", "Completed", and "Overdue" filters to ensure they accurately reflect the displayed workflow steps.
