### PR TITLE
Fix adapter config route structure to match template URLs

### DIFF
--- a/src/admin/app.py
+++ b/src/admin/app.py
@@ -262,7 +262,9 @@ def create_app(config=None):
     app.register_blueprint(creatives_bp, url_prefix="/tenant/<tenant_id>/creatives")
     app.register_blueprint(policy_bp, url_prefix="/tenant/<tenant_id>/policy")
     app.register_blueprint(settings_bp, url_prefix="/tenant/<tenant_id>/settings")
-    app.register_blueprint(adapters_bp, url_prefix="/tenant/<tenant_id>")
+    app.register_blueprint(
+        adapters_bp
+    )  # No url_prefix - routes define their own paths like /adapters/{adapter}/config/{tenant_id}/{product_id}
     app.register_blueprint(authorized_properties_bp, url_prefix="/tenant")  # Tenant-specific routes
     app.register_blueprint(creative_agents_bp, url_prefix="/tenant/<tenant_id>/creative-agents")
     app.register_blueprint(inventory_bp)  # Has its own internal routing

--- a/src/admin/blueprints/adapters.py
+++ b/src/admin/blueprints/adapters.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 adapters_bp = Blueprint("adapters", __name__)
 
 
-@adapters_bp.route("/adapters/mock/config/<product_id>", methods=["GET", "POST"])
+@adapters_bp.route("/adapters/mock/config/<tenant_id>/<product_id>", methods=["GET", "POST"])
 @require_tenant_access()
 def mock_config(tenant_id, product_id, **kwargs):
     """Configure mock adapter settings for a product."""


### PR DESCRIPTION
## Problem
PR #462 added mock adapter config route but with incorrect path structure that caused 404 errors:
- **Route was:** `/adapters/mock/config/<product_id>`  
- **Blueprint registered with:** `url_prefix="/tenant/<tenant_id>"`
- **Result:** Full path became `/tenant/<tenant_id>/adapters/mock/config/<product_id>`
- **Template expects:** `/adapters/mock/config/{tenant_id}/{product_id}`
- **Issue:** Route didn't match template URL structure → 404 errors

## Root Cause
The `adapters_bp` blueprint was registered with `/tenant/<tenant_id>` prefix, but adapter config routes need to be **top-level paths** that include `tenant_id` explicitly. This is required to support both:
- Subdomain routing: `wonderstruck.sales-agent.scope3.com`
- Virtual host routing: `test-agent.adcontextprotocol.org`

## Solution
- **Remove url_prefix** from adapters_bp registration (similar to gam_bp)
- **Update route** to `/adapters/mock/config/<tenant_id>/<product_id>`
- Now matches template's expected URL structure
- Works with both subdomain and virtual host routing

## Files Changed
- `src/admin/blueprints/adapters.py`: Updated route path
- `src/admin/app.py`: Removed url_prefix from adapters_bp registration

## Testing
After deployment, verify these URLs work:
- ✅ `https://wonderstruck.sales-agent.scope3.com/adapters/mock/config/wonderstruck/{product_id}`
- ✅ `https://test-agent.adcontextprotocol.org/adapters/mock/config/default/{product_id}`

Both should load the mock adapter configuration page with creative formats.