### PR TITLE
Fix nginx binding to 0.0.0.0:8000 for Fly.io load balancer

### DIFF
--- a/fly/nginx.conf
+++ b/fly/nginx.conf
@@ -41,7 +41,7 @@ http {
 
     # Admin UI subdomain server
     server {
-        listen 8000;
+        listen 0.0.0.0:8000;
         server_name admin.sales-agent.scope3.com;
 
         # Root redirects to admin index
@@ -79,7 +79,7 @@ http {
 
     # Tenant-specific subdomain routing
     server {
-        listen 8000;
+        listen 0.0.0.0:8000;
         server_name ~^(?<tenant>[^.]+)\.sales-agent\.scope3\.com$;
 
         # MCP endpoint for specific tenant - proxy entire path to MCP server
@@ -179,7 +179,7 @@ http {
 
     # Base domain server (redirects to admin)
     server {
-        listen 8000;
+        listen 0.0.0.0:8000;
         server_name sales-agent.scope3.com;
 
         # Admin UI routes
@@ -302,7 +302,7 @@ http {
 
     # Default fallback server for external domains (via Approximated)
     server {
-        listen 8000 default_server;
+        listen 0.0.0.0:8000 default_server;
         server_name _;
 
         # MCP endpoint


### PR DESCRIPTION
## Problem
Fly.io's load balancer was unable to route traffic because nginx was listening on `127.0.0.1:8000` (default when using `listen 8000;`) instead of `0.0.0.0:8000`.

The error message:
> Machines are not listening on 0.0.0.0:8000 so our proxy is having a hard time finding a candidate to route requests to.

## Solution
Updated `fly/nginx.conf` to explicitly bind to `0.0.0.0:8000` on all server blocks:
- Admin UI subdomain server
- Tenant-specific subdomain routing
- Base domain server
- Default fallback server

## Changes
- Changed `listen 8000;` to `listen 0.0.0.0:8000;` in all 4 server blocks
- The `config/nginx/nginx.conf` (used by Dockerfile.fly) already had correct bindings

## Testing
- ✅ All unit tests passed (834 passed)
- ✅ All integration tests passed (174 passed)
- ✅ Pre-commit hooks passed

## Verification
After deployment, nginx will properly bind to `0.0.0.0:8000` allowing Fly.io's proxy to route traffic correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)