### PR TITLE
Fix product add 500 error and JSON serialization

### DIFF
--- a/src/admin/blueprints/products.py
+++ b/src/admin/blueprints/products.py
@@ -107,7 +107,11 @@ def get_creative_formats(
             )
 
         format_dict = {
-            "id": fmt.format_id,  # Use "id" to match database schema (AdCP spec)
+            "id": (
+                fmt.format_id.id
+                if isinstance(fmt.format_id, object) and hasattr(fmt.format_id, "id")
+                else str(fmt.format_id)
+            ),  # Extract string ID from FormatId object
             "agent_url": fmt.agent_url,
             "name": fmt.name,
             "type": fmt.type,
@@ -552,13 +556,8 @@ def add_product(tenant_id):
                                 f"Use 'Browse Ad Units' to select valid ad units.",
                                 "error",
                             )
-                            return render_template(
-                                "add_product_gam.html",
-                                tenant_id=tenant_id,
-                                tenant_name=tenant.name,
-                                form_data=form_data,
-                                error="Invalid ad unit IDs",
-                            )
+                            # Redirect to form instead of re-rendering to avoid missing context
+                            return redirect(url_for("products.add_product", tenant_id=tenant_id))
 
                         base_config["targeted_ad_unit_ids"] = id_list
 
@@ -787,6 +786,7 @@ def add_product(tenant_id):
         return render_template(
             "add_product_gam.html",
             tenant_id=tenant_id,
+            tenant_name=tenant.name,
             inventory_synced=inventory_synced,
             formats=get_creative_formats(tenant_id=tenant_id),
             authorized_properties=properties_list,


### PR DESCRIPTION
## Summary
Fixes the 500 error on `/admin/tenant/tenant_wonderstruck/products/add` reported in production.

## Root Cause
**Production Error (2025-10-16 20:12:16 UTC):**
```
TypeError: Object of type FormatId is not JSON serializable
Exception on /tenant/tenant_wonderstruck/products/add [GET]
```

The `get_creative_formats()` function in `products.py:110` was assigning the entire `FormatId` Pydantic object to `format_dict["id"]` instead of extracting the string ID field. When Flask tried to serialize this for the Jinja2 template, it failed because `FormatId` (a BaseModel with `agent_url` and `id` fields) isn't JSON serializable.

## Changes
1. **Fixed FormatId serialization** (`products.py:110`):
   - Extract string `id` from `FormatId` object: `fmt.format_id.id`
   - Added fallback to `str()` for backward compatibility
   
2. **Fixed error handler** (`products.py:555`):
   - Changed from `render_template()` to `redirect()` to avoid missing template context variables
   - Prevents similar issues where required variables (`formats`, `currencies`, `inventory_synced`, etc.) are missing

3. **Added tenant_name** (`products.py:790`):
   - For consistency in template context

## Testing
- ✅ All unit tests passing (781 passed)
- ✅ All integration tests passing (174 passed)
- ✅ Pre-commit hooks passing
- 🔍 Verified fix addresses actual production error from Fly.io logs

## Impact
- Fixes 500 error when accessing product add page for tenant_wonderstruck (and any other tenant)
- Improves error handling for form validation failures
- No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>