### PR TITLE
Fix webhook operation name for list_creatives

### DIFF
--- a/src/core/context_manager.py
+++ b/src/core/context_manager.py
@@ -566,11 +566,13 @@ class ContextManager(DatabaseManager):
 
                 for webhook_config in webhooks:
                     # Build notification payload
+                    # Use tool_name for operation identification, mapping.action for workflow action context
                     payload = {
                         "step_id": step.step_id,
                         "object_type": mapping.object_type,
                         "object_id": mapping.object_id,
-                        "action": mapping.action,
+                        "operation": step.tool_name or mapping.action,  # Tool name is the actual operation
+                        "action": mapping.action,  # Workflow action (e.g., "approval_required", "created")
                         "status": new_status,
                         "step_type": step.step_type,
                         "owner": step.owner,


### PR DESCRIPTION
## Background
Webhook notifications for `list_creatives` calls were incorrectly labeled with "sync_creatives" as the operation, causing confusion for consumers.

## Changes
- Modified `src/core/context_manager.py` around lines 567-580.
- The `payload` dictionary for webhook notifications now includes a new `operation` field.
- This `operation` field is populated with `step.tool_name` (e.g., "list_creatives") to accurately reflect the AdCP operation.
- The existing `action` field (e.g., "created", "approval_required") is preserved from `mapping.action` for workflow context.

## Testing
- [ ] Trigger a `list_creatives` call and verify the webhook payload's `operation` field shows "list_creatives".
- [ ] Trigger a `sync_creatives` call and verify the webhook payload's `operation` field shows "sync_creatives".
- [ ] Trigger a call with a different `mapping.action` (e.g., "approval_required") and verify the `action` field is correctly populated.
