### PR TITLE
Fix format checkboxes not pre-checking on product edit

### DIFF
--- a/src/admin/blueprints/products.py
+++ b/src/admin/blueprints/products.py
@@ -81,7 +81,7 @@ def get_creative_formats(
             )
 
         format_dict = {
-            "format_id": fmt.format_id,
+            "id": fmt.format_id,  # Use "id" to match database schema (AdCP spec)
             "agent_url": fmt.agent_url,
             "name": fmt.name,
             "type": fmt.type,

--- a/templates/add_product_gam.html
+++ b/templates/add_product_gam.html
@@ -108,7 +108,7 @@
         <div id="formats-container" style="display: {% if product and product.formats %}grid{% else %}none{% endif %}; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 1rem; margin-bottom: 1rem; max-height: 500px; overflow-y: auto; padding: 1rem; background: #f9f9f9; border: 1px solid #ddd; border-radius: 4px;">
             {% for format in formats %}
             <label class="format-card"
-                   data-format-id="{{ format.format_id }}"
+                   data-format-id="{{ format.id }}"
                    data-dimensions="{{ format.dimensions or '' }}"
                    data-type="{{ format.type }}"
                    data-description="{{ format.description or '' }}"
@@ -116,9 +116,9 @@
                    data-agent-url="{{ format.agent_url or '' }}"
                    data-search="{{ format.name|lower }} {{ format.type|lower }} {{ format.dimensions or '' }}"
                    style="border: 2px solid #ddd; border-radius: 4px; padding: 1rem; cursor: pointer; transition: all 0.2s; background: white; position: relative;">
-                <input type="checkbox" name="formats" value="{{ format.agent_url }}|{{ format.format_id }}" data-format-id="{{ format.format_id }}" data-agent-url="{{ format.agent_url }}" {% if selected_format_ids and (format.agent_url, format.format_id) in selected_format_ids %}checked{% endif %} style="margin-right: 0.5rem;">
+                <input type="checkbox" name="formats" value="{{ format.agent_url }}|{{ format.id }}" data-format-id="{{ format.id }}" data-agent-url="{{ format.agent_url }}" {% if selected_format_ids and (format.agent_url, format.id) in selected_format_ids %}checked{% endif %} style="margin-right: 0.5rem;">
                 <strong>{{ format.name }}</strong>
-                <span class="format-info-icon" onclick="event.preventDefault(); event.stopPropagation(); showFormatInfo('{{ format.name }}', '{{ format.description or 'No description available' }}', '{{ format.preview_url or '' }}', '{{ format.agent_url or '' }}', '{{ format.format_id }}');" style="cursor: help; color: #007bff; font-size: 0.9rem; margin-left: 0.3rem; float: right;">ⓘ</span>
+                <span class="format-info-icon" onclick="event.preventDefault(); event.stopPropagation(); showFormatInfo('{{ format.name }}', '{{ format.description or 'No description available' }}', '{{ format.preview_url or '' }}', '{{ format.agent_url or '' }}', '{{ format.id }}');" style="cursor: help; color: #007bff; font-size: 0.9rem; margin-left: 0.3rem; float: right;">ⓘ</span>
                 <br>
                 <small style="color: #666;">
                     {{ format.type }}


### PR DESCRIPTION
## Summary

Fixes the issue where format checkboxes weren't pre-checked when editing a product, making it impossible to see which formats were currently selected.

## Problem

After PR #480 migrated database formats from `format_id` → `id`, there was a mismatch between:
- **Database**: formats with `{"agent_url": "...", "id": "..."}` 
- **Template format dicts**: had `{"agent_url": "...", "format_id": "..."}` from `get_creative_formats()`
- **Checkbox comparison**: `selected_format_ids` set compared `(agent_url, format_id)` tuples against database formats with `id`
- **Result**: No match → checkboxes never pre-checked!

Users couldn't see which formats were selected, making editing impossible.

## Root Cause

`get_creative_formats()` in `products.py:84` created format dicts with `format_id` key, but database now uses `id` key (AdCP spec compliant). Template used `format.format_id` everywhere, causing the mismatch.

## Fix

- **src/admin/blueprints/products.py:84** - Changed `format_dict["format_id"]` → `format_dict["id"]` to match database schema
- **templates/add_product_gam.html** - Changed all `format.format_id` → `format.id` references (lines 111, 119, 121)

Now checkbox values match database format objects, so pre-checking works correctly.

## Testing

Manual test after deployment:
1. Go to product edit page
2. Current formats should now be pre-checked
3. Change selections and save
4. Verify new formats persist (flag_modified fix from PR #480)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>