### PR TITLE
Refactor GAM inventory sync to background job

### DIFF
--- a/templates/inventory_browser.html
+++ b/templates/inventory_browser.html
@@ -294,8 +294,11 @@ function loadInventoryStatus() {
             }
 
             stats.innerHTML = `
-                <div><strong>Total Ad Units:</strong> ${data.total_units || 0}</div>
-                <div><strong>Root Units:</strong> ${data.root_units ? data.root_units.length : 0}</div>
+                <div><strong>Ad Units:</strong> ${data.total_units || 0}</div>
+                <div><strong>Placements:</strong> ${data.placements || 0}</div>
+                <div><strong>Labels:</strong> ${data.labels || 0}</div>
+                <div><strong>Targeting Keys:</strong> ${data.custom_targeting_keys || 0}</div>
+                <div><strong>Audience Segments:</strong> ${data.audience_segments || 0}</div>
             `;
 
             inventoryTree = data;
@@ -643,7 +646,7 @@ function performSelectiveSync() {
             if (data.ad_units) message += `Ad Units: ${data.ad_units.total}\n`;
             if (data.placements) message += `Placements: ${data.placements.total}\n`;
             if (data.labels) message += `Labels: ${data.labels.total}\n`;
-            if (data.custom_targeting) message += `Custom Targeting Keys: ${data.custom_targeting.total_keys}, Values: ${data.custom_targeting.total_values}\n`;
+            if (data.custom_targeting) message += `Custom Targeting Keys: ${data.custom_targeting.total_keys} (values lazy-loaded per key)\n`;
             if (data.audience_segments) message += `Audience Segments: ${data.audience_segments.total}\n`;
             message += `\nDuration: ${data.duration_seconds.toFixed(2)}s`;
 


### PR DESCRIPTION
## Background
Inventory syncs were timing out for tenants with large GAM accounts. The previous implementation blocked the user interface while the sync completed.

## Changes
- **`src/admin/blueprints/gam.py`**:
  - Modified `sync_gam_inventory` to initiate a background thread for the sync process.
  - Returns a `sync_id` immediately to the client.
  - Added a new endpoint `/sync-status/<sync_id>` to poll the status of the sync job.
  - Implemented `SyncJob` model to track sync status (pending, running, completed, failed) and details in the database.
  - Added logic to prevent duplicate concurrent syncs for the same tenant.
  - Updated the success response to indicate the sync has started in the background.
- **`src/services/gam_inventory_service.py`**:
  - Updated `get_inventory_stats` to return counts for placements, labels, custom targeting keys, and audience segments, in addition to ad units.
  - Modified the response structure for custom targeting keys to indicate values are lazy-loaded.
- **`static/js/tenant_settings.js`**:
  - Rewrote `syncGAMInventory` to initiate the background sync and then call `pollSyncStatus`.
  - `pollSyncStatus` polls the new `/sync-status` endpoint every 2 seconds.
  - The sync button now displays a "⏳ Syncing..." indicator with animated dots.
  - Removed verbose console logging.
  - Updated the success message to display counts for all inventory types returned by the backend.
- **`templates/inventory_browser.html`**:
  - Updated the "Quick Stats" section to display counts for all inventory types.

## Testing
- [ ] Initiate GAM inventory sync for a tenant with a large number of GAM objects (e.g., custom targeting keys). Verify the sync completes without a client-side timeout.
- [ ] Observe the sync button's behavior: it should show "⏳ Syncing..." and become disabled, then re-enable with original text upon completion.
- [ ] Verify that a new sync cannot be initiated while another is already in progress for the same tenant.
- [ ] Check the "Quick Stats" section in the inventory browser to confirm counts for Ad Units, Placements, Labels, Targeting Keys, and Audience Segments are displayed.
- [ ] Test the `/sync-status/<sync_id>` endpoint directly to confirm it returns correct status updates.
- [ ] Verify error handling for sync failures and check logs for background job errors.
