### PR TITLE
Fix format display and unhashable FormatId errors in products UI

### DIFF
--- a/templates/add_product_gam.html
+++ b/templates/add_product_gam.html
@@ -116,7 +116,7 @@
                    data-agent-url="{{ format.agent_url or '' }}"
                    data-search="{{ format.name|lower }} {{ format.type|lower }} {{ format.dimensions or '' }}"
                    style="border: 2px solid #ddd; border-radius: 4px; padding: 1rem; cursor: pointer; transition: all 0.2s; background: white; position: relative;">
-                <input type="checkbox" name="formats" value="{{ format.agent_url }}|{{ format.format_id }}" data-format-id="{{ format.format_id }}" data-agent-url="{{ format.agent_url }}" {% if selected_format_ids and format.format_id in selected_format_ids %}checked{% endif %} style="margin-right: 0.5rem;">
+                <input type="checkbox" name="formats" value="{{ format.agent_url }}|{{ format.format_id }}" data-format-id="{{ format.format_id }}" data-agent-url="{{ format.agent_url }}" {% if selected_format_ids and (format.agent_url, format.format_id) in selected_format_ids %}checked{% endif %} style="margin-right: 0.5rem;">
                 <strong>{{ format.name }}</strong>
                 <span class="format-info-icon" onclick="event.preventDefault(); event.stopPropagation(); showFormatInfo('{{ format.name }}', '{{ format.description or 'No description available' }}', '{{ format.preview_url or '' }}', '{{ format.agent_url or '' }}', '{{ format.format_id }}');" style="cursor: help; color: #007bff; font-size: 0.9rem; margin-left: 0.3rem; float: right;">ⓘ</span>
                 <br>


### PR DESCRIPTION
## Problem
Product formats displayed as ugly repr strings like `agent_url='...' id='display_970x250_generative'` instead of clean format names. Edit product page crashed with `unhashable type: FormatId`.

## Root Causes
1. Format resolution code had layers of fallbacks masking data issues
2. Tried to add Pydantic FormatId objects to set (not hashable)
3. Legacy string format support perpetuated deprecated data structure

## Solution
Apply same pattern as main.py fix (commit 14d5a7ca):
- Use composite key tuples `(agent_url, format_id)` per AdCP spec
- Remove all string format fallbacks (deprecated data structure)
- Clear error logging for invalid/deprecated formats instead of silent fallbacks
- Fail fast with actionable error messages

## Changes
- **list_products()**: Clean format resolution with proper error logging
- **edit_product()**: Use composite key tuples for `selected_format_ids` set
- **add/edit product parsing**: Remove string format fallbacks, validate structure
- **add_product_gam.html**: Check selection using composite key tuples

## Format Structure per AdCP Spec
- Database JSONB: `{"agent_url": "...", "id": "..."}`
- Pydantic objects have `format_id` attribute (serializes to `"id"` in JSON)
- String formats are DEPRECATED and will error

## Test Plan
- [x] Products list page displays clean format names
- [x] Edit product page doesn't crash with unhashable error
- [x] Selected formats are correctly checked in edit form
- [x] Invalid format data logs clear errors
- [x] Pre-commit hooks pass
- [x] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)