### PR TITLE
Fix creative format dimension extraction from AdCP v2.4 spec

### DIFF
--- a/src/admin/blueprints/products.py
+++ b/src/admin/blueprints/products.py
@@ -91,17 +91,20 @@ def get_creative_formats(
             "duration": None,
         }
 
-        # Add dimensions for display/video formats
-        if fmt.requirements and "width" in fmt.requirements and "height" in fmt.requirements:
-            format_dict["dimensions"] = f"{fmt.requirements['width']}x{fmt.requirements['height']}"
+        # Add dimensions for display/video formats using the helper method
+        dimensions = fmt.get_primary_dimensions()
+        if dimensions:
+            width, height = dimensions
+            format_dict["dimensions"] = f"{width}x{height}"
             if idx < 5:
-                logger.info(f"[DEBUG] Format {idx}: Got dimensions from requirements: {format_dict['dimensions']}")
-        elif "_" in fmt.format_id:
+                logger.info(f"[DEBUG] Format {idx}: Got dimensions: {format_dict['dimensions']}")
+        elif "_" in str(fmt.format_id):
             # Fallback: Parse dimensions from format_id (e.g., "display_300x250_image" → "300x250")
-            # This handles creative agents that don't populate requirements field
+            # This handles creative agents that don't populate renders or requirements field
             import re
 
-            match = re.search(r"_(\d+)x(\d+)_", fmt.format_id)
+            format_id_str = str(fmt.format_id)
+            match = re.search(r"_(\d+)x(\d+)_", format_id_str)
             if match:
                 format_dict["dimensions"] = f"{match.group(1)}x{match.group(2)}"
                 if idx < 5:


### PR DESCRIPTION
## Problem
When creating/editing GAM products in the Admin UI, the system queries the production creative agent at `https://creative.adcontextprotocol.org` for format dimensions, but dimensions don't appear in the UI.

## Root Cause
The creative agent **is working correctly** and returns dimensions in the `renders` array per AdCP v2.4 spec:
```json
{
  "renders": [{
    "role": "primary",
    "dimensions": {"width": 300.0, "height": 250.0}
  }]
}
```

However, our `Format` schema class was missing the `renders` field, so we weren't capturing this dimension data when parsing responses.

## Solution
1. **Added `renders` field** to `Format` class in `src/core/schemas.py`
2. **Created helper method** `get_primary_dimensions()` that:
   - Extracts dimensions from `renders` array (AdCP v2.4 spec - primary)
   - Falls back to `requirements` field (legacy support)
   - Returns `(width, height)` tuple or `None`
3. **Updated product form code** in `src/admin/blueprints/products.py` to use the new helper

## Verification
✅ Tested against production creative agent - all queries work correctly:
- 300x250 formats: 3 formats returned with dimensions
- 728x90 formats: 3 formats returned with dimensions  
- All display formats: 20 formats returned

## Impact
- Formats from creative agents will now display dimensions correctly in the product form
- GAM product creation/editing will show proper format dimensions
- Backward compatible - falls back to parsing format_id if renders/requirements missing
- Follows AdCP v2.4 spec properly

## Testing
Added diagnostic tools in `tools/` for future debugging:
- `diagnose_creative_agent.py` - Full diagnostic with multiple test queries
- `diagnose_creative_agent_detailed.py` - Detailed format structure inspector
- `test_format_dimensions.py` - Tests dimension extraction with Format schema