### PR TITLE
Fix SQLAlchemy session error in background sync

### DIFF
--- a/src/admin/blueprints/gam.py
+++ b/src/admin/blueprints/gam.py
@@ -581,6 +581,10 @@ def sync_gam_inventory(tenant_id):
                     409,
                 )
 
+            # Extract config values before starting background thread (avoid session issues)
+            gam_network_code = adapter_config.gam_network_code
+            gam_refresh_token = adapter_config.gam_refresh_token
+
             # Create sync job
             sync_id = f"sync_{tenant_id}_{int(datetime.now(UTC).timestamp())}"
             sync_job = SyncJob(
@@ -613,12 +617,12 @@ def sync_gam_inventory(tenant_id):
                         oauth2_client = oauth2.GoogleRefreshTokenClient(
                             client_id=os.environ.get("GAM_OAUTH_CLIENT_ID"),
                             client_secret=os.environ.get("GAM_OAUTH_CLIENT_SECRET"),
-                            refresh_token=adapter_config.gam_refresh_token,
+                            refresh_token=gam_refresh_token,
                         )
 
                         # Create GAM client
                         client = ad_manager.AdManagerClient(
-                            oauth2_client, "AdCP Sales Agent", network_code=adapter_config.gam_network_code
+                            oauth2_client, "AdCP Sales Agent", network_code=gam_network_code
                         )
 
                         # Initialize GAM inventory discovery


### PR DESCRIPTION
## Issue
Background thread was accessing `adapter_config` object from outer session, causing production error:
```
Instance <AdapterConfig at 0x...> is not bound to a Session; 
attribute refresh operation cannot proceed
```

## Root Cause
- `adapter_config` was loaded in the outer `db_session` context manager
- Background thread tried to access `adapter_config.gam_refresh_token` and `adapter_config.gam_network_code`
- By the time thread accessed these attributes, the outer session had closed

## Fix
Extract config values to local variables before starting background thread:
```python
# Extract before thread starts (avoids session issues)
gam_network_code = adapter_config.gam_network_code
gam_refresh_token = adapter_config.gam_refresh_token

# Now background thread uses local variables instead
oauth2_client = oauth2.GoogleRefreshTokenClient(
    refresh_token=gam_refresh_token,
    ...
)
```

## Testing
- Simple fix that copies values to avoid session binding
- No logic changes, just accessing data before session closes
- Fixes the production error reported

## Related
This is a hotfix for the inventory sync background processing feature merged earlier today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)