### PR TITLE
fix: Remove auto-restart of delivery simulators on server boot

### DIFF
--- a/src/core/startup.py
+++ b/src/core/startup.py
@@ -27,15 +27,6 @@ def initialize_application() -> None:
         validate_configuration()
         logger.info("✅ Configuration validation passed")
 
-        # Restart active delivery simulations (mock adapter only)
-        try:
-            from src.services.delivery_simulator import delivery_simulator
-
-            delivery_simulator.restart_active_simulations()
-        except Exception as e:
-            logger.warning(f"⚠️ Failed to restart delivery simulations: {e}")
-            # Don't fail startup if simulations can't restart
-
         logger.info("🎉 Application initialization completed successfully")
 
     except Exception as e:


### PR DESCRIPTION
## Problem

Production logs show webhooks firing continuously with high sequence numbers (#355+), indicating a webhook loop.

**Root Cause**: Delivery simulators were automatically restarted on every server boot via `restart_active_simulations()` in `initialize_application()`. In Fly.io production:
- Containers restart frequently (auto-scaling, health checks, deployments)
- Daemon threads don't survive restarts
- Each restart created new simulator threads → webhook spam

## Solution

Removed automatic simulator restart on server boot. Simulators now only start when explicitly requested (e.g., media buy creation).

**Changes**:
- `src/core/startup.py` - Removed call to `restart_active_simulations()`
- `src/services/delivery_simulator.py` - Added deprecation note and design decision documentation

## Impact

- **Mock adapter**: Simulators won't auto-resume after server restart (intended behavior)
- **Production**: No change - production should use GAM/Kevel, not mock adapter
- **Testing**: Tests still work - `restart_active_simulations()` method still exists, just not auto-called
- **Admin UI**: Can manually restart simulators if needed (method still available)

## Testing

- ✅ All unit tests pass (837 passed, 42 skipped)
- ✅ Pre-commit hooks pass
- ✅ Integration tests require PostgreSQL (will run in CI)

## Next Steps

After merge and deploy:
- Monitor Fly.io logs to verify webhook loop is resolved
- Verify no webhook spam in production
- Consider adding admin UI button to manually restart simulators if needed