### PR TITLE
Fix Approximated API endpoints for domain status check

### DIFF
--- a/templates/tenant_settings.html
+++ b/templates/tenant_settings.html
@@ -2349,9 +2349,25 @@ async function checkDomainRegistrationStatus() {
                 // Domain is registered
                 statusIcon.textContent = '✅';
                 statusText.textContent = 'Domain Registered';
-                statusDetails.textContent = data.tls_enabled
-                    ? 'HTTPS/TLS enabled - domain is ready'
-                    : 'TLS certificate pending (wait 1-2 minutes)';
+
+                let details = [];
+                if (data.ssl_active) {
+                    details.push('HTTPS/TLS active');
+                } else if (data.tls_enabled) {
+                    details.push('TLS certificate pending (wait 1-2 minutes)');
+                } else {
+                    details.push('TLS not yet active');
+                }
+
+                if (data.target_address) {
+                    details.push(`Backend: ${data.target_address}`);
+                }
+
+                if (data.status) {
+                    details.push(`Status: ${data.status}`);
+                }
+
+                statusDetails.textContent = details.join(' • ');
                 registerBtn.style.display = 'none';
                 unregisterBtn.style.display = 'inline-block';
             } else {


### PR DESCRIPTION
## Problem
The domain status check button in the Admin UI was returning 404 errors for domains that were actually registered and working correctly (like `test-agent.adcontextprotocol.org`).

## Root Cause
The code was using **incorrect Approximated API endpoints** that don't exist in their API:
- ❌ `/api/domains/{domain}` (doesn't exist)
- ❌ Missing required headers
- ❌ Wrong response field names

## Solution
Updated all Approximated API calls to use the correct endpoints per their official documentation:

### Backend Changes (`src/admin/blueprints/settings.py`)

**1. Check Domain Status:**
- Changed endpoint: `/api/vhosts/by/incoming/{domain}` (was `/api/domains/{domain}`)
- Added required headers: `Content-Type`, `Accept`, `api-key`
- Fixed response parsing to handle `{data: {...}}` wrapper
- Updated field names: `has_ssl` (was `tls_enabled`)

**2. Register Domain:**
- Changed endpoint: `/api/vhosts` (was `/api/domains`)
- Fixed payload structure:
  ```json
  {
    "incoming_address": "domain.com",
    "target_address": "backend.fly.dev"
  }
  ```
- Added `APPROXIMATED_BACKEND_URL` env var support (defaults to `adcp-sales-agent.fly.dev`)

**3. Unregister Domain:**
- Changed endpoint: `/api/vhosts/by/incoming/{domain}` (was `/api/domains/{domain}`)
- Added required headers

### Frontend Changes (`templates/tenant_settings.html`)

Enhanced status display to show:
- Backend target address
- SSL/TLS status (active vs pending)
- Full status from API (e.g., "ACTIVE_SSL_PROXIED")

## Testing

**Manual verification:**
```bash
# Before (404):
curl -H "api-key: ..." https://cloud.approximated.app/api/domains/test-agent.adcontextprotocol.org
# Not Found

# After (200 success):
curl -H "api-key: ..." https://cloud.approximated.app/api/vhosts/by/incoming/test-agent.adcontextprotocol.org
# {"data":{"status":"ACTIVE_SSL_PROXIED","has_ssl":true,"target_address":"sales-agent.scope3.com",...}}
```

**Automated tests:**
- ✅ All 831 unit tests pass
- ✅ All 174 integration tests pass
- ✅ All pre-commit hooks pass

## What Changes in UI

**Before:**
- ❌ "Domain Not Registered" (incorrect)

**After:**
- ✅ "Domain Registered"
- Details: "HTTPS/TLS active • Backend: sales-agent.scope3.com • Status: ACTIVE_SSL_PROXIED"
- Shows Unregister button

## Documentation Reference
- Official API docs: https://approximated.app/docs/
- Correct endpoints documented and implemented

## Impact
- ✅ Fixes false "not registered" errors for all properly configured domains
- ✅ Domain registration/unregistration now works correctly
- ✅ Better visibility into domain configuration (backend, SSL status)
- ✅ No breaking changes - backward compatible