### PR TITLE
fix: Set session role for super admin OAuth login

### DIFF
--- a/src/admin/blueprints/auth.py
+++ b/src/admin/blueprints/auth.py
@@ -261,6 +261,7 @@ def google_callback():
         # Check if user is super admin
         if email_domain == "scope3.com" or is_super_admin(email):
             session["is_super_admin"] = True
+            session["role"] = "super_admin"
             flash(f"Welcome {user.get('name', email)}! (Super Admin)", "success")
             return redirect(url_for("core.index"))
 


### PR DESCRIPTION
## Summary
Fixes "Access denied" error for super admin users (e.g., bokelley@scope3.com) logging in via Google OAuth.

## Problem
Super admin users successfully authenticated via OAuth but then got "Access denied" when the app tried to redirect them to the admin interface.

## Root Cause
The OAuth callback set `session["is_super_admin"] = True` but didn't set `session["role"] = "super_admin"`. 

The index route (`core.py:88`) checks for:
```python
if session.get("role") == "super_admin":
```

So super admins would fail this check and hit the access denied path.

## Fix
Added `session["role"] = "super_admin"` when authenticating super admin users via OAuth, matching the pattern used in the test user login path (`auth.py:385`):

```python
# Check if user is super admin
if email_domain == "scope3.com" or is_super_admin(email):
    session["is_super_admin"] = True
    session["role"] = "super_admin"  # ← Added this line
    flash(f"Welcome {user.get('name', email)}! (Super Admin)", "success")
    return redirect(url_for("core.index"))
```

## Testing
- ✅ Super admin OAuth login now works correctly
- ✅ Redirects to tenant list page (index.html)
- ✅ Regular tenant users still work as before

## Related
- Completes the OAuth flow fixes from PRs #650, #651, #652, #653
- This was the last remaining OAuth authentication issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)