### PR TITLE
Use logger.error for visible MCP debugging

### DIFF
--- a/src/core/main.py
+++ b/src/core/main.py
@@ -425,11 +425,29 @@ def get_principal_from_context(
     # NOTE: get_http_headers() works via context vars, so it can work even when context=None
     # This allows unauthenticated public discovery endpoints to detect tenant from headers
     # CRITICAL: Use include_all=True to get Host header (excluded by default)
+    import logging as log_module
     import sys
+
+    # URGENT DEBUG: Use logger.error() to ensure visibility in production logs
+    debug_logger = log_module.getLogger(__name__)
+    debug_logger.error(f"🔍 get_principal_from_context called: context={context}, type={type(context)}")
+    if context:
+        debug_logger.error(f"🔍 context attributes: {dir(context)[:10]}...")  # First 10 attrs
+        if hasattr(context, "meta"):
+            debug_logger.error(f"🔍 context.meta exists: {context.meta}")
+        if hasattr(context, "headers"):
+            try:
+                headers_len = len(context.headers) if context.headers else 0
+                debug_logger.error(f"🔍 context.headers exists: {headers_len} headers")
+            except (TypeError, AttributeError):
+                debug_logger.error(f"🔍 context.headers exists but not iterable: {type(context.headers)}")
 
     headers = None
     try:
         headers = get_http_headers(include_all=True)
+        debug_logger.error(f"🔍 get_http_headers() returned: {len(headers) if headers else 0} headers")
+        if headers:
+            debug_logger.error(f"🔍 Header keys: {list(headers.keys())}")
         print(
             f"[PRINCIPAL DEBUG] get_http_headers(include_all=True) returned {len(headers) if headers else 0} headers",
             file=sys.stderr,
@@ -442,6 +460,7 @@ def get_principal_from_context(
             print(f"[PRINCIPAL DEBUG] Header keys: {list(headers.keys())}", file=sys.stderr, flush=True)
             console.print(f"[blue]DEBUG: Header keys: {list(headers.keys())}[/blue]")
     except Exception as e:
+        debug_logger.error(f"🔍 get_http_headers() exception: {type(e).__name__}: {e}")
         print(f"[PRINCIPAL DEBUG] get_http_headers() exception: {type(e).__name__}: {e}", file=sys.stderr, flush=True)
         console.print(f"[yellow]DEBUG: get_http_headers() exception: {type(e).__name__}: {e}[/yellow]")
         pass  # Will try fallback below
@@ -450,6 +469,7 @@ def get_principal_from_context(
     # This is necessary for sync tools where get_http_headers() may not work
     # CRITICAL: get_http_headers() returns {} for sync tools, so we need fallback even for empty dict
     if not headers:  # Handles both None and {}
+        debug_logger.error(f"🔍 get_http_headers() empty, trying fallback - context is {type(context)}")
         print("[PRINCIPAL DEBUG] get_http_headers() empty, trying fallback methods", file=sys.stderr, flush=True)
         print(f"[PRINCIPAL DEBUG] context={context}, type={type(context)}", file=sys.stderr, flush=True)
         console.print("[yellow]DEBUG: get_http_headers() empty, trying fallback methods[/yellow]")
@@ -458,32 +478,39 @@ def get_principal_from_context(
             print(f"[PRINCIPAL DEBUG] hasattr(context, 'meta')={hasattr(context, 'meta')}", file=sys.stderr, flush=True)
             if hasattr(context, "meta"):
                 print(f"[PRINCIPAL DEBUG] context.meta={context.meta}", file=sys.stderr, flush=True)
+                debug_logger.error(f"🔍 context.meta={context.meta}")
             if hasattr(context, "meta") and context.meta and "headers" in context.meta:
                 headers = context.meta["headers"]
+                debug_logger.error(f"🔍 ✅ Got {len(headers)} headers from context.meta!")
                 print(f"[PRINCIPAL DEBUG] Got {len(headers)} headers from context.meta", file=sys.stderr, flush=True)
                 console.print(f"[blue]DEBUG: Got {len(headers)} headers from context.meta[/blue]")
             # Try other possible attributes
             elif hasattr(context, "headers"):
                 headers = context.headers
+                debug_logger.error(f"🔍 ✅ Got {len(headers)} headers from context.headers!")
                 print(f"[PRINCIPAL DEBUG] Got {len(headers)} headers from context.headers", file=sys.stderr, flush=True)
                 console.print(f"[blue]DEBUG: Got {len(headers)} headers from context.headers[/blue]")
             elif hasattr(context, "_headers"):
                 headers = context._headers
+                debug_logger.error(f"🔍 ✅ Got {len(headers)} headers from context._headers!")
                 print(
                     f"[PRINCIPAL DEBUG] Got {len(headers)} headers from context._headers", file=sys.stderr, flush=True
                 )
                 console.print(f"[blue]DEBUG: Got {len(headers)} headers from context._headers[/blue]")
             else:
+                debug_logger.error("🔍 ❌ No fallback attributes (meta/headers/_headers) available on context")
                 print("[PRINCIPAL DEBUG] No fallback attributes available", file=sys.stderr, flush=True)
                 console.print(
                     "[yellow]DEBUG: No fallback attributes available (context provided but no headers)[/yellow]"
                 )
         else:
+            debug_logger.error("🔍 ❌ context=None and get_http_headers() failed")
             print("[PRINCIPAL DEBUG] context=None", file=sys.stderr, flush=True)
             console.print("[yellow]DEBUG: context=None and get_http_headers() failed - no headers available[/yellow]")
 
     # If still no headers dict available, return None
     if not headers:
+        debug_logger.error("🔍 ❌ FINAL: No headers available - cannot detect tenant - returning (None, None)")
         print("[PRINCIPAL DEBUG] ❌ CRITICAL: No headers available - cannot detect tenant", file=sys.stderr, flush=True)
         console.print("[red]❌ CRITICAL: No headers available - cannot detect tenant[/red]")
         return (None, None)


### PR DESCRIPTION
Problem: Multiple PRs added debugging with print and console.print but none of it appears in Fly logs. Cannot diagnose why Test Agent MCP is failing.

Solution: Replace invisible debugging with logger.error calls that show up in production logs.

Added debugging with magnifying glass emoji at key points in get_principal_from_context showing context type, get_http_headers results, fallback paths, and final outcome.

Testing: All tests pass. Fixed test compatibility with Mock objects. logger.error output will be visible in Fly logs.