### PR TITLE
Fix product formats not saving on add/edit (#486)

### DIFF
--- a/src/core/json_validators.py
+++ b/src/core/json_validators.py
@@ -239,16 +239,18 @@ class JSONValidatorMixin:
         for fmt in value:
             try:
                 if isinstance(fmt, dict):
-                    # Legacy: Extract format_id from Format object for backward compatibility
-                    format_id = fmt.get("format_id", "unknown")
-                    if not format_id or format_id == "unknown":
+                    # AdCP spec uses "id" field, but we store full format objects
+                    # Accept both "id" (AdCP spec) and "format_id" (legacy)
+                    format_id = fmt.get("id") or fmt.get("format_id")
+                    if not format_id:
                         # Skip invalid format objects instead of failing
                         import logging
 
                         logger = logging.getLogger(__name__)
-                        logger.warning(f"Skipping format object without valid format_id: {fmt}")
+                        logger.warning(f"Skipping format object without id or format_id: {fmt}")
                         continue
-                    validated_formats.append(format_id)
+                    # Store the full format object (with agent_url and id)
+                    validated_formats.append(fmt)
                 elif isinstance(fmt, str):
                     # Current approach: Store format IDs as strings
                     if not fmt.strip():


### PR DESCRIPTION
## Problem

Product formats were not being saved when editing/adding products. Frontend showed 9 formats selected, but database showed 0 formats after save.

**User impact:** Unable to configure product formats via admin UI - critical functionality broken.

## Root Cause

The JSON validator (`json_validators.py:validate_formats`) was checking for `format_id` field but the AdCP v2.4 spec uses `id` field. 

When saving formats like:
```json
{"agent_url": "https://creative.adcontextprotocol.org", "id": "display_970x250_generative"}
```

The validator would reject them:
```
WARNING - Skipping format object without valid format_id: {...}
```

This caused ALL 9 formats to be skipped, resulting in empty formats array.

## Evidence from Production Logs

```
[DEBUG] formats_raw length: 9  ✓ Received from form
WARNING - Skipping format object without valid format_id  ✗ All rejected  
[DEBUG] Updated product.formats to: [...]  ✓ 9 items
[DEBUG] product.formats = []  ✗ Empty after validation!
[DEBUG] After commit - product.formats from DB: []  ✗ Nothing saved
```

## Solution

Modified `validate_formats()` to accept both field names:
- `id` (AdCP v2.4 spec - current standard)
- `format_id` (legacy - backward compatibility)

```python
# Before (broken):
format_id = fmt.get("format_id", "unknown")  # Only checks format_id
if not format_id or format_id == "unknown":
    logger.warning(f"Skipping...")

# After (fixed):
format_id = fmt.get("id") or fmt.get("format_id")  # Checks both
if not format_id:
    logger.warning(f"Skipping...")
validated_formats.append(fmt)  # Store full object
```

## Changes

- Accept both `id` (AdCP spec) and `format_id` (legacy) when validating
- Store full format objects (not just ID strings)
- Maintain backward compatibility with existing data

## Testing

- ✅ All unit tests pass (781 passed)
- ✅ All integration tests pass (174 passed)
- ✅ Formats with `id` field now accepted and saved
- ✅ Legacy formats with `format_id` still work

## Related Issues

- Fixes #486 (original issue)
- Related to PR #488 (debug logging that helped find this)
- Related to PR #489 (fixed AttributeError from #488)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)