### PR TITLE
Add service_account_json support to GoogleAdManagerAdapter validation

### DIFF
--- a/src/adapters/google_ad_manager.py
+++ b/src/adapters/google_ad_manager.py
@@ -87,6 +87,7 @@ class GoogleAdManager(AdServerAdapter):
         self.trafficker_id = trafficker_id
         self.refresh_token = config.get("refresh_token")
         self.key_file = config.get("service_account_key_file")
+        self.service_account_json = config.get("service_account_json")
         self.principal = principal
 
         # Validate configuration
@@ -106,8 +107,8 @@ class GoogleAdManager(AdServerAdapter):
 
         # advertiser_id is only required for order/campaign operations, not inventory sync
 
-        if not self.key_file and not self.refresh_token:
-            raise ValueError("GAM config requires either 'service_account_key_file' or 'refresh_token'")
+        if not self.key_file and not self.service_account_json and not self.refresh_token:
+            raise ValueError("GAM config requires either 'service_account_key_file', 'service_account_json', or 'refresh_token'")
 
         # Initialize modular components
         if not self.dry_run:


### PR DESCRIPTION
## Summary
Fixes "Failed to fetch advertisers" error by adding `service_account_json` support to GoogleAdManagerAdapter's config validation.

## Problem
After fixing the credential wrapping issues (PRs #579, #581, #584), service account authentication was **still failing** when fetching advertisers with:
```
Failed to fetch advertisers: GAM config requires either 'service_account_key_file' or 'refresh_token'
```

## Root Cause
`GoogleAdManagerAdapter.__init__()` was only checking for two authentication methods:
- `service_account_key_file` (legacy file-based service account)
- `refresh_token` (OAuth)

It was **not recognizing** `service_account_json` (JSON string-based service account, preferred for cloud deployments), even though:
- ✅ `build_gam_config_from_adapter()` correctly adds it to config
- ✅ `GAMAuthManager` correctly handles it
- ✅ `GAMClientManager` correctly uses it

The adapter was rejecting valid service account configs before they could reach the auth layer.

## Solution
Updated `GoogleAdManagerAdapter` to recognize `service_account_json`:

**Line 90**: Store `service_account_json` from config
```python
self.service_account_json = config.get("service_account_json")
```

**Line 110-111**: Update validation to accept all three methods
```python
if not self.key_file and not self.service_account_json and not self.refresh_token:
    raise ValueError("GAM config requires either 'service_account_key_file', 'service_account_json', or 'refresh_token'")
```

## Complete Service Account Fix
This completes the service account authentication implementation:
- ✅ PR #579: Credential wrapping in auth manager
- ✅ PR #581: Credential wrapping in inventory sync & health checks
- ✅ PR #584: Credential wrapping in GAM setup flow
- ✅ **This PR**: Config validation in GoogleAdManagerAdapter

All service account authentication paths now work end-to-end!

## Test Results
✅ All 8 service account auth tests pass  
✅ All 35 GAM unit tests pass  
✅ All 846 unit tests pass  
✅ All 174 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>