### PR TITLE
Fix MCP tenant detection by capturing Host header

### DIFF
--- a/src/core/main.py
+++ b/src/core/main.py
@@ -425,9 +425,10 @@ def get_principal_from_context(
         return (None, None)
 
     # Get headers using the recommended FastMCP approach
+    # CRITICAL: Use include_all=True to get Host header (excluded by default)
     headers = None
     try:
-        headers = get_http_headers()
+        headers = get_http_headers(include_all=True)
     except Exception:
         pass  # Will try fallback below
 


### PR DESCRIPTION
## Summary
Fixed MCP tenant detection by ensuring the Host header is captured from HTTP requests.

## Problem
MCP `list_authorized_properties` and other tools failed with "No tenant context set" because FastMCP's `get_http_headers()` was excluding the `Host` header by default.

**Production Logs Showed:**
```
Host: None
Apx-Incoming-Host: None  
x-adcp-tenant: None
→ No tenant context set error
```

## Root Cause
FastMCP's `get_http_headers()` explicitly **excludes** the `Host` header by default (line 70 of dependencies.py) to prevent issues when forwarding headers to downstream clients.

Without the Host header, tenant detection couldn't:
1. Extract subdomain (e.g., `tenant.sales-agent.scope3.com`)
2. Lookup virtual host (e.g., `test-agent.adcontextprotocol.org`)
3. Use `Apx-Incoming-Host` for Approximated.app routing

## Solution
Call `get_http_headers(include_all=True)` to capture ALL headers including `Host`.

**Before:**
```python
headers = get_http_headers()  # Host excluded
→ Host: None
```

**After:**
```python
headers = get_http_headers(include_all=True)  # All headers
→ Host: test-agent.adcontextprotocol.org
```

## Tenant Detection Flow (Now Working)
1. **Host header** → Extract subdomain or full hostname
2. **Subdomain lookup** → Try `get_tenant_by_subdomain(subdomain)`
3. **Virtual host lookup** (fallback) → Try `get_tenant_by_virtual_host(full_host)`
4. **Apx-Incoming-Host** (for Approximated.app) → Try proxy header
5. **x-adcp-tenant** (last resort) → Try explicit tenant header

## Testing
- ✅ **Local testing**: Host header now captured (`localhost:8126`)
- ✅ **All unit tests pass** (834 passed)
- ✅ **All integration tests pass** (174 passed)
- ✅ **Production ready**: Will capture `test-agent.adcontextprotocol.org` and match virtual_host

## Impact
- Fixes MCP tenant detection for all virtual host domains
- Enables proper multi-tenant routing without requiring client-side tenant headers
- Maintains backward compatibility (clients with `x-adcp-tenant` still work)

## Related
- Complements PR #556 (MCP decorator fix) 
- Complements PR #557 (A2A tenant detection fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)