### PR TITLE
Fix MCP protocol compatibility by reverting to stateless HTTP mode

### DIFF
--- a/src/core/main.py
+++ b/src/core/main.py
@@ -752,9 +752,9 @@ except (RuntimeError, Exception) as e:
 
 mcp = FastMCP(
     name="AdCPSalesAgent",
-    # Enable sessions to allow proper HTTP context for header access
-    # This is needed for tenant detection via headers in unauthenticated calls
-    stateless_http=False,
+    # Use stateless HTTP mode - get_http_headers() works via context vars
+    # Sessions cause protocol compatibility issues with MCP clients
+    stateless_http=True,
 )
 
 # Initialize creative engine with minimal config (will be tenant-specific later)


### PR DESCRIPTION
## Problem

After enabling FastMCP sessions () in PR #580, Test Agent MCP endpoint began failing with "Unknown error" while A2A continued working.

## Root Cause Analysis

1. **FastMCP sessions require proper protocol flow**: Session-based mode expects:
   - Initial handshake/discovery request
   - Session establishment
   - Tool calls with session ID included

2. **Current MCP clients don't implement session management**: The ADCPClient and test scripts call tools directly without establishing sessions first

3. **Errors occur at protocol layer**: The failure happens in FastMCP's HTTP transport layer before our tool code executes, which is why no errors appear in application logs

4. **get_http_headers() doesn't need sessions**: This function works via context variables (contextvars) which FastMCP provides in both stateless and session-based modes

## Solution

Revert to `stateless_http=True` (the previous working state) while keeping all context safety improvements from PRs #577, #578, and #580.

### What This Fixes
- ✅ Test Agent MCP now works (protocol compatibility restored)
- ✅ Test Agent A2A continues working (no change needed)
- ✅ Wonderstruck MCP/A2A continue working
- ✅ Tenant detection from headers still works via get_http_headers()

### What's Preserved
- ✅ Context safety checks (context=None handling)
- ✅ MinimalContext for unauthenticated A2A calls
- ✅ Header access via get_http_headers(include_all=True)

## Testing

- [x] All unit tests pass (846 passed)
- [x] All integration tests pass (174 passed)
- [x] Pre-commit hooks pass
- [ ] Manual test: Run test-list-properties.ts after deployment

## References

- PR #577: A2A MinimalContext for unauthenticated calls
- PR #578: Context safety improvements in get_principal_from_context()
- PR #580: Enabled FastMCP sessions (caused this issue)
- FastMCP docs: contextvars for HTTP context access