### PR TITLE
Auto-install uv in Conductor workspace setup

### DIFF
--- a/scripts/setup/setup_conductor_workspace.sh
+++ b/scripts/setup/setup_conductor_workspace.sh
@@ -18,6 +18,31 @@ echo "Setting up Conductor workspace: $CONDUCTOR_WORKSPACE_NAME"
 echo "Workspace path: $CONDUCTOR_WORKSPACE_PATH"
 echo "Root path: $CONDUCTOR_ROOT_PATH"
 
+# Check and install uv if needed
+echo ""
+echo "Checking for uv package manager..."
+if ! command -v uv &> /dev/null; then
+    echo "✗ uv not found, installing via Homebrew..."
+    if command -v brew &> /dev/null; then
+        brew install uv
+        if command -v uv &> /dev/null; then
+            echo "✓ uv installed successfully"
+        else
+            echo "✗ Warning: uv installation failed"
+            echo "  Schema generation will be skipped"
+            echo "  To install manually: brew install uv"
+        fi
+    else
+        echo "✗ Warning: Homebrew not found, cannot auto-install uv"
+        echo "  To install uv manually:"
+        echo "    macOS: brew install uv"
+        echo "    Linux: curl -LsSf https://astral.sh/uv/install.sh | sh"
+        echo "  Schema generation will be skipped"
+    fi
+else
+    echo "✓ uv is already installed ($(uv --version))"
+fi
+
 # Check for secrets configuration
 echo ""
 echo "Checking secrets configuration..."


### PR DESCRIPTION
## Summary
- Fixes workspace creation errors where AdCP schema generation fails due to missing `uv` package manager
- Adds automatic detection and installation of `uv` during workspace setup

## Changes
- Auto-detect if `uv` is installed at workspace setup start
- Install via Homebrew on macOS if missing
- Provide manual installation instructions for Linux/other platforms
- Gracefully degrade if installation fails (skip schema generation with warnings)

## Testing
- ✅ Tested on macOS with Homebrew
- ✅ Schema generation now works in fresh Conductor workspaces
- ✅ Existing workspaces with `uv` already installed are unaffected

## Impact
All new Conductor workspaces will automatically have `uv` installed and can generate AdCP schemas without manual intervention.

## Before
```
Downloading AdCP schemas from official registry...
✗ Warning: uv not found, skipping schema download

🔧 Generating Pydantic schemas from AdCP spec...
✗ Warning: uv not found, skipping Pydantic schema generation
```

## After
```
Checking for uv package manager...
✓ uv installed successfully
Downloading AdCP schemas from official registry...
✓ AdCP schemas downloaded/refreshed successfully
🔧 Generating Pydantic schemas from AdCP spec...
✓ Pydantic schemas generated successfully
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)