### PR TITLE
Add real-time progress tracking to inventory sync

### DIFF
--- a/alembic/versions/ed7d05fea3be_add_progress_tracking_to_sync_jobs.py
+++ b/alembic/versions/ed7d05fea3be_add_progress_tracking_to_sync_jobs.py
@@ -1,0 +1,31 @@
+"""Add progress tracking to sync_jobs
+
+Revision ID: ed7d05fea3be
+Revises: 1a7693edad5d
+Create Date: 2025-10-19 06:43:06.718520
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "ed7d05fea3be"
+down_revision: str | Sequence[str] | None = "1a7693edad5d"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Add progress column to sync_jobs table
+    op.add_column("sync_jobs", sa.Column("progress", sa.dialects.postgresql.JSONB, nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Remove progress column from sync_jobs table
+    op.drop_column("sync_jobs", "progress")

--- a/src/admin/blueprints/gam.py
+++ b/src/admin/blueprints/gam.py
@@ -628,14 +628,72 @@ def sync_gam_inventory(tenant_id):
                         # Initialize GAM inventory discovery
                         discovery = GAMInventoryDiscovery(client=client, tenant_id=tenant_id)
 
-                        # Perform full inventory sync
-                        result = discovery.sync_all()
+                        # Helper function to update progress
+                        def update_progress(phase: str, phase_num: int, total_phases: int, count: int = 0):
+                            bg_sync_job.progress = {
+                                "phase": phase,
+                                "phase_num": phase_num,
+                                "total_phases": total_phases,
+                                "count": count,
+                            }
+                            bg_session.commit()
 
-                        # Save to database
+                        # Perform full inventory sync with progress tracking
+                        total_phases = 6
+                        from datetime import datetime as dt
+
+                        start_time = dt.now()
+
+                        # Phase 1: Ad Units
+                        update_progress("Discovering Ad Units", 1, total_phases)
+                        ad_units = discovery.discover_ad_units()
+                        update_progress("Discovering Ad Units", 1, total_phases, len(ad_units))
+
+                        # Phase 2: Placements
+                        update_progress("Discovering Placements", 2, total_phases)
+                        placements = discovery.discover_placements()
+                        update_progress("Discovering Placements", 2, total_phases, len(placements))
+
+                        # Phase 3: Labels
+                        update_progress("Discovering Labels", 3, total_phases)
+                        labels = discovery.discover_labels()
+                        update_progress("Discovering Labels", 3, total_phases, len(labels))
+
+                        # Phase 4: Custom Targeting Keys
+                        update_progress("Discovering Targeting Keys", 4, total_phases)
+                        custom_targeting = discovery.discover_custom_targeting(fetch_values=False)
+                        update_progress(
+                            "Discovering Targeting Keys", 4, total_phases, custom_targeting.get("total_keys", 0)
+                        )
+
+                        # Phase 5: Audience Segments
+                        update_progress("Discovering Audience Segments", 5, total_phases)
+                        audience_segments = discovery.discover_audience_segments()
+                        update_progress("Discovering Audience Segments", 5, total_phases, len(audience_segments))
+
+                        # Phase 6: Saving to database
+                        update_progress("Saving to Database", 6, total_phases)
                         from src.services.gam_inventory_service import GAMInventoryService
 
                         inventory_service = GAMInventoryService(bg_session)
                         inventory_service._save_inventory_to_db(tenant_id, discovery)
+                        update_progress("Saving to Database", 6, total_phases, len(ad_units))
+
+                        # Build result summary
+                        end_time = dt.now()
+                        result = {
+                            "tenant_id": tenant_id,
+                            "sync_time": end_time.isoformat(),
+                            "duration_seconds": (end_time - start_time).total_seconds(),
+                            "ad_units": {"total": len(ad_units)},
+                            "placements": {"total": len(placements)},
+                            "labels": {"total": len(labels)},
+                            "custom_targeting": {
+                                "total_keys": custom_targeting.get("total_keys", 0),
+                                "note": "Values lazy loaded on demand",
+                            },
+                            "audience_segments": {"total": len(audience_segments)},
+                        }
 
                         # Update sync job with success
                         bg_sync_job.status = "completed"
@@ -695,6 +753,10 @@ def get_sync_status(tenant_id, sync_id):
                 "started_at": sync_job.started_at.isoformat() if sync_job.started_at else None,
                 "completed_at": sync_job.completed_at.isoformat() if sync_job.completed_at else None,
             }
+
+            # Include real-time progress if available
+            if sync_job.progress:
+                response["progress"] = sync_job.progress
 
             if sync_job.summary:
                 try:

--- a/src/core/database/models.py
+++ b/src/core/database/models.py
@@ -917,6 +917,7 @@ class SyncJob(Base):
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
     triggered_by: Mapped[str] = mapped_column(String(50), nullable=False)
     triggered_by_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    progress: Mapped[dict | None] = mapped_column(JSONType, nullable=True)  # Real-time progress tracking
 
     # Relationships
     tenant = relationship("Tenant")

--- a/static/js/tenant_settings.js
+++ b/static/js/tenant_settings.js
@@ -627,14 +627,41 @@ function syncGAMInventory() {
 function pollSyncStatus(syncId, button, originalText, loadingInterval) {
     const statusUrl = `${config.scriptName}/tenant/${config.tenantId}/gam/sync-status/${syncId}`;
 
+    // Show "navigate away" message
+    const syncMessage = document.createElement('div');
+    syncMessage.id = 'sync-progress-message';
+    syncMessage.className = 'alert alert-info mt-2';
+    syncMessage.innerHTML = '<strong>💡 Tip:</strong> Feel free to navigate away - the sync continues in the background!';
+    button.parentElement.appendChild(syncMessage);
+
     const checkStatus = () => {
         fetch(statusUrl)
             .then(response => response.json())
             .then(data => {
+                // Update button text with progress
+                if (data.progress) {
+                    clearInterval(loadingInterval);
+                    const progress = data.progress;
+                    const phaseText = progress.phase || 'Syncing';
+                    const count = progress.count || 0;
+                    const phaseNum = progress.phase_num || 0;
+                    const totalPhases = progress.total_phases || 6;
+
+                    if (count > 0) {
+                        button.innerHTML = `⏳ ${phaseText}: ${count} items (${phaseNum}/${totalPhases})`;
+                    } else {
+                        button.innerHTML = `⏳ ${phaseText} (${phaseNum}/${totalPhases})`;
+                    }
+                }
+
                 if (data.status === 'completed') {
                     clearInterval(loadingInterval);
                     button.disabled = false;
                     button.innerHTML = originalText;
+
+                    // Remove progress message
+                    const msg = document.getElementById('sync-progress-message');
+                    if (msg) msg.remove();
 
                     // Show success message with summary
                     const summary = data.summary || {};
@@ -657,6 +684,11 @@ function pollSyncStatus(syncId, button, originalText, loadingInterval) {
                     clearInterval(loadingInterval);
                     button.disabled = false;
                     button.innerHTML = originalText;
+
+                    // Remove progress message
+                    const msg = document.getElementById('sync-progress-message');
+                    if (msg) msg.remove();
+
                     alert('❌ Sync failed: ' + (data.error || 'Unknown error'));
                 } else if (data.status === 'running' || data.status === 'pending') {
                     // Still running - continue polling
@@ -666,6 +698,11 @@ function pollSyncStatus(syncId, button, originalText, loadingInterval) {
                     clearInterval(loadingInterval);
                     button.disabled = false;
                     button.innerHTML = originalText;
+
+                    // Remove progress message
+                    const msg = document.getElementById('sync-progress-message');
+                    if (msg) msg.remove();
+
                     alert('❌ Unknown sync status: ' + data.status);
                 }
             })
@@ -673,6 +710,11 @@ function pollSyncStatus(syncId, button, originalText, loadingInterval) {
                 clearInterval(loadingInterval);
                 button.disabled = false;
                 button.innerHTML = originalText;
+
+                // Remove progress message
+                const msg = document.getElementById('sync-progress-message');
+                if (msg) msg.remove();
+
                 alert('❌ Error checking sync status: ' + error.message);
             });
     };


### PR DESCRIPTION
## Overview
Adds real-time phase-by-phase progress tracking to inventory sync, replacing generic "Syncing..." with specific phase info and item counts.

## Features

### 1. Phase-by-Phase Progress (6 phases)
- **Phase 1**: Discovering Ad Units
- **Phase 2**: Discovering Placements
- **Phase 3**: Discovering Labels
- **Phase 4**: Discovering Targeting Keys
- **Phase 5**: Discovering Audience Segments
- **Phase 6**: Saving to Database

### 2. Real-Time Item Counts
Button shows: `⏳ Discovering Ad Units: 243 items (1/6)`
- Phase name
- Item count discovered
- Progress (current phase / total phases)

### 3. "Navigate Away" Message
Shows info alert: *"💡 Tip: Feel free to navigate away - the sync continues in the background!"*

### 4. Polling Updates Every 2 Seconds
Frontend polls status endpoint and updates button text in real-time

## Technical Implementation

**Database:**
- Added `progress` JSONB column to `sync_jobs` table
- Migration: `ed7d05fea3be_add_progress_tracking_to_sync_jobs.py`

**Backend (`gam.py`):**
- Replace single `sync_all()` call with phase-by-phase discovery
- Update `SyncJob.progress` after each phase completion
- Helper function: `update_progress(phase, phase_num, total_phases, count)`

**Frontend (`tenant_settings.js`):**
- Parse `progress` object from status endpoint
- Update button text with phase info and counts
- Show/hide "navigate away" message
- Clear progress message on completion/error

**Status Endpoint:**
- Include `progress` field in response if available
- Format: `{"phase": "...", "phase_num": 1, "total_phases": 6, "count": 243}`

## UX Improvements

**Before:**
```
⏳ Syncing...
```

**After:**
```
⏳ Discovering Ad Units: 243 items (1/6)
⏳ Discovering Placements: 67 items (2/6)
⏳ Discovering Labels: 12 items (3/6)
⏳ Discovering Targeting Keys: 145 items (4/6)
⏳ Discovering Audience Segments: 23 items (5/6)
⏳ Saving to Database: 243 items (6/6)
```

Plus info message: "💡 Feel free to navigate away - the sync continues in the background!"

## Testing Notes
- Tested with AccuWeather sync (running in production now)
- Progress updates visible every 2 seconds
- No breaking changes to existing sync functionality
- Migration is additive (new nullable column)

## Related
Follow-up to PR #507 (background sync with polling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)