### PR TITLE
Fix schema generator trailing newline inconsistency

### DIFF
--- a/tests/e2e/adcp_schema_validator.py
+++ b/tests/e2e/adcp_schema_validator.py
@@ -174,6 +174,7 @@ class AdCPSchemaValidator:
             # Save to cache
             with open(cache_path, "w") as f:
                 json.dump(index_data, f, indent=2)
+                f.write("\n")  # Add trailing newline for pre-commit compatibility
 
             # Save new metadata
             metadata = {
@@ -183,6 +184,7 @@ class AdCPSchemaValidator:
             }
             with open(meta_path, "w") as f:
                 json.dump(metadata, f, indent=2)
+                f.write("\n")  # Add trailing newline for pre-commit compatibility
 
             return index_data
 
@@ -256,6 +258,7 @@ class AdCPSchemaValidator:
             # Save to cache
             with open(cache_path, "w") as f:
                 json.dump(schema_data, f, indent=2)
+                f.write("\n")  # Add trailing newline for pre-commit compatibility
 
             # Save new metadata
             metadata = {
@@ -266,6 +269,7 @@ class AdCPSchemaValidator:
             }
             with open(meta_path, "w") as f:
                 json.dump(metadata, f, indent=2)
+                f.write("\n")  # Add trailing newline for pre-commit compatibility
 
             return schema_data
 


### PR DESCRIPTION
## Summary

Fix schema generator to add trailing newlines, preventing constant file churn between workspaces.

## The Problem

The schema generator and pre-commit hooks were fighting:
- Schema generator (`tests/e2e/adcp_schema_validator.py`) writes JSON files using `json.dump()` **without trailing newlines**
- Pre-commit hook `end-of-file-fixer` **adds trailing newlines** on commit
- Result: Constant churn where generator removes newlines, pre-commit adds them back
- Every fresh workspace checkout shows all schema files as "modified"

## The Fix

Add `f.write("\n")` after all `json.dump()` calls in the schema validator:

```python
# Before
json.dump(schema_data, f, indent=2)

# After  
json.dump(schema_data, f, indent=2)
f.write("\n")  # Add trailing newline for pre-commit compatibility
```

## Impact

**Affected files** (no longer show spurious modifications):
- `schemas/v1/index.json` 
- `schemas/v1/_schemas_*.json` (all schema JSON files)
- `schemas/v1/_schemas_*.json.meta` (all metadata files)

**Workflow improvements:**
- ✅ Fresh workspace checkouts are clean
- ✅ Schema generator output matches pre-commit expectations
- ✅ No more constant re-committing of unchanged schemas
- ✅ Reduces noise in diffs and PRs

## Test Plan

- [x] Pre-commit hooks pass
- [x] Files generated with trailing newlines
- [x] Fresh checkout in new workspace shows no modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)