### PR TITLE
Fix GAM service account authentication missing scope parameter

### DIFF
--- a/src/admin/blueprints/gam.py
+++ b/src/admin/blueprints/gam.py
@@ -1183,18 +1183,13 @@ def test_gam_connection(tenant_id):
                 except json_lib.JSONDecodeError as e:
                     return jsonify({"error": f"Invalid service account JSON: {str(e)}"}), 400
 
-                # Create OAuth2 client from service account
+                # Create credentials from service account (in-memory, no temp file needed)
                 from google.oauth2 import service_account
-                from googleads import oauth2
 
-                # Create credentials from service account info
-                credentials = service_account.Credentials.from_service_account_info(
+                oauth2_client = service_account.Credentials.from_service_account_info(
                     service_account_info,
                     scopes=["https://www.googleapis.com/auth/dfp"],
                 )
-
-                # Wrap in GoogleAds OAuth2 client
-                oauth2_client = oauth2.GoogleServiceAccountClient(credentials)
 
         else:
             return jsonify({"error": f"Invalid auth_method: {auth_method}"}), 400


### PR DESCRIPTION
## Summary
Fixes the "Connection failed!" error when testing GAM service account authentication: `GoogleServiceAccountClient.__init__() missing 1 required positional argument: 'scope'`

## Problem
The test connection endpoint was incorrectly using `googleads.oauth2.GoogleServiceAccountClient`, which:
- Requires a file path to the service account JSON key
- Requires a `scope` parameter
- Would require writing temp files on every request

## Solution
Changed to use `google.oauth2.service_account.Credentials.from_service_account_info()` directly, matching the pattern already used in `src/adapters/gam/auth.py`:
- Works with in-memory JSON (no temp files needed)
- Is the correct way to pass service account credentials to `AdManagerClient`
- Avoids unnecessary file I/O on every request
- Consistent with the rest of the codebase

## Changes
- Updated `src/admin/blueprints/gam.py` test connection endpoint
- Removed incorrect `GoogleServiceAccountClient` usage
- Added proper in-memory credentials creation

## Testing
- ✅ All unit tests pass
- ✅ All integration tests pass
- ✅ Service account test connection should now work properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)