### PR TITLE
Add stderr debugging for MCP header extraction

### DIFF
--- a/src/core/main.py
+++ b/src/core/main.py
@@ -4071,21 +4071,34 @@ def list_authorized_properties(
     # FIX: Create MinimalContext with headers from FastMCP request (like A2A does)
     # This ensures tenant detection works the same way for both MCP and A2A
     import logging
+    import sys
 
     logger = logging.getLogger(__name__)
     tool_context = None
 
     if context:
         try:
+            print(f"[MCP DEBUG] context type={type(context)}", file=sys.stderr, flush=True)
+            print(f"[MCP DEBUG] has request_context={hasattr(context, 'request_context')}", file=sys.stderr, flush=True)
             logger.info(f"MCP list_authorized_properties: context type={type(context)}")
             logger.info(f"MCP list_authorized_properties: has request_context={hasattr(context, 'request_context')}")
 
             # Access raw Starlette request headers via context.request_context.request
             request = context.request_context.request
+            print(
+                f"[MCP DEBUG] request={request}, type={type(request) if request else None}", file=sys.stderr, flush=True
+            )
             logger.info(f"MCP list_authorized_properties: request={request}, type={type(request) if request else None}")
 
             if request and hasattr(request, "headers"):
                 headers = dict(request.headers)
+                print(f"[MCP DEBUG] Extracted {len(headers)} headers from request", file=sys.stderr, flush=True)
+                print(f"[MCP DEBUG] Host header={headers.get('host')}", file=sys.stderr, flush=True)
+                print(
+                    f"[MCP DEBUG] Apx-Incoming-Host header={headers.get('apx-incoming-host')}",
+                    file=sys.stderr,
+                    flush=True,
+                )
                 logger.info(f"MCP list_authorized_properties: Extracted {len(headers)} headers from request")
                 logger.info(f"MCP list_authorized_properties: Host header={headers.get('host')}")
 
@@ -4096,17 +4109,21 @@ def list_authorized_properties(
                         self.headers = headers
 
                 tool_context = MinimalContext(headers)
+                print("[MCP DEBUG] Created MinimalContext successfully", file=sys.stderr, flush=True)
                 logger.info("MCP list_authorized_properties: Created MinimalContext successfully")
             else:
+                print("[MCP DEBUG] request has no headers attribute", file=sys.stderr, flush=True)
                 logger.warning("MCP list_authorized_properties: request has no headers attribute")
                 tool_context = context
         except Exception as e:
             # Fallback to passing context as-is
+            print(f"[MCP DEBUG] Exception extracting headers: {e}", file=sys.stderr, flush=True)
             logger.error(
                 f"MCP list_authorized_properties: Could not extract headers from FastMCP context: {e}", exc_info=True
             )
             tool_context = context
     else:
+        print("[MCP DEBUG] No context provided", file=sys.stderr, flush=True)
         logger.info("MCP list_authorized_properties: No context provided")
         tool_context = context
 


### PR DESCRIPTION
Added print() statements to stderr alongside logger.info() to ensure debugging output is visible in production logs. This will help diagnose why Test Agent MCP is failing to extract headers from FastMCP context.

Test Agent MCP has 0/7 successful runs (0%) while other endpoints work:
- ✅ Wonderstruck A2A/MCP: 100%
- ✅ Test Agent A2A: 100%  
- ❌ Test Agent MCP: 0%

This PR adds stderr output that should be more visible in Fly logs to understand where header extraction is failing.