### PR TITLE
Fix timezone-aware datetime comparison in stale sync detection

### DIFF
--- a/src/admin/blueprints/gam.py
+++ b/src/admin/blueprints/gam.py
@@ -572,7 +572,12 @@ def sync_gam_inventory(tenant_id):
                 # Check if sync is stale (running for >1 hour with no progress updates)
                 from datetime import timedelta
 
-                time_running = datetime.now(UTC) - existing_sync.started_at
+                # Make started_at timezone-aware if it's naive (from database)
+                started_at = existing_sync.started_at
+                if started_at.tzinfo is None:
+                    started_at = started_at.replace(tzinfo=UTC)
+
+                time_running = datetime.now(UTC) - started_at
                 is_stale = time_running > timedelta(hours=1) and not existing_sync.progress
 
                 if is_stale:


### PR DESCRIPTION
## Problem
Sync endpoint returns 500 error when trying to detect stale syncs:
```
TypeError: can't subtract offset-naive and offset-aware datetimes
```

**Root cause:** Database timestamps () are timezone-naive, but  is timezone-aware. Can't subtract them directly.

## Solution
Convert timezone-naive database timestamp to timezone-aware before comparison:
```python
# Make started_at timezone-aware if it's naive (from database)
started_at = existing_sync.started_at
if started_at.tzinfo is None:
    started_at = started_at.replace(tzinfo=UTC)

time_running = datetime.now(UTC) - started_at
```

## Testing
- Fixes 500 error when clicking "Sync Inventory" button
- Allows stale sync detection to work properly
- User can now start fresh sync after old one is marked as failed

## Changes
- `src/admin/blueprints/gam.py`: Add timezone conversion for database timestamps

Fixes 500 error when trying to start AccuWeather inventory sync