### PR TITLE
Fix AI creative review auto-reject threshold to require high confidence

### DIFF
--- a/templates/tenant_settings.html
+++ b/templates/tenant_settings.html
@@ -1191,14 +1191,14 @@ REJECT - Creative cannot be approved:
                                 <div class="form-group" style="margin-top: 1rem;">
                                     <label for="auto_reject_threshold">
                                         Auto-Reject Threshold
-                                        <span style="color: #ef4444; font-weight: 600; margin-left: 0.5rem;" id="reject_threshold_value">10%</span>
+                                        <span style="color: #ef4444; font-weight: 600; margin-left: 0.5rem;" id="reject_threshold_value">90%</span>
                                     </label>
                                     <input type="range" id="auto_reject_threshold" name="auto_reject_threshold"
-                                           min="0.0" max="0.5" step="0.05"
-                                           value="{{ (tenant.ai_policy.auto_reject_threshold if tenant.ai_policy else 0.10) }}"
+                                           min="0.5" max="1.0" step="0.05"
+                                           value="{{ (tenant.ai_policy.auto_reject_threshold if tenant.ai_policy else 0.90) }}"
                                            class="form-control" style="margin-bottom: 0.5rem;"
                                            oninput="document.getElementById('reject_threshold_value').textContent = Math.round(this.value * 100) + '%'">
-                                    <small>AI must be this certain or less to auto-reject (default: 10%)</small>
+                                    <small>AI must be at least this confident to auto-reject (default: 90%)</small>
                                 </div>
                             </div>
 

--- a/tests/e2e/schemas/v1/_schemas_v1_core_product_json.json
+++ b/tests/e2e/schemas/v1/_schemas_v1_core_product_json.json
@@ -42,6 +42,14 @@
         "$ref": "/schemas/v1/core/format-id.json"
       }
     },
+    "placements": {
+      "type": "array",
+      "description": "Optional array of specific placements within this product. When provided, buyers can target specific placements when assigning creatives.",
+      "items": {
+        "$ref": "/schemas/v1/core/placement.json"
+      },
+      "minItems": 1
+    },
     "delivery_type": {
       "$ref": "/schemas/v1/enums/delivery-type.json"
     },


### PR DESCRIPTION
## Problem
The AI creative review UI showed conflicting information about auto-reject thresholds:
- **UI slider**: 10-50% range with default 10%
- **UI description**: "AI must be this certain or **less** to auto-reject" (backwards logic)
- **Code logic**: Correctly required ≥90% confidence for auto-rejection
- **User confusion**: Screenshot showed 40% reject threshold, implying low confidence triggers rejection

## Root Cause
The original template incorrectly implied that **low confidence (10%)** should trigger auto-rejection. This is backwards - both approval AND rejection should require **high confidence (90%+)**, with low-confidence decisions routing to human review.

## Solution
Updated `templates/tenant_settings.html` to match code behavior:

| Field | Before | After |
|-------|--------|-------|
| Slider range | `0.0-0.5` (0-50%) | `0.5-1.0` (50-100%) |
| Default value | `0.10` (10%) | `0.90` (90%) |
| Description | "AI must be this certain or **less**" | "AI must be **at least this confident**" |
| Display value | 10% | 90% |

## Key Changes
- Fixed slider range from 0-50% to 50-100%
- Changed default from 10% to 90%
- Corrected description to "at least this confident" (matches code logic)
- Updated display value to show 90% by default
- Also synced AdCP product schema to latest registry version

## Verification
- ✅ All 20 AI review unit tests pass
- ✅ Code logic uses `>= threshold` (high confidence required)
- ✅ Tests confirm 90% default for both approve and reject
- ✅ UI now symmetrically requires high confidence for both actions
- ✅ 816 unit tests + 174 integration tests pass

## Behavior
With this fix:
- **High confidence (≥90%)** → Auto-approve or auto-reject
- **Low confidence (<90%)** → Route to human review
- **Sensitive categories** → Always route to human review (regardless of confidence)

This matches the intended design: AI should only make automatic decisions when highly confident in either direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)