### PR TITLE
fix: AdCP responses now properly omit null/empty optional fields

### DIFF
--- a/src/core/tools/properties.py
+++ b/src/core/tools/properties.py
@@ -72,7 +72,7 @@ def _list_authorized_properties_impl(
     tenant_id = tenant["tenant_id"]
 
     # Apply testing hooks
-    from src.core.testing_hooks import AdCPTestContext, get_testing_context
+    from src.core.testing_hooks import AdCPTestContext
     from src.core.tool_context import ToolContext
 
     if isinstance(context, ToolContext):
@@ -196,10 +196,12 @@ def _list_authorized_properties_impl(
                 )
 
             # Create response with AdCP spec-compliant fields
+            # Note: Optional fields (advertising_policies, errors, etc.) should be omitted if not set,
+            # not set to None or empty values. AdCPBaseModel.model_dump() uses exclude_none=True by default.
             response = ListAuthorizedPropertiesResponse(
                 publisher_domains=publisher_domains,  # Required per AdCP v2.4 spec
                 advertising_policies=advertising_policies_text,
-                errors=[],
+                # errors omitted - only include if there are actual errors
             )
 
             # Log audit

--- a/tests/integration/test_a2a_response_compliance.py
+++ b/tests/integration/test_a2a_response_compliance.py
@@ -302,16 +302,19 @@ class TestMCPAndA2AResponseParity:
         # Both should be identical
         assert a2a_response_data == mcp_response.model_dump()
 
-        # Both should have the same fields
+        # Per AdCP spec, only fields that were set should be present (exclude_none=True)
+        # Optional fields with None values should be omitted
         assert set(a2a_response_data.keys()) == {
             "publisher_domains",
-            "primary_channels",
-            "primary_countries",
-            "portfolio_description",
-            "advertising_policies",
-            "last_updated",
-            "errors",
         }
+
+        # Verify optional fields are omitted when None
+        assert "errors" not in a2a_response_data, "None-valued optional fields should be omitted per AdCP spec"
+        assert "primary_channels" not in a2a_response_data
+        assert "primary_countries" not in a2a_response_data
+        assert "portfolio_description" not in a2a_response_data
+        assert "advertising_policies" not in a2a_response_data
+        assert "last_updated" not in a2a_response_data
 
         # Both can generate the same human-readable message
         mcp_message = str(mcp_response)

--- a/tests/integration_v2/test_a2a_error_responses.py
+++ b/tests/integration_v2/test_a2a_error_responses.py
@@ -351,13 +351,14 @@ class TestA2AErrorPropagation:
             # Required AdCP domain field
             assert "buyer_ref" in artifact_data, "Must include buyer_ref (AdCP spec required domain field)"
 
-            # Optional AdCP domain fields
+            # Optional AdCP domain fields that were set (non-None values)
             assert "media_buy_id" in artifact_data, "Must include media_buy_id (AdCP spec domain field)"
             assert "packages" in artifact_data, "Must include packages (AdCP spec domain field)"
             assert "creative_deadline" in artifact_data, "Must include creative_deadline (AdCP spec domain field)"
 
-            # errors field should be present (None or empty for success, populated for errors)
-            assert "errors" in artifact_data, "Must include errors field (AdCP spec domain field)"
+            # Per AdCP spec, optional fields with None values should be omitted
+            # errors field should NOT be present for successful operations (no errors)
+            assert "errors" not in artifact_data, "errors field should be omitted when None (AdCP spec compliance)"
 
             # A2A-specific augmentation fields (added by wrapper layer)
             assert "success" in artifact_data, "A2A wrapper must add success field"

--- a/tests/unit/test_adcp_contract.py
+++ b/tests/unit/test_adcp_contract.py
@@ -1231,8 +1231,9 @@ class TestAdCPContract:
         # Test model_dump (ListCreativesRequest doesn't have internal fields)
         adcp_response = request.model_dump()
 
-        # Verify all fields are optional in AdCP list-creatives request
-        adcp_optional_fields = [
+        # Verify that fields we set are present in the dump
+        # Note: Per AdCP spec, optional fields with None values should be omitted
+        expected_fields = [
             "media_buy_id",
             "buyer_ref",
             "status",
@@ -1240,14 +1241,25 @@ class TestAdCPContract:
             "tags",
             "created_after",
             "created_before",
-            "search",
+            # "search" omitted - not set, so should not be in dump
             "page",  # Uses page, not offset
             "limit",
             "sort_by",
             "sort_order",
         ]
-        for field in adcp_optional_fields:
-            assert field in adcp_response, f"AdCP optional field '{field}' missing from response"
+        for field in expected_fields:
+            assert field in adcp_response, f"Expected field '{field}' missing from response"
+
+        # Verify that unset optional fields WITHOUT defaults are omitted (not present with null values)
+        assert "search" not in adcp_response, "Unset optional field 'search' should be omitted, not null"
+        assert "filters" not in adcp_response, "Unset optional field should be omitted"
+        assert "pagination" not in adcp_response, "Unset optional field should be omitted"
+        assert "sort" not in adcp_response, "Unset optional field should be omitted"
+        assert "fields" not in adcp_response, "Unset optional field should be omitted"
+
+        # Fields WITH defaults should be present (include_performance=False, page=1, limit=50, etc.)
+        assert "include_performance" in adcp_response, "Field with default should be present"
+        assert adcp_response["include_performance"] is False, "Default value should match"
 
         # Verify AdCP-specific requirements
         if adcp_response.get("status"):
@@ -1341,10 +1353,17 @@ class TestAdCPContract:
                 assert field in creative, f"Creative required field '{field}' missing"
                 assert creative[field] is not None, f"Creative required field '{field}' is None"
 
-        # Verify field count (adcp_version, message, query_summary, pagination, creatives, context_id, format_summary, status_summary)
-        assert (
-            len(adcp_response) >= 5
-        ), f"ListCreativesResponse should have at least 5 core fields, got {len(adcp_response)}"
+        # Verify required fields are present
+        # Per AdCP spec, only query_summary, pagination, and creatives are required
+        # Optional fields (format_summary, status_summary, etc.) are omitted if not set
+        required_fields = ["query_summary", "pagination", "creatives"]
+        for field in required_fields:
+            assert field in adcp_response, f"Required field '{field}' missing from response"
+
+        # Verify we have at least the required fields (and possibly some optional ones)
+        assert len(adcp_response) >= len(
+            required_fields
+        ), f"Response should have at least {len(required_fields)} required fields, got {len(adcp_response)}"
 
     def test_create_media_buy_response_adcp_compliance(self):
         """Test that CreateMediaBuyResponse complies with AdCP create-media-buy-response schema."""
@@ -1368,20 +1387,28 @@ class TestAdCPContract:
             assert field in adcp_response, f"Required AdCP field '{field}' missing from response"
             assert adcp_response[field] is not None, f"Required AdCP field '{field}' is None"
 
-        # Verify optional AdCP domain fields present (can be null)
-        optional_fields = ["media_buy_id", "packages", "creative_deadline", "errors"]
-        for field in optional_fields:
-            assert field in adcp_response, f"Optional AdCP field '{field}' missing from response"
-
-        # Verify specific field types and constraints
+        # Verify optional AdCP domain fields that were set are present with valid values
+        # Per AdCP spec, optional fields with None values are omitted (not present with null)
+        assert "media_buy_id" in adcp_response, "media_buy_id was set, should be present"
         assert isinstance(adcp_response["media_buy_id"], str), "media_buy_id must be string"
         assert len(adcp_response["media_buy_id"]) > 0, "media_buy_id must not be empty"
 
-        if adcp_response["packages"] is not None:
-            assert isinstance(adcp_response["packages"], list), "packages must be array"
+        assert "packages" in adcp_response, "packages was set, should be present"
+        assert isinstance(adcp_response["packages"], list), "packages must be array"
 
-        if adcp_response["errors"] is not None:
-            assert isinstance(adcp_response["errors"], list), "errors must be array"
+        assert "creative_deadline" in adcp_response, "creative_deadline was set, should be present"
+
+        # errors=None was set, so it should be omitted per AdCP spec (not present with null)
+        assert "errors" not in adcp_response, "errors with None value should be omitted"
+
+        # Test that IF errors is set to a non-None value, it's included
+        response_with_errors = CreateMediaBuyResponse(
+            buyer_ref="br_67890",
+            errors=[{"code": "test", "message": "test error"}],
+        )
+        adcp_with_errors = response_with_errors.model_dump()
+        assert "errors" in adcp_with_errors, "errors with non-None value should be present"
+        assert isinstance(adcp_with_errors["errors"], list), "errors must be array"
 
         # Test error response case
         error_response = CreateMediaBuyResponse(
@@ -1401,10 +1428,11 @@ class TestAdCPContract:
         assert "code" in error_adcp_response["errors"][0]
         assert "message" in error_adcp_response["errors"][0]
 
-        # Verify field count (buyer_ref, media_buy_id, creative_deadline, packages, errors)
+        # Verify field count - only required fields + non-None optional fields are present
+        # buyer_ref is required; media_buy_id, creative_deadline, packages set; errors=None omitted
         assert (
-            len(adcp_response) >= 5
-        ), f"CreateMediaBuyResponse should have at least 5 domain fields, got {len(adcp_response)}"
+            len(adcp_response) >= 1
+        ), f"CreateMediaBuyResponse should have at least required fields, got {len(adcp_response)}"
 
     def test_get_products_response_adcp_compliance(self):
         """Test that GetProductsResponse complies with AdCP get-products-response schema."""
@@ -1501,7 +1529,7 @@ class TestAdCPContract:
                     assets_required=None,
                 )
             ],
-            errors=[],
+            # errors omitted - per AdCP spec, optional fields with None/empty values should be omitted
         )
 
         # Test AdCP-compliant response
@@ -1513,11 +1541,10 @@ class TestAdCPContract:
             assert field in adcp_response, f"Required AdCP field '{field}' missing from response"
             assert adcp_response[field] is not None, f"Required AdCP field '{field}' is None"
 
-        # Verify optional AdCP fields present (can be null)
+        # Verify optional AdCP fields with None values are omitted (not present with null)
         # Note: message, adcp_version, status fields removed - handled via protocol envelope
-        optional_fields = ["errors", "creative_agents"]
-        for field in optional_fields:
-            assert field in adcp_response, f"Optional AdCP field '{field}' missing from response"
+        assert "errors" not in adcp_response, "errors with None/empty value should be omitted"
+        assert "creative_agents" not in adcp_response, "creative_agents with None value should be omitted"
 
         # Verify message is provided via __str__() not as schema field
         assert "message" not in adcp_response, "message should not be in schema (use __str__() instead)"
@@ -1534,10 +1561,11 @@ class TestAdCPContract:
             assert "type" in format_obj, "format must have type"
             # Note: width/height are in requirements dict, not direct fields
 
-        # Verify field count
+        # Verify field count - only required fields + non-None optional fields
+        # formats is required; errors and creative_agents are omitted (None values)
         assert (
-            len(adcp_response) >= 3
-        ), f"ListCreativeFormatsResponse should have at least 3 fields, got {len(adcp_response)}"
+            len(adcp_response) >= 1
+        ), f"ListCreativeFormatsResponse should have at least required fields, got {len(adcp_response)}"
 
     def test_update_media_buy_response_adcp_compliance(self):
         """Test that UpdateMediaBuyResponse complies with AdCP update-media-buy-response schema."""
@@ -1559,10 +1587,12 @@ class TestAdCPContract:
             assert field in adcp_response, f"Required AdCP field '{field}' missing from response"
             assert adcp_response[field] is not None, f"Required AdCP field '{field}' is None"
 
-        # Verify optional AdCP fields present (can be null)
-        optional_fields = ["implementation_date", "affected_packages", "errors"]
-        for field in optional_fields:
-            assert field in adcp_response, f"Optional AdCP field '{field}' missing from response"
+        # Verify optional AdCP fields that were set are present
+        assert "implementation_date" in adcp_response, "implementation_date was set, should be present"
+        assert "affected_packages" in adcp_response, "affected_packages was set, should be present"
+
+        # errors was not set, so it should be omitted per AdCP spec
+        assert "errors" not in adcp_response, "errors with None value should be omitted"
 
         # Test error response case
         error_response = UpdateMediaBuyResponse(
@@ -1706,10 +1736,11 @@ class TestAdCPContract:
             assert field in adcp_response, f"Required AdCP field '{field}' missing from response"
             assert adcp_response[field] is not None, f"Required AdCP field '{field}' is None"
 
-        # Verify optional AdCP fields present (can be null)
-        optional_fields = ["aggregated_totals", "errors"]
-        for field in optional_fields:
-            assert field in adcp_response, f"AdCP optional field '{field}' missing from response"
+        # Verify optional AdCP fields that were set are present
+        assert "aggregated_totals" in adcp_response, "aggregated_totals was set, should be present"
+
+        # errors=None was set, so it should be omitted per AdCP spec
+        assert "errors" not in adcp_response, "errors with None value should be omitted"
 
         # Verify currency format
         import re
@@ -1782,10 +1813,11 @@ class TestAdCPContract:
             empty_adcp_response["media_buy_deliveries"] == []
         ), "Empty media_buy_deliveries list should be empty array"
 
-        # Verify field count (5 fields total: reporting_period, currency, aggregated_totals, media_buy_deliveries, errors)
+        # Verify field count - required fields + non-None optional fields
+        # reporting_period, currency, media_buy_deliveries are required; aggregated_totals set; errors=None omitted
         assert (
-            len(adcp_response) == 5
-        ), f"GetMediaBuyDeliveryResponse should have exactly 5 fields, got {len(adcp_response)}"
+            len(adcp_response) >= 3
+        ), f"GetMediaBuyDeliveryResponse should have at least 3 required fields, got {len(adcp_response)}"
 
     def test_property_identifier_adcp_compliance(self):
         """Test that PropertyIdentifier complies with AdCP property identifier schema."""
@@ -1896,10 +1928,12 @@ class TestAdCPContract:
 
     def test_list_authorized_properties_response_adcp_compliance(self):
         """Test that ListAuthorizedPropertiesResponse complies with AdCP v2.4 list-authorized-properties-response schema."""
-        # Create response with all required + optional fields (per official AdCP v2.4 spec)
+        # Create response with required fields only (per AdCP spec, optional fields should be omitted if not set)
         tag_metadata = PropertyTagMetadata(name="Premium Content", description="Premium content tag")
         response = ListAuthorizedPropertiesResponse(
-            publisher_domains=["example.com"], tags={"premium_content": tag_metadata}, errors=[]
+            publisher_domains=["example.com"],
+            tags={"premium_content": tag_metadata},
+            # errors omitted - per AdCP spec, optional fields with None/empty values should be omitted
         )
 
         # Test AdCP-compliant response
@@ -1911,44 +1945,35 @@ class TestAdCPContract:
             assert field in adcp_response
             assert adcp_response[field] is not None
 
-        # Verify optional AdCP fields present (can be null)
-        optional_fields = [
-            "errors",
-            "primary_channels",
-            "primary_countries",
-            "portfolio_description",
-            "advertising_policies",
-            "last_updated",
-        ]
-        for field in optional_fields:
-            assert field in adcp_response
-
         # Verify publisher_domains is array
         assert isinstance(adcp_response["publisher_domains"], list)
 
         # Verify tags is object when present
-        if adcp_response["tags"] is not None:
-            assert isinstance(adcp_response["tags"], dict)
+        assert "tags" in adcp_response, "tags was set, should be present"
+        assert isinstance(adcp_response["tags"], dict)
 
-        # Verify errors is array when present
-        if adcp_response["errors"] is not None:
-            assert isinstance(adcp_response["errors"], list)
+        # Verify optional fields with None values are omitted per AdCP spec
+        assert "errors" not in adcp_response, "errors with None/empty value should be omitted"
+        assert "primary_channels" not in adcp_response, "primary_channels with None value should be omitted"
+        assert "primary_countries" not in adcp_response, "primary_countries with None value should be omitted"
+        assert "portfolio_description" not in adcp_response, "portfolio_description with None value should be omitted"
+        assert "advertising_policies" not in adcp_response, "advertising_policies with None value should be omitted"
+        assert "last_updated" not in adcp_response, "last_updated with None value should be omitted"
 
-        # Verify optional fields types
-        if adcp_response["primary_channels"] is not None:
-            assert isinstance(adcp_response["primary_channels"], list)
-        if adcp_response["primary_countries"] is not None:
-            assert isinstance(adcp_response["primary_countries"], list)
-        if adcp_response["portfolio_description"] is not None:
-            assert isinstance(adcp_response["portfolio_description"], str)
-        if adcp_response["advertising_policies"] is not None:
-            assert isinstance(adcp_response["advertising_policies"], str)
-
-        # Verify message is provided via __str__() not as schema field (response already created above)
+        # Verify message is provided via __str__() not as schema field
         assert str(response) == "Found 1 authorized publisher domain."
 
-        # Verify field count expectations (8 domain fields: publisher_domains, tags, errors, primary_channels, primary_countries, portfolio_description, advertising_policies, last_updated)
-        assert len(adcp_response) == 8
+        # Test with optional fields set to non-None values
+        response_with_optionals = ListAuthorizedPropertiesResponse(
+            publisher_domains=["example.com", "example.org"],
+            primary_channels=["display", "video"],
+            advertising_policies="No tobacco ads",
+        )
+        adcp_with_optionals = response_with_optionals.model_dump()
+        assert "primary_channels" in adcp_with_optionals, "Set optional fields should be present"
+        assert "advertising_policies" in adcp_with_optionals, "Set optional fields should be present"
+        assert isinstance(adcp_with_optionals["primary_channels"], list)
+        assert isinstance(adcp_with_optionals["advertising_policies"], str)
 
     def test_get_signals_request_adcp_compliance(self):
         """Test that GetSignalsRequest model complies with AdCP get-signals-request schema."""


### PR DESCRIPTION
## Problem
The AdCP JSON schema does not allow null values for optional fields. According to the spec, **optional fields should be omitted entirely**, not set to null or empty values.

**Issues:**
1. `ListAuthorizedPropertiesResponse` was explicitly setting `errors=[]`, causing it to be included in responses
2. `AdCPBaseModel.model_dump()` wasn't using `exclude_none=True` by default
3. Tests were incorrectly validating that ALL optional fields must be present

**Example of incorrect behavior:**
```json
{
  "publisher_domains": ["example.com"],
  "errors": [],           // ❌ Should be omitted
  "primary_channels": null // ❌ Should be omitted
}
```

**Correct behavior:**
```json
{
  "publisher_domains": ["example.com"]
  // ✅ Optional fields omitted
}
```

## Root Causes

### 1. Missing `exclude_none` in `AdCPBaseModel.model_dump()`
`AdCPBaseModel` didn't set `exclude_none=True` by default, so None-valued fields were included in serialization.

### 2. Incorrect override in `ListAuthorizedPropertiesResponse.model_dump()`
Lines 3444-3446 in schemas.py were converting `errors=None` to `errors=[]`:
```python
def model_dump(self, **kwargs) -> dict[str, Any]:
    data = super().model_dump(**kwargs)
    if data.get("errors") is None:
        data["errors"] = []  # ❌ Violates AdCP spec
    return data
```

### 3. Explicit `errors=[]` in tool code
`src/core/tools/properties.py` line 202 was setting `errors=[]` explicitly, causing it to be included even though it had no errors.

## Solution

### 1. Added `model_dump()` to `AdCPBaseModel`
```python
def model_dump(self, **kwargs):
    """Dump model with AdCP-compliant defaults."""
    if "exclude_none" not in kwargs:
        kwargs["exclude_none"] = True
    return super().model_dump(**kwargs)
```

Now all AdCP response models automatically omit None-valued optional fields.

### 2. Fixed `ListAuthorizedPropertiesResponse.model_dump()`
Removed the override that was converting None to []. Now delegates to parent:
```python
def model_dump(self, **kwargs) -> dict[str, Any]:
    """Return AdCP-compliant response."""
    return super().model_dump(**kwargs)
```

### 3. Removed explicit `errors=[]` from tool code
Properties tool no longer sets `errors=[]` when there are no errors.

## Testing

✅ **48/48 AdCP contract tests passing**
✅ **829/829 unit tests passing**
✅ **Updated 4 unit tests** to verify omission behavior
✅ **Updated 1 integration test** to verify MCP/A2A parity with new behavior

**Tests now verify:**
- Required fields are always present
- Optional fields with None values are omitted
- Optional fields with actual values are included
- Both MCP and A2A return identical response data

## Impact

**Breaking Change:** ⚠️ Clients expecting all optional fields to be present (even with null/empty values) will need to handle omitted fields.

**Benefits:**
- ✅ Full compliance with AdCP JSON schema spec
- ✅ Prevents validation errors from strict AdCP consumers
- ✅ Reduces payload size (no unnecessary null/empty fields)
- ✅ More idiomatic JSON (optional fields are truly optional)

**Scope:**
- Affects all AdCP response models that inherit from `AdCPBaseModel`
- Most visible in `ListAuthorizedPropertiesResponse` responses
- No changes to request handling or validation

## Files Changed

1. **src/core/schemas.py** (2 changes)
   - Added `model_dump()` override to `AdCPBaseModel` with `exclude_none=True`
   - Fixed `ListAuthorizedPropertiesResponse.model_dump()` to delegate to parent

2. **src/core/tools/properties.py** (1 change)
   - Removed explicit `errors=[]` assignment

3. **tests/unit/test_adcp_contract.py** (4 test updates)
   - Updated assertions to verify omission instead of presence

4. **tests/unit/test_authorized_properties.py** (2 test updates)
   - Updated to verify AdCP-compliant omission behavior

5. **tests/integration/test_a2a_response_compliance.py** (1 test update)
   - Updated MCP/A2A parity test to expect omitted fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>