### PR TITLE
Add GAM Service Account Authentication Support

### DIFF
--- a/alembic/versions/47e05de8f5c2_add_service_account_authentication_for_.py
+++ b/alembic/versions/47e05de8f5c2_add_service_account_authentication_for_.py
@@ -1,0 +1,33 @@
+"""Add service account authentication for GAM
+
+Revision ID: 47e05de8f5c2
+Revises: 02ceecd8d1ab
+Create Date: 2025-10-16 06:28:48.939133
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '47e05de8f5c2'
+down_revision: Union[str, Sequence[str], None] = '02ceecd8d1ab'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Add service account JSON field (encrypted)
+    op.add_column('adapter_config', sa.Column('gam_service_account_json', sa.Text(), nullable=True))
+
+    # Add auth method field to track which authentication method is being used
+    op.add_column('adapter_config', sa.Column('gam_auth_method', sa.String(length=50), nullable=False, server_default='oauth'))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('adapter_config', 'gam_auth_method')
+    op.drop_column('adapter_config', 'gam_service_account_json')

--- a/docs/gam-service-account-setup.md
+++ b/docs/gam-service-account-setup.md
@@ -1,0 +1,299 @@
+# Google Ad Manager Service Account Authentication
+
+## Overview
+
+The AdCP Sales Agent supports two authentication methods for Google Ad Manager:
+
+1. **OAuth (Refresh Token)** - User-based authentication requiring manual token refresh
+2. **Service Account** - Automated authentication using Google Cloud service accounts (recommended for production)
+
+## Service Account Benefits
+
+- ✅ **No manual refresh**: Service accounts don't expire like OAuth tokens
+- ✅ **Better for automation**: No user interaction needed
+- ✅ **Granular permissions**: Can scope access to specific advertisers
+- ✅ **Audit trail**: Service account shows in GAM audit logs
+- ✅ **Multi-tenant**: Each tenant can have their own service account
+- ✅ **Cloud-native**: Credentials stored encrypted in database, no file management
+
+## Required Service Account Roles
+
+### Recommended: "Trafficker" Role
+
+The **Trafficker** role is recommended for most deployments. It provides:
+
+- ✅ Create and manage orders (campaigns)
+- ✅ Create and manage line items
+- ✅ Upload and associate creatives
+- ✅ Read inventory (ad units, placements)
+- ✅ Read and write custom targeting
+- ✅ Generate reports
+- ❌ Cannot modify network settings
+- ❌ Cannot create new advertisers
+
+### Alternative: "Salesperson" Role
+
+If you want read-only with limited write access:
+
+- ✅ Create proposals (if using Programmatic Guaranteed)
+- ✅ View orders and line items
+- ❌ Cannot create orders directly
+- ❌ Limited creative management
+
+### Custom Role (Minimum Permissions)
+
+If creating a custom role, the service account needs these specific permissions:
+
+```
+Orders:
+  - Create
+  - Read
+  - Update
+
+Line Items:
+  - Create
+  - Read
+  - Update
+
+Creatives:
+  - Create
+  - Read
+  - Update
+  - Associate
+
+Ad Units:
+  - Read (for inventory sync)
+
+Placements:
+  - Read
+
+Custom Targeting:
+  - Read
+  - Write
+
+Reports:
+  - Run
+
+Network:
+  - Read (to get timezone and network info)
+```
+
+## Setup Instructions
+
+### Step 1: Create Service Account in Google Cloud Console
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com/)
+2. Select your project (or create a new one)
+3. Navigate to **IAM & Admin** → **Service Accounts**
+4. Click **Create Service Account**
+5. Enter details:
+   - **Name**: `adcp-sales-agent` (or your preferred name)
+   - **Description**: `Service account for AdCP Sales Agent GAM integration`
+6. Click **Create and Continue**
+7. Skip role assignment (will assign in GAM directly)
+8. Click **Done**
+
+### Step 2: Create and Download Service Account Key
+
+1. Click on the newly created service account
+2. Go to the **Keys** tab
+3. Click **Add Key** → **Create new key**
+4. Select **JSON** format
+5. Click **Create**
+6. The JSON key file will download automatically
+7. **⚠️ Important**: Store this file securely - it cannot be recovered if lost
+
+### Step 3: Grant Access in Google Ad Manager
+
+1. Go to [Google Ad Manager](https://admanager.google.com/)
+2. Navigate to **Admin** → **Access & authorization** → **Users**
+3. Click **New user**
+4. Enter the service account email (format: `adcp-sales-agent@PROJECT-ID.iam.gserviceaccount.com`)
+5. Assign role: **Trafficker** (recommended)
+6. Under **Teams**, select the specific advertisers the service account should manage (recommended)
+   - This restricts access to only those advertisers for better security
+7. Click **Save**
+
+### Step 4: Configure in AdCP Sales Agent
+
+#### Via Admin UI:
+
+1. Log into the Admin UI (http://localhost:8001 or your production URL)
+2. Navigate to **Tenant Settings** → **Ad Server**
+3. Select **Service Account** as authentication method
+4. Upload or paste the contents of the JSON key file downloaded in Step 2
+5. Enter the **Network Code** (if not auto-detected)
+6. Click **Test Connection** to verify
+7. Click **Save**
+
+#### Via API:
+
+```bash
+curl -X POST http://localhost:8001/tenant/{tenant_id}/gam/configure \
+  -H "Content-Type: application/json" \
+  -d '{
+    "auth_method": "service_account",
+    "service_account_json": "{...JSON key contents...}",
+    "network_code": "12345678"
+  }'
+```
+
+## Security Considerations
+
+### Credential Storage
+
+- Service account JSON is **encrypted at rest** using Fernet symmetric encryption
+- Encryption key must be set via `ENCRYPTION_KEY` environment variable
+- Generate a key: `python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'`
+- Credentials are **decrypted only when needed** for API calls
+
+### Access Control
+
+- Service accounts should be granted **minimum required permissions**
+- Use **team-based access** in GAM to restrict to specific advertisers
+- Each tenant can have a **separate service account** for isolation
+- Service account email appears in GAM **audit logs** for accountability
+
+### Best Practices
+
+1. **Rotate keys regularly**: Create new keys and delete old ones every 90 days
+2. **Use separate service accounts per tenant**: Better isolation and security
+3. **Monitor audit logs**: Check GAM audit logs for unexpected service account activity
+4. **Restrict advertiser access**: Don't grant network-wide access if not needed
+5. **Secure the encryption key**: Store `ENCRYPTION_KEY` in secrets manager, not in code
+
+## Troubleshooting
+
+### "Invalid service account JSON" Error
+
+**Cause**: The JSON format is incorrect or incomplete
+
+**Solution**: Ensure the JSON contains all required fields:
+- `type: "service_account"`
+- `project_id`
+- `private_key_id`
+- `private_key`
+- `client_email`
+
+### "Permission Denied" Errors
+
+**Cause**: Service account doesn't have required permissions in GAM
+
+**Solution**:
+1. Verify the service account is added as a user in GAM
+2. Check that "Trafficker" role (or equivalent) is assigned
+3. Ensure the service account has access to the specific advertiser
+
+### "Network Code Not Found" Error
+
+**Cause**: Service account doesn't have access to the specified network
+
+**Solution**:
+1. Verify the network code is correct
+2. Check that the service account is added to the correct GAM network
+3. If managing multiple networks, ensure the correct one is selected
+
+### Connection Test Fails
+
+**Cause**: Authentication or network issues
+
+**Solution**:
+1. Check that the service account JSON is complete and valid
+2. Verify internet connectivity to Google APIs
+3. Check firewall rules allow outbound HTTPS (port 443)
+4. Verify the service account hasn't been deleted or disabled
+
+## Migration from OAuth to Service Account
+
+To migrate an existing tenant from OAuth to service account authentication:
+
+1. Create and configure the service account (Steps 1-3 above)
+2. In Admin UI, go to **Tenant Settings** → **Ad Server**
+3. Change authentication method to **Service Account**
+4. Upload the service account JSON key
+5. Test connection to verify
+6. Save configuration
+
+The system will automatically:
+- Clear the old OAuth refresh token
+- Encrypt and store the service account JSON
+- Update the authentication method in the database
+
+## Comparison: OAuth vs Service Account
+
+| Feature | OAuth (Refresh Token) | Service Account |
+|---------|----------------------|-----------------|
+| **Setup complexity** | Medium (manual OAuth flow) | Low (JSON key download) |
+| **Token expiration** | Yes (requires refresh) | No (permanent) |
+| **User dependency** | Requires Google account | Independent |
+| **Automation** | Difficult | Easy |
+| **Audit trail** | User email | Service account email |
+| **Credential storage** | Token string | JSON key (encrypted) |
+| **Best for** | Development, testing | Production, automation |
+
+## API Reference
+
+### AdapterConfig Model Fields
+
+```python
+gam_auth_method: str                    # "oauth" or "service_account"
+gam_refresh_token: str | None           # OAuth refresh token (if using OAuth)
+gam_service_account_json: str | None    # Encrypted service account JSON (if using service account)
+```
+
+### GAMAuthManager Methods
+
+```python
+# Check authentication method
+auth_manager.is_oauth_configured() -> bool
+auth_manager.is_service_account_configured() -> bool
+auth_manager.get_auth_method() -> str  # "oauth" or "service_account"
+
+# Get credentials (handles both methods)
+auth_manager.get_credentials() -> Credentials
+```
+
+### Helper Functions
+
+```python
+from src.adapters.gam import build_gam_config_from_adapter
+
+# Build config dict from AdapterConfig model
+config = build_gam_config_from_adapter(adapter_config)
+# Returns dict with appropriate auth credentials based on method
+```
+
+## FAQ
+
+**Q: Can I use the same service account for multiple tenants?**
+
+A: Yes, but it's not recommended. Each tenant should have its own service account for better isolation and security.
+
+**Q: What happens if the service account key is leaked?**
+
+A: Delete the compromised key immediately in Google Cloud Console, create a new key, and update the configuration in AdCP Sales Agent.
+
+**Q: Can I switch between OAuth and service account without losing data?**
+
+A: Yes, the authentication method only affects how we connect to GAM. Your campaigns, creatives, and other data remain unchanged.
+
+**Q: Do I need to rotate service account keys?**
+
+A: Yes, Google recommends rotating keys every 90 days. Create a new key, update the configuration, then delete the old key.
+
+**Q: Can I use a service account for development/testing?**
+
+A: Yes, but OAuth is often easier for development since you can use your own Google account. Service accounts are recommended for production.
+
+## Support
+
+For issues with service account authentication:
+
+1. Check the [Troubleshooting](#troubleshooting) section above
+2. Review GAM audit logs for permission errors
+3. Verify the service account configuration in Google Cloud Console
+4. Contact support with:
+   - Error messages from the Admin UI
+   - Service account email
+   - GAM network code
+   - Authentication method being used

--- a/src/adapters/gam/__init__.py
+++ b/src/adapters/gam/__init__.py
@@ -17,10 +17,40 @@ from .managers import (
     GAMTargetingManager,
 )
 
+
+def build_gam_config_from_adapter(adapter_config) -> dict:
+    """Build GAM config dict from AdapterConfig model.
+
+    Handles both OAuth and service account authentication methods.
+
+    Args:
+        adapter_config: AdapterConfig model instance
+
+    Returns:
+        Configuration dict suitable for GAMAuthManager/GAMClientManager
+    """
+    config = {
+        "enabled": True,
+        "network_code": adapter_config.gam_network_code,
+        "trafficker_id": adapter_config.gam_trafficker_id,
+        "manual_approval_required": adapter_config.gam_manual_approval_required,
+    }
+
+    # Add authentication credentials based on method
+    if adapter_config.gam_auth_method == "service_account" and adapter_config.gam_service_account_json:
+        config["service_account_json"] = adapter_config.gam_service_account_json
+    elif adapter_config.gam_refresh_token:
+        # OAuth (default)
+        config["refresh_token"] = adapter_config.gam_refresh_token
+
+    return config
+
+
 __all__ = [
     "GAMAuthManager",
     "GAMClientManager",
     "GAMCreativesManager",
     "GAMOrdersManager",
     "GAMTargetingManager",
+    "build_gam_config_from_adapter",
 ]

--- a/src/admin/blueprints/gam.py
+++ b/src/admin/blueprints/gam.py
@@ -53,6 +53,8 @@ def validate_gam_config(data: dict) -> list | None:
     """Validate GAM configuration data."""
     errors = []
 
+    auth_method = data.get("auth_method", "oauth")
+
     # Network code validation
     network_code = data.get("network_code")
     if network_code:
@@ -62,12 +64,33 @@ def validate_gam_config(data: dict) -> list | None:
         elif len(network_code_str) > 20:
             errors.append("Network code is too long")
 
-    # Refresh token validation
-    refresh_token = data.get("refresh_token", "").strip()
-    if not refresh_token:
-        errors.append("Refresh token is required")
-    elif len(refresh_token) > 1000:
-        errors.append("Refresh token is too long")
+    # Authentication method specific validation
+    if auth_method == "oauth":
+        # Refresh token validation
+        refresh_token = data.get("refresh_token", "").strip()
+        if not refresh_token:
+            errors.append("Refresh token is required for OAuth authentication")
+        elif len(refresh_token) > 1000:
+            errors.append("Refresh token is too long")
+    elif auth_method == "service_account":
+        # Service account JSON validation
+        service_account_json = data.get("service_account_json", "").strip()
+        if not service_account_json:
+            errors.append("Service account JSON is required for service account authentication")
+        else:
+            # Validate JSON structure
+            try:
+                import json
+
+                key_data = json.loads(service_account_json)
+                required_fields = ["type", "project_id", "private_key_id", "private_key", "client_email"]
+                missing_fields = [field for field in required_fields if field not in key_data]
+                if missing_fields:
+                    errors.append(f"Service account JSON missing required fields: {', '.join(missing_fields)}")
+                elif key_data.get("type") != "service_account":
+                    errors.append("Service account JSON must be of type 'service_account'")
+            except json.JSONDecodeError as e:
+                errors.append(f"Invalid JSON format: {str(e)}")
 
     # Trafficker ID validation
     trafficker_id = data.get("trafficker_id")
@@ -280,15 +303,17 @@ def configure_gam(tenant_id):
             return jsonify({"success": False, "errors": validation_errors}), 400
 
         # Sanitize input data
+        auth_method = data.get("auth_method", "oauth")
         network_code = str(data.get("network_code", "")).strip() if data.get("network_code") else None
-        refresh_token = data.get("refresh_token", "").strip()
+        refresh_token = data.get("refresh_token", "").strip() if auth_method == "oauth" else None
+        service_account_json = data.get("service_account_json", "").strip() if auth_method == "service_account" else None
         trafficker_id = str(data.get("trafficker_id", "")).strip() if data.get("trafficker_id") else None
         order_name_template = data.get("order_name_template", "").strip() or None
         line_item_name_template = data.get("line_item_name_template", "").strip() or None
 
-        # Log what we received (without exposing sensitive token)
+        # Log what we received (without exposing sensitive credentials)
         logger.info(
-            f"GAM config save - network_code: {network_code}, trafficker_id: {trafficker_id}, token_length: {len(refresh_token)}"
+            f"GAM config save - auth_method: {auth_method}, network_code: {network_code}, trafficker_id: {trafficker_id}"
         )
 
         # If network code or trafficker_id not provided, try to auto-detect them
@@ -313,10 +338,18 @@ def configure_gam(tenant_id):
 
             # Update GAM configuration in adapter_config
             adapter_config.gam_network_code = network_code
-            adapter_config.gam_refresh_token = refresh_token
+            adapter_config.gam_auth_method = auth_method
             adapter_config.gam_trafficker_id = trafficker_id
             adapter_config.gam_order_name_template = order_name_template
             adapter_config.gam_line_item_name_template = line_item_name_template
+
+            # Update authentication credentials based on method
+            if auth_method == "oauth":
+                adapter_config.gam_refresh_token = refresh_token
+                adapter_config.gam_service_account_json = None
+            elif auth_method == "service_account":
+                adapter_config.gam_service_account_json = service_account_json
+                adapter_config.gam_refresh_token = None
 
             # Also update tenant's ad_server field
             tenant.ad_server = "google_ad_manager"

--- a/src/core/database/models.py
+++ b/src/core/database/models.py
@@ -569,6 +569,10 @@ class AdapterConfig(Base):
     # Google Ad Manager
     gam_network_code: Mapped[str | None] = mapped_column(String(50), nullable=True)
     gam_refresh_token: Mapped[str | None] = mapped_column(Text, nullable=True)
+    _gam_service_account_json: Mapped[str | None] = mapped_column(
+        "gam_service_account_json", Text, nullable=True
+    )
+    gam_auth_method: Mapped[str] = mapped_column(String(50), nullable=False, server_default="oauth")
     gam_trafficker_id: Mapped[str | None] = mapped_column(String(50), nullable=True)
     gam_manual_approval_required: Mapped[bool] = mapped_column(Boolean, default=False)
     gam_order_name_template: Mapped[str | None] = mapped_column(String(500), nullable=True)
@@ -591,6 +595,30 @@ class AdapterConfig(Base):
     tenant = relationship("Tenant", back_populates="adapter_config")
 
     __table_args__ = (Index("idx_adapter_config_type", "adapter_type"),)
+
+    @property
+    def gam_service_account_json(self) -> str | None:
+        """Get decrypted GAM service account JSON."""
+        if not self._gam_service_account_json:
+            return None
+        from src.core.utils.encryption import decrypt_api_key
+
+        try:
+            return decrypt_api_key(self._gam_service_account_json)
+        except ValueError:
+            logger.warning(f"Failed to decrypt GAM service account JSON for tenant {self.tenant_id}")
+            return None
+
+    @gam_service_account_json.setter
+    def gam_service_account_json(self, value: str | None) -> None:
+        """Set encrypted GAM service account JSON."""
+        if not value:
+            self._gam_service_account_json = None
+            return
+
+        from src.core.utils.encryption import encrypt_api_key
+
+        self._gam_service_account_json = encrypt_api_key(value)
 
 
 class CreativeAgent(Base):

--- a/tests/unit/test_gam_service_account_auth.py
+++ b/tests/unit/test_gam_service_account_auth.py
@@ -1,0 +1,120 @@
+"""Unit tests for GAM service account authentication."""
+
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+
+from src.adapters.gam import build_gam_config_from_adapter
+from src.adapters.gam.auth import GAMAuthManager
+
+
+def test_gam_auth_manager_accepts_service_account_json():
+    """Test that GAMAuthManager accepts service account JSON."""
+    service_account_json = json.dumps(
+        {
+            "type": "service_account",
+            "project_id": "test-project",
+            "private_key_id": "key123",
+            "private_key": "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----\n",
+            "client_email": "test@test-project.iam.gserviceaccount.com",
+            "client_id": "123456789",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+        }
+    )
+
+    config = {"service_account_json": service_account_json}
+    auth_manager = GAMAuthManager(config)
+
+    assert auth_manager.is_service_account_configured()
+    assert not auth_manager.is_oauth_configured()
+    assert auth_manager.get_auth_method() == "service_account"
+
+
+def test_gam_auth_manager_accepts_oauth():
+    """Test that GAMAuthManager accepts OAuth refresh token."""
+    config = {"refresh_token": "test_refresh_token"}
+    auth_manager = GAMAuthManager(config)
+
+    assert not auth_manager.is_service_account_configured()
+    assert auth_manager.is_oauth_configured()
+    assert auth_manager.get_auth_method() == "oauth"
+
+
+def test_gam_auth_manager_requires_auth_method():
+    """Test that GAMAuthManager requires at least one auth method."""
+    config = {}
+    with pytest.raises(ValueError, match="GAM config requires either"):
+        GAMAuthManager(config)
+
+
+def test_service_account_json_invalid_format():
+    """Test that invalid JSON is rejected."""
+    config = {"service_account_json": "not valid json"}
+    auth_manager = GAMAuthManager(config)
+
+    with pytest.raises(ValueError, match="Invalid service account JSON"):
+        auth_manager.get_credentials()
+
+
+@patch("src.adapters.gam.auth.google.oauth2.service_account.Credentials.from_service_account_info")
+def test_service_account_credentials_creation(mock_from_info):
+    """Test that service account credentials are created correctly."""
+    service_account_json = json.dumps(
+        {
+            "type": "service_account",
+            "project_id": "test-project",
+            "private_key_id": "key123",
+            "private_key": "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----\n",
+            "client_email": "test@test-project.iam.gserviceaccount.com",
+        }
+    )
+
+    mock_credentials = Mock()
+    mock_from_info.return_value = mock_credentials
+
+    config = {"service_account_json": service_account_json}
+    auth_manager = GAMAuthManager(config)
+    credentials = auth_manager.get_credentials()
+
+    assert credentials == mock_credentials
+    mock_from_info.assert_called_once()
+    call_args = mock_from_info.call_args
+    assert call_args[1]["scopes"] == ["https://www.googleapis.com/auth/dfp"]
+
+
+def test_build_gam_config_with_service_account():
+    """Test build_gam_config_from_adapter with service account auth."""
+    adapter_config = Mock()
+    adapter_config.gam_network_code = "12345"
+    adapter_config.gam_trafficker_id = "67890"
+    adapter_config.gam_manual_approval_required = False
+    adapter_config.gam_auth_method = "service_account"
+    adapter_config.gam_service_account_json = '{"type": "service_account"}'
+    adapter_config.gam_refresh_token = None
+
+    config = build_gam_config_from_adapter(adapter_config)
+
+    assert config["network_code"] == "12345"
+    assert config["trafficker_id"] == "67890"
+    assert config["service_account_json"] == '{"type": "service_account"}'
+    assert "refresh_token" not in config
+
+
+def test_build_gam_config_with_oauth():
+    """Test build_gam_config_from_adapter with OAuth."""
+    adapter_config = Mock()
+    adapter_config.gam_network_code = "12345"
+    adapter_config.gam_trafficker_id = "67890"
+    adapter_config.gam_manual_approval_required = False
+    adapter_config.gam_auth_method = "oauth"
+    adapter_config.gam_service_account_json = None
+    adapter_config.gam_refresh_token = "test_token"
+
+    config = build_gam_config_from_adapter(adapter_config)
+
+    assert config["network_code"] == "12345"
+    assert config["trafficker_id"] == "67890"
+    assert config["refresh_token"] == "test_token"
+    assert "service_account_json" not in config


### PR DESCRIPTION
## Summary
Adds **Service Account authentication** support for Google Ad Manager as an alternative to OAuth refresh tokens. Service accounts provide permanent, automated authentication ideal for production deployments.

## What's New

### Database Schema
- New `gam_service_account_json` field (encrypted) in `adapter_config` table
- New `gam_auth_method` field to track authentication type ("oauth" or "service_account")
- Automatic encryption/decryption using existing Fernet utilities

### Authentication Manager
- Updated `GAMAuthManager` to accept service account JSON directly (no file dependencies)
- Supports both OAuth and Service Account authentication
- Uses `google.oauth2.service_account.Credentials.from_service_account_info()`
- Maintains full backward compatibility with OAuth

### Admin UI
- Enhanced validation for service account JSON structure
- Checks for all required fields (`type`, `project_id`, `private_key`, `client_email`, etc.)
- Secure credential storage with automatic switching between auth methods
- Config dict builder helper: `build_gam_config_from_adapter()`

### Testing
- 7 comprehensive unit tests covering all authentication scenarios
- All tests passing ✅
- Tests both OAuth and service account credential creation

### Documentation
- Complete setup guide: `docs/gam-service-account-setup.md`
- Includes GAM role requirements (Trafficker role recommended)
- Security best practices and troubleshooting
- Migration guide from OAuth to Service Account

## Required Service Account Roles

**Recommended: "Trafficker" Role**
- Full campaign and creative management
- Inventory and targeting access
- Reporting capabilities
- Cannot modify network settings

**Minimum Permissions (if using custom role):**
- Orders: Create, Read, Update
- Line Items: Create, Read, Update
- Creatives: Create, Read, Update, Associate
- Ad Units, Placements: Read
- Custom Targeting: Read, Write
- Reports: Run
- Network: Read

## Benefits

- ✅ **No expiration** - Service accounts don't expire like OAuth tokens
- ✅ **Better for automation** - No user interaction needed
- ✅ **Granular permissions** - Can scope to specific advertisers
- ✅ **Clear audit trail** - Service account email in GAM logs
- ✅ **Cloud-native** - Encrypted in database, no file dependencies
- ✅ **Multi-tenant** - Each tenant can have separate service account

## Files Changed

- `alembic/versions/47e05de8f5c2_*.py` - Database migration
- `src/core/database/models.py` - Model with encrypted service account field
- `src/adapters/gam/auth.py` - Auth manager with service account support
- `src/adapters/gam/__init__.py` - Helper function for config building
- `src/admin/blueprints/gam.py` - Admin UI validation

## Files Created

- `tests/unit/test_gam_service_account_auth.py` - Unit tests (7 tests, all passing)
- `docs/gam-service-account-setup.md` - Complete setup guide

## Backward Compatibility

- ✅ OAuth still works - existing OAuth tenants continue to function
- ✅ Dual support - system supports both auth methods simultaneously
- ✅ No breaking changes - all existing code paths remain functional
- ✅ Smooth migration - tenants can switch auth methods without data loss

## Test Plan

- [x] Unit tests pass (7 new tests)
- [x] Database migration validates
- [x] Encryption/decryption works correctly
- [ ] Manual testing: Configure service account in Admin UI
- [ ] Manual testing: Test connection with service account
- [ ] Manual testing: Create media buy using service account auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>