### PR TITLE
Fix service account network code update validation

### DIFF
--- a/src/admin/blueprints/gam.py
+++ b/src/admin/blueprints/gam.py
@@ -74,11 +74,11 @@ def validate_gam_config(data: dict) -> list | None:
             errors.append("Refresh token is too long")
     elif auth_method == "service_account":
         # Service account JSON validation
+        # Note: service_account_json is only required on initial setup
+        # For network code updates, it's optional (already stored in DB)
         service_account_json = data.get("service_account_json", "").strip()
-        if not service_account_json:
-            errors.append("Service account JSON is required for service account authentication")
-        else:
-            # Validate JSON structure
+        if service_account_json:
+            # Validate JSON structure only if provided
             try:
                 import json
 
@@ -350,7 +350,9 @@ def configure_gam(tenant_id):
                 adapter_config.gam_refresh_token = refresh_token
                 adapter_config.gam_service_account_json = None
             elif auth_method == "service_account":
-                adapter_config.gam_service_account_json = service_account_json
+                # Only update service_account_json if provided (to allow network code updates without resending JSON)
+                if service_account_json:
+                    adapter_config.gam_service_account_json = service_account_json
                 adapter_config.gam_refresh_token = None
 
             # Also update tenant's ad_server field


### PR DESCRIPTION
## Problem

When updating the GAM network code for an existing service account, the UI was getting an error:

```
❌ Failed to save network code:
Service account JSON is required for service account authentication
```

This happened because:
1. The service account JSON is already stored in the database (created via the "Create Service Account" button)
2. The UI only sends `auth_method: 'service_account'` and `network_code: '123456789'` when saving the network code
3. The backend validation was incorrectly requiring `service_account_json` to always be present, even for network code updates

## Solution

Updated `src/admin/blueprints/gam.py`:

1. **Validation Logic (lines 76-93)**: Made `service_account_json` optional in validation
   - Only validate JSON structure if it's actually provided
   - Allows network code updates without re-sending credentials

2. **Save Logic (lines 353-356)**: Preserve existing service account credentials
   - Only update `service_account_json` database field if new value is provided
   - Prevents clearing existing credentials on network code updates

## Testing

- ✅ All pre-commit hooks passed
- ✅ Unit tests passed (822 passed, 24 skipped)
- ✅ Integration tests passed (174 passed, 75 skipped)

## Use Case

This fix enables the following workflow:
1. Admin creates a service account → credentials stored in database
2. Admin enters GAM network code → saves successfully without re-uploading JSON
3. Admin can now test the connection with stored credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>