### PR TITLE
Fix AttributeError when Context object lacks meta attribute

### DIFF
--- a/src/core/main.py
+++ b/src/core/main.py
@@ -3788,7 +3788,7 @@ def _list_authorized_properties_impl(
         headers = {}
     else:
         # FastMCP Context has meta.headers
-        headers = context.meta.get("headers", {}) if context and context.meta else {}
+        headers = context.meta.get("headers", {}) if context and hasattr(context, "meta") and context.meta else {}
         testing_context = get_testing_context(headers)
 
     # Note: apply_testing_hooks signature is (data, testing_ctx, operation, campaign_info)


### PR DESCRIPTION
## Summary
Fixed `'Context' object has no attribute 'meta'` error reported from the Wonderstruck agent by adding proper `hasattr()` check in `_list_authorized_properties_impl()`.

## Problem
Line 3791 in `src/core/main.py` used the pattern:
```python
headers = context.meta.get("headers", {}) if context and context.meta else {}
```

This raises `AttributeError` when `context` exists but doesn't have a `meta` attribute, because Python evaluates `context.meta` even when `context` is truthy but lacks the attribute.

## Solution
Changed to use `hasattr()` check:
```python
headers = context.meta.get("headers", {}) if context and hasattr(context, "meta") and context.meta else {}
```

This safely checks for the attribute's existence before accessing it.

## Testing
- ✅ All 831 unit tests pass
- ✅ All 174 integration tests pass
- ✅ Import validation successful
- ✅ Follows existing pattern used elsewhere in codebase (lines 431, 973)
- ✅ Pre-commit hooks pass

## Impact
- Prevents crashes when Context object lacks `meta` attribute
- No behavior change for contexts that do have `meta`
- Consistent with defensive programming pattern used throughout the codebase

## Related
This follows the same safe attribute access pattern used in:
- `src/core/main.py:431` - Auth header extraction
- `src/core/main.py:973` - Header debugging
- `src/core/auth_utils.py:104` - Auth utility functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>