### PR TITLE
Fix MCP connection and format lookup

### DIFF
--- a/tests/e2e/schemas/v1/_schemas_v1_core_format_json.json
+++ b/tests/e2e/schemas/v1/_schemas_v1_core_format_json.json
@@ -9,11 +9,6 @@
       "$ref": "/schemas/v1/core/format-id.json",
       "description": "Structured format identifier with agent URL and format name"
     },
-    "agent_url": {
-      "type": "string",
-      "format": "uri",
-      "description": "Base URL of the agent that provides this format (authoritative source). E.g., 'https://reference.adcp.org', 'https://dco.example.com'"
-    },
     "name": {
       "type": "string",
       "description": "Human-readable format name"


### PR DESCRIPTION
## Background
Intermittent "Client failed to connect: Session terminated" errors occurred when verifying creative formats, leading to failed media buy creations. Additionally, the `get_format` method incorrectly compared a `FormatId` object with a string.

## Changes
- **`src/core/creative_agent_registry.py`**:
    - Added `asyncio` import.
    - Implemented a retry mechanism with exponential backoff (3 attempts, 1s/2s/4s delay) for MCP connections to handle transient network issues.
    - Normalized agent URLs using `normalize_agent_url` to prevent double slashes before appending `/mcp`.
    - Modified the `get_format` method to correctly compare `fmt.format_id.id` (string) with the provided `format_id` (string).
    - Updated logging for connection attempts and failures.
- **`tests/e2e/schemas/v1/_schemas_v1_core_format_json.json`**:
    - Removed the `agent_url` field from the schema as it's now handled by `FormatId`.

## Testing
- [ ] Test MCP connection with a known-good agent URL.
- [ ] Test MCP connection with a URL that is temporarily unavailable to verify retry logic.
- [ ] Verify format lookup in `get_format` with various format IDs.
- [ ] Ensure URL normalization prevents double slashes in MCP requests.
