### PR TITLE
Fix MCP list_authorized_properties tenant detection without context

### DIFF
--- a/src/core/main.py
+++ b/src/core/main.py
@@ -421,10 +421,9 @@ def get_principal_from_context(
     don't reliably propagate to async callers (Python ContextVar + async/sync boundary issue).
     The caller MUST call set_current_tenant(tenant_context) in their own context.
     """
-    if not context:
-        return (None, None)
-
     # Get headers using the recommended FastMCP approach
+    # NOTE: get_http_headers() works via context vars, so it can work even when context=None
+    # This allows unauthenticated public discovery endpoints to detect tenant from headers
     # CRITICAL: Use include_all=True to get Host header (excluded by default)
     headers = None
     try:


### PR DESCRIPTION
## Summary
Completes the fix for test-agent.adcontextprotocol.org by enabling MCP `list_authorized_properties` to work without authentication.

This is the second part of the fix - PR #577 fixed A2A, this fixes MCP.

## Problem
When `list_authorized_properties` is called via MCP without an auth token:
- `context` parameter is `None`
- `get_principal_from_context()` had early return when `context=None` → returned `(None, None)`
- Tool couldn't detect tenant from headers → "No tenant context set" error

## Solution
Remove the early return in `get_principal_from_context()` when `context=None`:
- `get_http_headers()` uses FastMCP context variables internally, works without context object
- Tenant can be detected from headers (Apx-Incoming-Host, Host, x-adcp-tenant)
- Returns `(None, tenant_context)` for unauthenticated public discovery calls

## Changes
**src/core/main.py**:
- Removed early return `if not context: return (None, None)`
- Added comment explaining `get_http_headers()` works via context vars
- Allows unauthenticated calls to detect tenant from HTTP headers

## Impact
- ✅ MCP `list_authorized_properties` now works without authentication
- ✅ Tenant properly detected from virtual host headers
- ✅ Matches A2A behavior (both protocols support unauthenticated discovery)
- ✅ Completes test-agent.adcontextprotocol.org fix

## Test Results (Expected)
**Before:**
- ❌ Test Agent A2A: "No tenant context set" (fixed in PR #577)
- ❌ Test Agent MCP: "Unknown error" 

**After (both PRs):**
- ✅ Test Agent A2A: Returns `publisher_domains` ✅ VERIFIED
- ✅ Test Agent MCP: Returns `publisher_domains` ⏳ PENDING DEPLOYMENT

## Related
- Part 1: PR #577 (A2A fix)
- Similar pattern: MCP already supported headers via `get_http_headers()`, just needed to remove guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)