### PR TITLE
Remove erroneous impressions update logic

### DIFF
--- a/src/core/main.py
+++ b/src/core/main.py
@@ -5652,26 +5652,7 @@ def _update_media_buy_impl(
                     return result
 
             # Handle budget updates
-            if pkg_update.impressions is not None:
-                result = adapter.update_media_buy(
-                    media_buy_id=req.media_buy_id,
-                    buyer_ref=req.buyer_ref or "",
-                    action="update_package_impressions",
-                    package_id=pkg_update.package_id,
-                    budget=pkg_update.impressions,
-                    today=datetime.combine(today, datetime.min.time()),
-                )
-                if result.errors:
-                    error_message = (
-                        result.errors[0].get("message", "Update failed") if result.errors else "Update failed"
-                    )
-                    ctx_manager.update_workflow_step(
-                        step.step_id,
-                        status="failed",
-                        error_message=error_message,
-                    )
-                    return result
-            elif pkg_update.budget is not None:
+            if pkg_update.budget is not None:
                 result = adapter.update_media_buy(
                     media_buy_id=req.media_buy_id,
                     buyer_ref=req.buyer_ref or "",


### PR DESCRIPTION
## Background
The `update_media_buy` function was attempting to update an `impressions` field that is not part of the AdCP package update specification. This caused a server-side `AttributeError` for the Wonderstruck agent.

## Changes
- Removed code block (lines 5655-5673 in `src/core/main.py`) that handled updating the non-existent `impressions` field.
- The logic now correctly uses the `pkg_update.budget` field for budget updates, aligning with the AdCP v2.4 specification.

## Testing
- [ ] Verify that package budget updates succeed.
- [ ] Confirm that no `AttributeError` is raised related to `impressions`.
- [ ] Ensure existing AdCP contract tests pass.
