### PR TITLE
Add MCP debugging to diagnose Test Agent failure

### DIFF
--- a/src/core/main.py
+++ b/src/core/main.py
@@ -4055,6 +4055,22 @@ def list_authorized_properties(
     Returns:
         ListAuthorizedPropertiesResponse with properties and tag metadata
     """
+    # DEBUG: Log what FastMCP provides
+    console.print("[yellow]DEBUG MCP list_authorized_properties:[/yellow]")
+    console.print(f"[yellow]  context={context}[/yellow]")
+    console.print(f"[yellow]  context type={type(context)}[/yellow]")
+    if context:
+        console.print(f"[yellow]  context.meta={getattr(context, 'meta', 'NO META')}[/yellow]")
+
+    # Try get_http_headers()
+    try:
+        from fastmcp.utilities.context import get_http_headers
+
+        headers = get_http_headers(include_all=True)
+        console.print(f"[yellow]  get_http_headers()={headers}[/yellow]")
+    except Exception as e:
+        console.print(f"[yellow]  get_http_headers() failed: {e}[/yellow]")
+
     return _list_authorized_properties_impl(req, context)
 
 


### PR DESCRIPTION
## Problem

Test Agent MCP has never worked. Need to understand why.

## Investigation

Add logging at MCP tool entry to see what FastMCP provides:
- Is context None or actual object?
- What is in context.meta?
- Does get_http_headers return anything?

## Next Steps

1. Merge and deploy
2. Run test
3. Check prod logs for DEBUG output
4. Fix based on evidence