### PR TITLE
Fix remaining service account credential wrapping issues

### DIFF
--- a/src/adapters/gam/utils/health_check.py
+++ b/src/adapters/gam/utils/health_check.py
@@ -79,11 +79,14 @@ class GAMHealthChecker:
             if not key_file:
                 raise GAMConfigurationError("Missing service_account_key_file in config")
 
-            oauth2_credentials = google.oauth2.service_account.Credentials.from_service_account_file(
+            credentials = google.oauth2.service_account.Credentials.from_service_account_file(
                 key_file, scopes=["https://www.googleapis.com/auth/dfp"]
             )
+            # Wrap in GoogleCredentialsClient for AdManagerClient compatibility
+            from googleads import oauth2
+            oauth2_client = oauth2.GoogleCredentialsClient(credentials)
 
-            self.client = ad_manager.AdManagerClient(oauth2_credentials, self.config.get("network_code"))
+            self.client = ad_manager.AdManagerClient(oauth2_client, "AdCP Health Check", network_code=self.config.get("network_code"))
             return True
 
         except Exception as e:

--- a/src/admin/blueprints/inventory.py
+++ b/src/admin/blueprints/inventory.py
@@ -567,13 +567,15 @@ def sync_inventory(tenant_id):
                     temp_keyfile = f.name
 
                 try:
-                    # Create service account credentials (same pattern as GAM health check)
-                    oauth2_credentials = google.oauth2.service_account.Credentials.from_service_account_file(
+                    # Create service account credentials
+                    credentials = google.oauth2.service_account.Credentials.from_service_account_file(
                         temp_keyfile, scopes=["https://www.googleapis.com/auth/dfp"]
                     )
+                    # Wrap in GoogleCredentialsClient for AdManagerClient compatibility
+                    oauth2_client = oauth2.GoogleCredentialsClient(credentials)
 
                     # Create GAM client with service account credentials
-                    client = ad_manager.AdManagerClient(oauth2_credentials, adapter_config.gam_network_code)
+                    client = ad_manager.AdManagerClient(oauth2_client, "AdCP Sales Agent", network_code=adapter_config.gam_network_code)
                 finally:
                     # Clean up temp file
                     try:


### PR DESCRIPTION
## Summary
Fixes the `CreateHttpHeader` attribute error when using service account authentication by wrapping credentials in all remaining locations.

## Problem
After PR #579 fixed the auth manager, service account authentication was still failing with:
```
Sync failed: GAM error: 'Credentials' object has no attribute 'CreateHttpHeader'
```

The previous fix only updated `src/adapters/gam/auth.py`, but there were two additional locations creating raw `google.oauth2.service_account.Credentials` objects and passing them directly to `AdManagerClient`.

## Root Cause
`AdManagerClient` requires a `googleads.oauth2.GoogleOAuth2Client` subclass (like `GoogleCredentialsClient`), not raw `google.auth.credentials.Credentials` objects. The raw credentials don't implement the `CreateHttpHeader()` method that the googleads library expects.

## Solution
Wrapped service account credentials in `oauth2.GoogleCredentialsClient` in the remaining two locations:

1. **`src/admin/blueprints/inventory.py`** (line 571-578): Inventory sync operations
2. **`src/adapters/gam/utils/health_check.py`** (line 82-89): GAM health checks

Both now follow the same pattern as the auth manager fix:
```python
# Create credentials
credentials = google.oauth2.service_account.Credentials.from_service_account_file(...)
# Wrap in GoogleCredentialsClient for AdManagerClient compatibility
oauth2_client = oauth2.GoogleCredentialsClient(credentials)
# Pass wrapped client to AdManagerClient
client = ad_manager.AdManagerClient(oauth2_client, ...)
```

## Changes
**File: `src/admin/blueprints/inventory.py`**
- Line 571-578: Wrap credentials in `GoogleCredentialsClient` for inventory sync

**File: `src/adapters/gam/utils/health_check.py`**
- Line 82-89: Wrap credentials in `GoogleCredentialsClient` for health checks

## Test Results
✅ All 8 service account auth tests pass  
✅ All 35 GAM unit tests pass  
✅ All 846 unit tests pass  
✅ All 174 integration tests pass

## Related
- Builds on PR #579 (auth manager fix)
- Completes the service account authentication fix across the entire codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>