### PR TITLE
Fix: Exclude null values from list_authorized_properties response

### DIFF
--- a/src/core/schema_adapters.py
+++ b/src/core/schema_adapters.py
@@ -445,6 +445,22 @@ class ListAuthorizedPropertiesResponse(AdCPBaseModel):
     last_updated: str | None = Field(None, description="ISO 8601 timestamp of when authorization list was last updated")
     errors: list[Any] | None = Field(None, description="Task-specific errors and warnings")
 
+    def dict(self, **kwargs):
+        """Override dict to use model_dump with exclude_none=True for AdCP compliance.
+
+        FastMCP may use dict() for serialization instead of model_dump().
+        This ensures optional fields with None values are excluded from the response.
+        """
+        return self.model_dump(**kwargs)
+
+    def __iter__(self):
+        """Override iteration to exclude None values for AdCP compliance.
+
+        When dict() or json.dumps() iterates over the model, it will only include
+        non-None fields. This ensures the response is spec-compliant.
+        """
+        return iter(self.model_dump().items())
+
     def __str__(self) -> str:
         """Return human-readable message for protocol layer.
 

--- a/src/core/tools/properties.py
+++ b/src/core/tools/properties.py
@@ -198,11 +198,14 @@ def _list_authorized_properties_impl(
             # Create response with AdCP spec-compliant fields
             # Note: Optional fields (advertising_policies, errors, etc.) should be omitted if not set,
             # not set to None or empty values. AdCPBaseModel.model_dump() uses exclude_none=True by default.
-            response = ListAuthorizedPropertiesResponse(
-                publisher_domains=publisher_domains,  # Required per AdCP v2.4 spec
-                advertising_policies=advertising_policies_text,
-                # errors omitted - only include if there are actual errors
-            )
+            # Build response dict with only non-None values
+            response_data = {"publisher_domains": publisher_domains}  # Required per AdCP v2.4 spec
+
+            # Only add optional fields if they have actual values
+            if advertising_policies_text:
+                response_data["advertising_policies"] = advertising_policies_text
+
+            response = ListAuthorizedPropertiesResponse(**response_data)
 
             # Log audit
             audit_logger = get_audit_logger("AdCP", tenant_id)


### PR DESCRIPTION
## Problem
AdCP client schema validation was rejecting the `list_authorized_properties` response because optional fields were being set to `null` instead of being completely omitted from the JSON.

**Error messages:**
- `primary_channels: Expected array, received null`
- `primary_countries: Expected array, received null`
- `portfolio_description: Expected string, received null`
- `advertising_policies: Expected string, received null`
- `last_updated: Expected string, received null`
- `errors: Expected array, received null`

The AdCP JSON schema expects optional fields to be either:
1. Present with the correct type (array/string)
2. Completely omitted from the JSON

It does NOT accept `null` values for these fields.

## Root Cause
When FastMCP serializes Pydantic models, it may use Python's built-in `dict()` function which calls `__iter__` instead of the model's `model_dump()` method. This resulted in all fields (including those with `None` values) being included in the response.

## Solution
1. **Override `__iter__()`** in `ListAuthorizedPropertiesResponse` to only yield non-None fields
2. **Override `dict()`** method to use `model_dump()` with `exclude_none=True`
3. **Only pass non-None values** when constructing the response object

These changes ensure optional fields are completely omitted from the JSON response rather than being present with `null` values, matching AdCP spec requirements.

## Testing
- ✅ Unit tests pass (837 passed)
- ✅ Manual serialization testing confirms `None` values are excluded
- ✅ Both `dict(response)` and `response.model_dump()` now exclude None fields

## Files Changed
- `src/core/schema_adapters.py`: Added `__iter__` and `dict` method overrides
- `src/core/tools/properties.py`: Only pass non-None values to response constructor