### PR TITLE
Fix failed media buy detail view

### DIFF
--- a/src/admin/blueprints/operations.py
+++ b/src/admin/blueprints/operations.py
@@ -174,7 +174,7 @@ def media_buy_detail(tenant_id, media_buy_id):
             principal = None
             if media_buy.principal_id:
                 stmt = select(Principal).filter_by(tenant_id=tenant_id, principal_id=media_buy.principal_id)
-            principal = db_session.scalars(stmt).first()
+                principal = db_session.scalars(stmt).first()
 
             return render_template(
                 "media_buy_detail.html", tenant_id=tenant_id, media_buy=media_buy, principal=principal

--- a/templates/media_buy_detail.html
+++ b/templates/media_buy_detail.html
@@ -145,5 +145,10 @@
     background-color: #d4edda;
     color: #155724;
 }
+
+.status-failed {
+    background-color: #f8d7da;
+    color: #721c24;
+}
 </style>
 {% endblock %}


### PR DESCRIPTION
## Background
Users were directed to an error page when attempting to view details for a failed media buy.

## Changes
- Corrected indentation in `src/admin/blueprints/operations.py` around the `principal` query to prevent a `NameError`. The `db_session.scalars(stmt).first()` call is now correctly nested within the `if media_buy.principal_id:` block.
- Added `.status-failed` CSS class to `templates/media_buy_detail.html` to provide distinct styling for failed media buy statuses.

## Testing
- [ ] Navigate to a media buy with a "failed" status and verify the details page loads correctly without errors.
- [ ] Confirm the "failed" status is visually distinct from other statuses.
