### PR TITLE
Debug: Add logging for ad unit and countries fields in product edit

### DIFF
--- a/src/admin/blueprints/products.py
+++ b/src/admin/blueprints/products.py
@@ -703,6 +703,15 @@ def edit_product(tenant_id, product_id):
                 pricing_fields = {k: v for k, v in form_data.items() if "pricing" in k or "rate_" in k or "floor_" in k}
                 logger.info(f"[DEBUG] Pricing form fields for product {product_id}: {pricing_fields}")
 
+                # Debug: Log ad unit and countries fields
+                targeting_fields = {
+                    "targeted_ad_unit_ids": form_data.get("targeted_ad_unit_ids"),
+                    "targeted_placement_ids": form_data.get("targeted_placement_ids"),
+                    "countries": countries_list,
+                    "formats": formats,
+                }
+                logger.info(f"[DEBUG] Targeting/format fields for product {product_id}: {targeting_fields}")
+
                 # Update basic fields
                 product.name = form_data.get("name", product.name)
                 product.description = form_data.get("description", product.description)


### PR DESCRIPTION
Adding debug logging to diagnose why ad units and countries are not being saved when editing products.

This will help us see:
- What values are being submitted for targeted_ad_unit_ids
- What values are being submitted for countries
- What formats are being sent

Related to inventory targeting issue.