### PR TITLE
Fix service account credential wrapping in GAM setup flow

### DIFF
--- a/src/admin/blueprints/gam.py
+++ b/src/admin/blueprints/gam.py
@@ -1186,10 +1186,12 @@ def test_gam_connection(tenant_id):
                 # Create credentials from service account (in-memory, no temp file needed)
                 from google.oauth2 import service_account
 
-                oauth2_client = service_account.Credentials.from_service_account_info(
+                credentials = service_account.Credentials.from_service_account_info(
                     service_account_info,
                     scopes=["https://www.googleapis.com/auth/dfp"],
                 )
+                # Wrap in GoogleCredentialsClient for AdManagerClient compatibility
+                oauth2_client = oauth2.GoogleCredentialsClient(credentials)
 
         else:
             return jsonify({"error": f"Invalid auth_method: {auth_method}"}), 400


### PR DESCRIPTION
## Summary
Fixes the final location where service account credentials weren't being wrapped, causing `CreateHttpHeader` errors during GAM tenant setup.

## Problem
After PRs #579 and #581 fixed the auth manager, inventory sync, and health checks, service account authentication was still failing during **GAM tenant setup** (network detection and advertiser/user fetching) with:
```
'Credentials' object has no attribute 'CreateHttpHeader'
```

## Root Cause
One more location in `src/admin/blueprints/gam.py` (line 1189-1192) was creating raw `google.oauth2.service_account.Credentials` and passing them directly to `AdManagerClient` without wrapping them in `GoogleCredentialsClient`.

This code is used during the tenant setup flow when:
- Detecting available GAM networks
- Fetching advertisers and users for initial configuration

## Solution
Wrapped the credentials in `oauth2.GoogleCredentialsClient` at line 1189-1194:

```python
# Before (WRONG):
oauth2_client = service_account.Credentials.from_service_account_info(...)

# After (CORRECT):
credentials = service_account.Credentials.from_service_account_info(...)
oauth2_client = oauth2.GoogleCredentialsClient(credentials)
```

## Comprehensive Fix Complete
This completes the service account authentication fix across **all locations** in the codebase:
- ✅ PR #579: `src/adapters/gam/auth.py` (auth manager)
- ✅ PR #581: `src/admin/blueprints/inventory.py` (inventory sync)
- ✅ PR #581: `src/adapters/gam/utils/health_check.py` (health checks)  
- ✅ **This PR**: `src/admin/blueprints/gam.py` (tenant setup)

## Test Results
✅ All 8 service account auth tests pass  
✅ All 35 GAM unit tests pass  
✅ All 846 unit tests pass  
✅ All 174 integration tests pass

## Verification
Searched entire codebase - all instances of `service_account.Credentials.from_service_account_*` are now properly wrapped in `GoogleCredentialsClient` before being passed to `AdManagerClient`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>