### PR TITLE
Fix: Virtual host detection for MCP requests

### DIFF
--- a/tests/unit/test_auth_removal_simple.py
+++ b/tests/unit/test_auth_removal_simple.py
@@ -44,22 +44,24 @@ class TestAuthRemovalChanges:
                 "host": "test-tenant.sales-agent.scope3.com",
             },
         ):
-            # Mock tenant lookup to succeed
-            with patch("src.core.main.get_tenant_by_subdomain") as mock_tenant_lookup:
-                mock_tenant_lookup.return_value = {
-                    "tenant_id": "tenant_test",
-                    "subdomain": "test-tenant",
-                    "name": "Test Tenant",
-                }
-                with patch("src.core.main.set_current_tenant"):
-                    with patch("src.core.main.get_principal_from_token", return_value="test_principal"):
-                        principal_id, tenant = get_principal_from_context(context)
-                        assert principal_id == "test_principal"
-                        assert tenant == {
-                            "tenant_id": "tenant_test",
-                            "subdomain": "test-tenant",
-                            "name": "Test Tenant",
-                        }
+            # Mock virtual host lookup to fail (not a virtual host)
+            with patch("src.core.main.get_tenant_by_virtual_host", return_value=None):
+                # Mock subdomain lookup to succeed
+                with patch("src.core.main.get_tenant_by_subdomain") as mock_tenant_lookup:
+                    mock_tenant_lookup.return_value = {
+                        "tenant_id": "tenant_test",
+                        "subdomain": "test-tenant",
+                        "name": "Test Tenant",
+                    }
+                    with patch("src.core.main.set_current_tenant"):
+                        with patch("src.core.main.get_principal_from_token", return_value="test_principal"):
+                            principal_id, tenant = get_principal_from_context(context)
+                            assert principal_id == "test_principal"
+                            assert tenant == {
+                                "tenant_id": "tenant_test",
+                                "subdomain": "test-tenant",
+                                "name": "Test Tenant",
+                            }
 
     def test_audit_logging_handles_none_principal(self):
         """Test that audit logging works with None principal_id."""

--- a/tests/unit/test_tenant_isolation_breach_fix.py
+++ b/tests/unit/test_tenant_isolation_breach_fix.py
@@ -66,6 +66,8 @@ def test_get_principal_from_context_uses_global_lookup_when_no_tenant_detected()
     mock_tenant = {"tenant_id": "tenant_test", "subdomain": "test"}
     with (
         patch("src.core.main.get_http_headers", return_value={}),
+        patch("src.core.main.get_tenant_by_virtual_host", return_value=None),  # localhost not a virtual host
+        patch("src.core.main.get_tenant_by_subdomain", return_value=None),  # localhost not a subdomain
         patch("src.core.main.get_principal_from_token") as mock_get_principal,
         patch("src.core.main.get_current_tenant", return_value=mock_tenant),
     ):


### PR DESCRIPTION
## Problem
- ✅ MCP works for subdomains (wonderstruck.sales-agent.scope3.com)
- ❌ MCP fails for virtual hosts (test-agent.adcontextprotocol.org)
- A2A works for BOTH subdomains and virtual hosts

## Root Cause
When host='test-agent.adcontextprotocol.org':
1. Old code extracted subdomain='test-agent' FIRST
2. Found tenant with subdomain='test-agent' (correct)  
3. Never checked if it was actually a virtual host request
4. Tenant detected as 'subdomain' instead of 'virtual host'

The issue: tenant with subdomain='test-agent' also has virtual_host='test-agent.adcontextprotocol.org'. When the request comes in with the virtual host, we need to detect it as a virtual host, not extract the subdomain.

## Fix
- Try virtual host lookup FIRST (matches full hostname against tenant.virtual_host)
- Only fallback to subdomain extraction if virtual host lookup fails
- This ensures virtual host requests are detected correctly

## Changes
- src/core/main.py: Reordered tenant detection to check virtual_host before subdomain
- tests/unit/test_auth_removal_simple.py: Added mock for get_tenant_by_virtual_host
- tests/unit/test_tenant_isolation_breach_fix.py: Added mocks for both virtual host and subdomain lookups

## Test Results
- ✅ All 846 unit tests pass
- ✅ All 174 integration tests pass  
- ✅ Pre-commit hooks pass

## Expected Impact
After deployment, Test Agent MCP should work correctly:
- Virtual host detection will work for test-agent.adcontextprotocol.org
- MCP requests will properly detect the tenant
- No impact on subdomain detection (still works as before)

Related: #577 (Test Agent A2A fix)