### PR TITLE
URGENT: Fix deployment crash - product.adapter_type doesn't exist

### DIFF
--- a/src/services/delivery_simulator.py
+++ b/src/services/delivery_simulator.py
@@ -47,7 +47,7 @@ class DeliverySimulator:
             from sqlalchemy import select
 
             from src.core.database.database_session import get_db_session
-            from src.core.database.models import MediaBuy, Product, PushNotificationConfig
+            from src.core.database.models import MediaBuy, Product, PushNotificationConfig, Tenant
 
             logger.info("🔄 Checking for active media buys to restart simulations...")
 
@@ -94,8 +94,14 @@ class DeliverySimulator:
                     if not product:
                         continue
 
-                    # Only restart for mock adapter products
-                    if product.adapter_type != "mock":
+                    # Get tenant to check adapter type (adapter is configured at tenant level, not product level)
+                    tenant_stmt = select(Tenant).where(Tenant.tenant_id == media_buy.tenant_id)
+                    tenant = session.scalars(tenant_stmt).first()
+                    if not tenant:
+                        continue
+
+                    # Only restart for mock adapter tenants (simulations only run with mock adapter)
+                    if tenant.adapter_type != "mock":
                         continue
 
                     # Get simulation config from product


### PR DESCRIPTION
## Problem
Deployment was hanging with AttributeError on server startup:
```
AttributeError: 'Product' object has no attribute 'adapter_type'
```

## Root Cause
- `delivery_simulator.py` line 98 was checking `product.adapter_type`
- Products don't have `adapter_type` field - adapters are configured at **tenant level**
- Bug introduced in PR #347 (commit 6c4ef08) on Oct 12
- Only triggered when server restarts with active media buys + webhooks

## Solution
- Query tenant and check `tenant.adapter_type` (the correct field)
- Add Tenant to imports
- Remove invalid `product.adapter_type` reference

## Testing
- ✅ All unit tests pass
- ✅ All integration tests pass  
- ✅ Fixes deployment hang

This unblocks production deployment.