### PR TITLE
Fix: Show service account email in UI after creation

### DIFF
--- a/src/admin/blueprints/tenants.py
+++ b/src/admin/blueprints/tenants.py
@@ -236,6 +236,7 @@ def tenant_settings(tenant_id, section=None):
                     "refresh_token": adapter_config_obj.gam_refresh_token or "",
                     "trafficker_id": adapter_config_obj.gam_trafficker_id or "",
                     "application_name": getattr(adapter_config_obj, "gam_application_name", "") or "",
+                    "service_account_email": adapter_config_obj.gam_service_account_email or "",
                 }
 
             # Get environment info for URL generation


### PR DESCRIPTION
## Problem
After creating a service account successfully, the UI was not showing the service account details. Instead, it continued to show the "Create Service Account" button.

## Root Cause  
The adapter_config_dict passed to the template in tenant_settings() was missing the service_account_email field. It only included network_code, refresh_token, trafficker_id, and application_name, but NOT service_account_email.

## Solution
Added service_account_email to the adapter_config_dict so the template can correctly detect when a service account exists and display:
- Service account email with copy button
- Next steps for adding to GAM  
- Test Connection button

## Testing
- Verified the field is now included in the dict
- Template logic already handles this correctly
- UI will now properly display service account details after creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>