### PR TITLE
Fix migration head conflict causing 503 errors

### DIFF
--- a/alembic/versions/ed7d05fea3be_add_progress_tracking_to_sync_jobs.py
+++ b/alembic/versions/ed7d05fea3be_add_progress_tracking_to_sync_jobs.py
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "ed7d05fea3be"
-down_revision: str | Sequence[str] | None = "1a7693edad5d"
+down_revision: str | Sequence[str] | None = "661c474053fa"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 


### PR DESCRIPTION
## Critical Bug Fix

### Issue
The progress tracking feature (PR #508) created a **migration head conflict** causing 503 errors in production.

### Symptoms
- ❌ 503 errors when polling sync status
- ❌ Migration error: "Multiple head revisions are present for given argument 'head'"
- ❌ Database migrations failing on deployment
- ❌ `progress` column never created in production database
- ❌ Code accessing `sync_job.progress` causing AttributeError → 503

### Root Cause
Two migrations both pointed to the same parent (`1a7693edad5d`), creating a branch:

```
1a7693edad5d (branchpoint)
├─→ 661c474053fa (add_gam_service_account_email)
└─→ ed7d05fea3be (add progress tracking) ← CONFLICT!
```

Alembic couldn't determine which migration to run when executing `alembic upgrade head`.

### Fix
Updated progress tracking migration to depend on `661c474053fa` instead of `1a7693edad5d`, creating a linear chain:

```
1a7693edad5d → 661c474053fa → ed7d05fea3be ✅
```

### Changes
**File**: `alembic/versions/ed7d05fea3be_add_progress_tracking_to_sync_jobs.py`
- Changed `down_revision` from `"1a7693edad5d"` to `"661c474053fa"`

### Verification
```bash
$ uv run alembic heads
ed7d05fea3be (head)  # ✅ Single head!
```

### Impact
- ✅ Migration will run successfully on next deploy
- ✅ `progress` column will be created in database
- ✅ 503 errors will be resolved
- ✅ Progress tracking will work correctly
- ✅ AccuWeather sync can complete and report progress

### Testing
- Pre-commit hooks: ✅ Passed (including "Check for multiple Alembic migration heads")
- Alembic heads check: ✅ Single head confirmed
- Migration history: ✅ Linear chain verified

### Priority
**🚨 HIGH** - Blocks progress tracking feature from working in production

### Related
- PR #508: Add real-time progress tracking to inventory sync
- Current issue: AccuWeather sync running but can't report progress (503 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)