### PR TITLE
Fix creative approval 500 error and webhook auth bug

### DIFF
--- a/src/core/context_manager.py
+++ b/src/core/context_manager.py
@@ -594,8 +594,8 @@ class ContextManager(DatabaseManager):
                         headers = {"Content-Type": "application/json"}
 
                         # Add HMAC signature if configured
-                        if webhook_config.auth_type == "hmac_sha256" and webhook_config.auth_config:
-                            secret = webhook_config.auth_config.get("secret")
+                        if webhook_config.authentication_type == "hmac_sha256" and webhook_config.webhook_secret:
+                            secret = webhook_config.webhook_secret
                             if secret:
                                 from src.core.webhook_authenticator import WebhookAuthenticator
 

--- a/templates/creative_management.html
+++ b/templates/creative_management.html
@@ -146,7 +146,7 @@
                 <strong style="font-size: 0.9rem; color: #666;">📊 Campaigns ({{ creative.assignment_count }}):</strong>
                 <div style="margin-top: 0.5rem; display: flex; flex-wrap: gap: 0.5rem;">
                     {% for buy in creative.media_buys %}
-                    <a href="{{ url_for('operations.operations_dashboard', tenant_id=tenant_id) }}#{{ buy.media_buy_id }}"
+                    <a href="{{ url_for('operations.reporting', tenant_id=tenant_id) }}#{{ buy.media_buy_id }}"
                        style="padding: 0.25rem 0.75rem; background: #f3f4f6; border-radius: 4px; text-decoration: none; color: #374151; font-size: 0.85rem;">
                         {{ buy.order_name }} ({{ buy.status }})
                     </a>


### PR DESCRIPTION
## Summary
Fixed two production bugs discovered in logs on 2025-10-23:

### 1. Creative Review Template 500 Error
**Problem**: Clicking creative approval link from Slack resulted in 500 error  
**Root Cause**: Template trying to call non-existent endpoint `operations.operations_dashboard`  
**Fix**: Changed to `operations.reporting` (the correct endpoint)  
**Location**: `templates/creative_management.html` line 149

### 2. Webhook Push Notification Auth Error  
**Problem**: Webhook delivery failing with `AttributeError: 'PushNotificationConfig' object has no attribute 'auth_type'`  
**Root Cause**: Code accessing wrong field names on database model  
**Fix**: 
- Changed `webhook_config.auth_type` → `webhook_config.authentication_type`
- Changed `webhook_config.auth_config.get("secret")` → `webhook_config.webhook_secret`
**Location**: `src/core/context_manager.py` line 597

## Test Plan
- ✅ Unit tests passed (837 passed, 21 skipped)
- ✅ Integration tests passed (174 passed, 75 skipped)
- ✅ All pre-commit hooks passed

## Production Impact
Both issues are currently affecting production:
- Creative approval links from Slack are broken (500 errors)
- Webhook notifications are failing silently

Merging this will immediately fix both issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)