### PR TITLE
Remove duplicate format config from mock adapter

### DIFF
--- a/src/admin/blueprints/adapters.py
+++ b/src/admin/blueprints/adapters.py
@@ -10,7 +10,6 @@ from src.admin.utils import require_tenant_access
 from src.admin.utils.audit_decorator import log_admin_action
 from src.core.database.database_session import get_db_session
 from src.core.database.models import Product
-from src.core.format_resolver import list_available_formats
 
 logger = logging.getLogger(__name__)
 
@@ -57,10 +56,8 @@ def mock_config(tenant_id, product_id, **kwargs):
                     "update_interval_seconds": float(request.form.get("update_interval_seconds", 1.0)),
                 }
 
-                # Creative formats
-                selected_formats = request.form.getlist("formats")
-                if selected_formats:
-                    config["formats"] = selected_formats
+                # Note: Creative formats are managed in product.formats (via add/edit product page)
+                # NOT in implementation_config - removing format handling to avoid duplication
 
                 # Debug settings
                 config["verbose_logging"] = "verbose_logging" in request.form
@@ -76,49 +73,15 @@ def mock_config(tenant_id, product_id, **kwargs):
                 logger.error(f"Error saving mock config: {e}", exc_info=True)
                 flash(f"Error saving configuration: {str(e)}", "error")
 
-        # GET request - fetch formats and render template
-        try:
-            logger.info(f"Fetching creative formats for tenant {tenant_id}")
-            all_formats = list_available_formats(tenant_id=tenant_id)
-            logger.info(f"Successfully fetched {len(all_formats)} formats from creative agents")
+        # GET request - render template with product config
+        config = product.implementation_config or {}
 
-            # Convert formats to template-friendly dicts
-            formats = []
-            for fmt in all_formats:
-                dimensions = fmt.get_primary_dimensions()
-                formats.append(
-                    {
-                        "format_id": fmt.format_id.id if hasattr(fmt.format_id, "id") else str(fmt.format_id),
-                        "name": fmt.name,
-                        "type": fmt.type,
-                        "dimensions": f"{dimensions[0]}x{dimensions[1]}" if dimensions else None,
-                        "duration": getattr(fmt, "duration", None),
-                    }
-                )
-
-            # Get selected formats from product config
-            config = product.implementation_config or {}
-            selected_formats = config.get("formats", [])
-
-            return render_template(
-                "adapters/mock_product_config.html",
-                tenant_id=tenant_id,
-                product=product,
-                formats=formats,
-                selected_formats=selected_formats,
-                config=config,
-            )
-        except Exception as e:
-            logger.error(f"Error fetching formats: {e}", exc_info=True)
-            return render_template(
-                "adapters/mock_product_config.html",
-                tenant_id=tenant_id,
-                product=product,
-                formats=[],  # Empty list will show the warning in template
-                selected_formats=[],
-                config=product.implementation_config or {},
-                error=f"Error fetching formats: {str(e)}",
-            )
+        return render_template(
+            "adapters/mock_product_config.html",
+            tenant_id=tenant_id,
+            product=product,
+            config=config,
+        )
 
 
 @adapters_bp.route("/adapter/<adapter_name>/inventory_schema", methods=["GET"])

--- a/templates/adapters/mock_product_config.html
+++ b/templates/adapters/mock_product_config.html
@@ -166,44 +166,27 @@
 
         <h3 style="margin-top: 2rem;">Creative Formats</h3>
         <div class="alert" style="background: #e3f2fd; border-color: #90caf9; color: #1565c0; margin-bottom: 1rem;">
-            <strong>ℹ️ Configure Creative Formats:</strong> Select the creative formats this product supports.
-            Formats are fetched from the reference creative agent (https://creative.adcontextprotocol.org).
+            <strong>ℹ️ Creative Formats:</strong> This product's formats are managed in the product edit page.
+            <a href="{{ url_for('products.edit_product', tenant_id=tenant_id, product_id=product.product_id) }}" style="color: #1565c0; text-decoration: underline;">Edit Product →</a>
         </div>
 
-        {% if formats %}
-        <div style="margin-bottom: 1rem;">
-            <input type="text" id="format-search" placeholder="Search formats by name, type, or size..."
-                   style="width: 100%; padding: 0.5rem; border: 1px solid #ddd; border-radius: 4px;"
-                   onkeyup="filterFormats()">
-        </div>
-
-        <div id="formats-container" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 1rem; max-height: 400px; overflow-y: auto; padding: 1rem; background: #f9f9f9; border: 1px solid #ddd; border-radius: 4px;">
-            {% for format in formats %}
-            <label class="format-card"
-                   data-format-id="{{ format.format_id }}"
-                   data-search="{{ format.name|lower }} {{ format.type|lower }} {{ format.dimensions or '' }}"
-                   style="border: 2px solid #ddd; border-radius: 4px; padding: 0.75rem; cursor: pointer; transition: all 0.2s; background: white;">
-                <input type="checkbox" name="formats" value="{{ format.format_id }}"
-                       {% if format.format_id in selected_formats %}checked{% endif %}
-                       style="margin-right: 0.5rem;">
-                <strong>{{ format.name }}</strong><br>
-                <small style="color: #666;">
-                    {{ format.type }}
-                    {% if format.dimensions %} - {{ format.dimensions }}{% endif %}
-                    {% if format.duration %} - {{ format.duration }}{% endif %}
-                </small>
-            </label>
-            {% endfor %}
-        </div>
-
-        <div id="format-summary" style="padding: 0.75rem; background: #d4edda; border: 1px solid #28a745; border-radius: 4px; margin-top: 1rem;">
-            <strong style="color: #155724;">Selected:</strong>
-            <span id="format-count" style="font-weight: 600;">{{ selected_formats|length }}</span> format(s)
+        {% if product.formats %}
+        <div style="padding: 1rem; background: #f9f9f9; border: 1px solid #ddd; border-radius: 4px;">
+            <div style="display: flex; flex-wrap: wrap; gap: 0.5rem;">
+                {% for format in product.formats %}
+                <span class="badge" style="display: inline-block; padding: 0.5rem 0.75rem; background: #e3f2fd; color: #1565c0; border-radius: 4px; font-size: 0.9rem;">
+                    {% if format.id or format.format_id %}
+                        {{ format.id or format.format_id }}
+                    {% else %}
+                        {{ format }}
+                    {% endif %}
+                </span>
+                {% endfor %}
+            </div>
         </div>
         {% else %}
         <div class="alert alert-warning" style="background: #fff3cd; border-color: #ffc107;">
-            <strong>⚠️ No formats available:</strong> Could not fetch formats from creative agents.
-            Please check your network connection or creative agent configuration.
+            <strong>⚠️ No formats configured:</strong> Please edit the product to add creative formats.
         </div>
         {% endif %}
 
@@ -253,56 +236,6 @@ document.getElementById('test_mode').addEventListener('change', function() {
     }
 });
 
-// Format search and filtering
-function filterFormats() {
-    const searchInput = document.getElementById('format-search');
-    const searchTerm = searchInput ? searchInput.value.toLowerCase() : '';
-    const formatCards = document.querySelectorAll('.format-card');
-
-    formatCards.forEach(card => {
-        const searchData = card.getAttribute('data-search') || '';
-        if (searchData.includes(searchTerm)) {
-            card.style.display = '';
-        } else {
-            card.style.display = 'none';
-        }
-    });
-}
-
-// Update format count on checkbox change
-function updateFormatCount() {
-    const checkedBoxes = document.querySelectorAll('input[name="formats"]:checked');
-    const countElement = document.getElementById('format-count');
-    if (countElement) {
-        countElement.textContent = checkedBoxes.length;
-    }
-}
-
-// Add event listeners for format checkboxes
-document.addEventListener('DOMContentLoaded', function() {
-    const formatCheckboxes = document.querySelectorAll('input[name="formats"]');
-    formatCheckboxes.forEach(checkbox => {
-        checkbox.addEventListener('change', updateFormatCount);
-
-        // Visual feedback on selection
-        checkbox.addEventListener('change', function() {
-            const card = this.closest('.format-card');
-            if (this.checked) {
-                card.style.borderColor = '#28a745';
-                card.style.backgroundColor = '#d4edda';
-            } else {
-                card.style.borderColor = '#ddd';
-                card.style.backgroundColor = 'white';
-            }
-        });
-
-        // Initialize visual state
-        if (checkbox.checked) {
-            const card = checkbox.closest('.format-card');
-            card.style.borderColor = '#28a745';
-            card.style.backgroundColor = '#d4edda';
-        }
-    });
-});
+// Test mode auto-adjustment remains
 </script>
 {% endblock %}


### PR DESCRIPTION
## Background
Creative format selection was duplicated across the "Add/Edit Product" page and the mock adapter's configuration page. This led to confusion and potential bugs, with formats being managed in two separate locations.

## Changes
- **`src/admin/blueprints/adapters.py`**:
  - Removed the logic for fetching and saving creative formats from `mock_config`. These are now exclusively managed via the product's `formats` field.
  - Removed the import of `list_available_formats`.
  - Simplified the GET request to only render the template with existing configuration.
- **`templates/adapters/mock_product_config.html`**:
  - Removed the creative format selection UI (search bar, checkboxes, format cards).
  - Added a read-only display of the product's configured formats, fetched from `product.formats`.
  - Added a direct link to the product's edit page for managing formats.
  - Removed associated JavaScript for format filtering and selection.

## Testing
- [ ] Verify that the mock adapter's configuration page now displays product formats as read-only.
- [ ] Confirm that navigating to the "Edit Product" page allows for format selection and that these changes are reflected on the mock adapter config page.
- [ ] Ensure all advanced mock delivery simulation settings (traffic, performance, delivery) remain accessible and functional on the mock adapter config page.
