### PR TITLE
Fix migration: Update ALL adapter_config rows, not just mock

### DIFF
--- a/alembic/versions/e38f2f6f395a_add_mock_manual_approval_required.py
+++ b/alembic/versions/e38f2f6f395a_add_mock_manual_approval_required.py
@@ -23,8 +23,8 @@ def upgrade() -> None:
     # Add mock_manual_approval_required column to adapter_config table
     op.add_column('adapter_config', sa.Column('mock_manual_approval_required', sa.Boolean(), nullable=True))
 
-    # Set default value to False for existing rows
-    op.execute("UPDATE adapter_config SET mock_manual_approval_required = false WHERE adapter_type = 'mock'")
+    # Set default value to False for ALL existing rows (not just mock adapters)
+    op.execute("UPDATE adapter_config SET mock_manual_approval_required = false")
 
     # Make the column non-nullable after setting defaults
     op.alter_column('adapter_config', 'mock_manual_approval_required', nullable=False, server_default=sa.false())


### PR DESCRIPTION
## Problem
The deployment is failing with:
```
column "mock_manual_approval_required" of relation "adapter_config" contains null values
[SQL: ALTER TABLE adapter_config ALTER COLUMN mock_manual_approval_required SET NOT NULL]
```

## Root Cause
Migration `e38f2f6f395a` only updated rows `WHERE adapter_type = 'mock'`:
```sql
UPDATE adapter_config SET mock_manual_approval_required = false WHERE adapter_type = 'mock'
```

But then set NOT NULL constraint on the **entire column**, leaving NULL values for non-mock adapters (GAM, Kevel, etc.).

## Fix
Update **ALL** existing rows before setting NOT NULL:
```sql
UPDATE adapter_config SET mock_manual_approval_required = false
```

## Migration Steps
The migration correctly follows the pattern:
1. Add column as nullable ✅
2. Set values for ALL rows ✅ (fixed)
3. Make column NOT NULL ✅

This allows the migration to succeed for tenants with any adapter type.

## Testing
- Migration logic verified
- Deployment currently blocked - needs immediate merge

Fixes: adcontextprotocol/salesagent#602