### PR TITLE
Fix get_products_raw to use correct request object

### DIFF
--- a/src/core/tools.py
+++ b/src/core/tools.py
@@ -122,9 +122,8 @@ async def get_products_raw(
         filters=filters,
     )
 
-    # Call shared implementation with unwrapped variant
-    # GetProductsRequest is a RootModel, so we pass req.root (the actual variant)
-    return await _get_products_impl(req.root, context)  # type: ignore[arg-type]
+    # Call shared implementation
+    return await _get_products_impl(req, context)  # type: ignore[arg-type]
 
 
 async def get_signals_raw(req: GetSignalsRequest, context: Context = None) -> GetSignalsResponse:


### PR DESCRIPTION
## Background
The A2A skill `get_products` was failing with an `AttributeError: 'GetProductsRequest' object has no attribute 'root'`. This was because the `GetProductsRequest` object was refactored to be a standard `BaseModel` but the A2A path was still trying to access a `.root` attribute, which is only present on `RootModel` objects.

## Changes
- Modified `src/core/tools.py` in the `get_products_raw` function.
- Changed the call from `_get_products_impl(req.root, context)` to `_get_products_impl(req, context)` to pass the `GetProductsRequest` object directly.

## Testing
- [ ] Verify `get_products` A2A skill call succeeds with a valid request.
- [ ] Test with different product filter inputs.
