### PR TITLE
Fix A2A update_media_buy and update_performance_index response serialization

### DIFF
--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -1637,8 +1637,19 @@ class AdCPRequestHandler(RequestHandler):
                 context=tool_context,
             )
 
-            # Convert response to A2A format
-            return response  # Raw function already returns dict format
+            # Convert response to A2A format (handle both Pydantic objects and dicts)
+            if hasattr(response, "model_dump"):
+                # Real Pydantic response object
+                result = response.model_dump(exclude_none=False, mode="json")
+                result["success"] = response.errors is None or len(response.errors) == 0
+                result["message"] = str(response)  # Human-readable message via __str__
+            else:
+                # Already a dict (from mock or legacy code)
+                result = response
+                if "success" not in result:
+                    result["success"] = result.get("errors") is None or len(result.get("errors", [])) == 0
+
+            return result
 
         except Exception as e:
             logger.error(f"Error in update_media_buy skill: {e}")
@@ -1714,8 +1725,19 @@ class AdCPRequestHandler(RequestHandler):
                 context=tool_context,
             )
 
-            # Convert response to A2A format
-            return response  # Raw function already returns dict format
+            # Convert response to A2A format (handle both Pydantic objects and dicts)
+            if hasattr(response, "model_dump"):
+                # Real Pydantic response object
+                result = response.model_dump(exclude_none=False, mode="json")
+                result["success"] = response.errors is None or len(response.errors) == 0
+                result["message"] = str(response)  # Human-readable message via __str__
+            else:
+                # Already a dict (from mock or legacy code)
+                result = response
+                if "success" not in result:
+                    result["success"] = result.get("errors") is None or len(result.get("errors", [])) == 0
+
+            return result
 
         except Exception as e:
             logger.error(f"Error in update_performance_index skill: {e}")


### PR DESCRIPTION
## Problem

The `update_media_buy` A2A endpoint was failing with a Pydantic validation error when constructing the response Part:

```
DataPart.data
  Input should be a valid dictionary [type=dict_type, input_value=UpdateMediaBuyResponse(...)]
```

## Root Cause

Two A2A skill handlers were passing Pydantic response objects directly to `DataPart`, but Pydantic expects a `dict`:

1. **`_handle_update_media_buy_skill`** (line 1641)
2. **`_handle_update_performance_index_skill`** (line 1725)

Both handlers incorrectly returned response objects without serialization, with comments claiming "Raw function already returns dict format" - which was incorrect.

## Solution

Applied the same serialization pattern used in working handlers like `create_media_buy`:

- Serialize responses using `response.model_dump(exclude_none=False, mode='json')`
- Add A2A-specific fields (`success`, `message`) to the result
- Handle both Pydantic objects (production) and dicts (mocks/tests) defensively with `hasattr(response, 'model_dump')`

## Testing

✅ All 5 tests in `test_a2a_parameter_mapping.py` pass
✅ All pre-commit hooks pass
✅ 829 unit tests passed, 174 integration tests passed

## Verification

Before:
```json
{
  "message": {
    "parts": [{
      "kind": "data",
      "data": UpdateMediaBuyResponse(...)  // ❌ Pydantic object
    }]
  }
}
```

After:
```json
{
  "message": {
    "parts": [{
      "kind": "data",
      "data": {
        "media_buy_id": "buy_123",
        "buyer_ref": "ref_123",
        "affected_packages": [],
        "success": true,
        "message": "Media buy updated successfully"
      }  // ✅ Proper dict
    }]
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>