### PR TITLE
fix: Route external domains to tenant login instead of signup

### DIFF
--- a/src/admin/blueprints/core.py
+++ b/src/admin/blueprints/core.py
@@ -62,10 +62,22 @@ def index():
             return redirect(url_for("auth.login"))
 
         # Check if we're on an external virtual host (via Approximated)
-        # External domains should always show landing page for signup
         if approximated_host and not approximated_host.endswith(".sales-agent.scope3.com"):
-            logger.info(f"[LANDING DEBUG] External domain detected: {approximated_host}, showing landing page")
-            return render_template("landing.html")
+            # External domain detected - check if tenant exists for this virtual host
+            logger.info(f"[LANDING DEBUG] External domain detected: {approximated_host}, checking for tenant")
+            tenant = get_tenant_from_hostname()
+            if tenant:
+                # Tenant exists - redirect to login for this tenant
+                logger.info(
+                    f"[LANDING DEBUG] Tenant found for external domain: {tenant.tenant_id}, redirecting to login"
+                )
+                return redirect(url_for("auth.login"))
+            else:
+                # No tenant configured for this external domain - show signup landing page
+                logger.info(
+                    f"[LANDING DEBUG] No tenant found for external domain: {approximated_host}, showing landing page"
+                )
+                return render_template("landing.html")
 
         # Check if we're on a tenant-specific subdomain (*.sales-agent.scope3.com)
         tenant = get_tenant_from_hostname()

--- a/tests/unit/test_external_domain_routing.py
+++ b/tests/unit/test_external_domain_routing.py
@@ -1,0 +1,156 @@
+"""Test external domain routing via Approximated."""
+
+from unittest.mock import Mock, patch
+
+from src.admin.blueprints.core import get_tenant_from_hostname
+
+
+class TestExternalDomainRouting:
+    """Test that external domains (via Approximated) route to tenant home page instead of signup."""
+
+    def test_get_tenant_from_hostname_with_approximated_header(self):
+        """Test tenant lookup via Apx-Incoming-Host header."""
+        from src.admin.app import create_app
+
+        app, _ = create_app()
+
+        with app.test_request_context(
+            "/",
+            headers={
+                "Host": "backend.example.com",
+                "Apx-Incoming-Host": "sales-agent.accuweather.com",
+            },
+        ):
+            with patch("src.admin.blueprints.core.get_db_session") as mock_db:
+                # Mock the database session
+                mock_session = Mock()
+                mock_db.return_value.__enter__.return_value = mock_session
+
+                # Mock tenant object
+                mock_tenant = Mock()
+                mock_tenant.tenant_id = "accuweather"
+                mock_tenant.name = "AccuWeather"
+                mock_tenant.subdomain = "accuweather"
+                mock_tenant.virtual_host = "sales-agent.accuweather.com"
+
+                # Mock the database query
+                mock_scalars = Mock()
+                mock_scalars.first.return_value = mock_tenant
+                mock_session.scalars.return_value = mock_scalars
+
+                # Call the function
+                result = get_tenant_from_hostname()
+
+                # Verify tenant was returned
+                assert result is not None
+                assert result.tenant_id == "accuweather"
+                assert result.virtual_host == "sales-agent.accuweather.com"
+
+    def test_get_tenant_from_hostname_no_tenant_configured(self):
+        """Test that None is returned when no tenant is configured for external domain."""
+        from src.admin.app import create_app
+
+        app, _ = create_app()
+
+        with app.test_request_context(
+            "/",
+            headers={
+                "Host": "backend.example.com",
+                "Apx-Incoming-Host": "unknown-domain.com",
+            },
+        ):
+            with patch("src.admin.blueprints.core.get_db_session") as mock_db:
+                # Mock the database session
+                mock_session = Mock()
+                mock_db.return_value.__enter__.return_value = mock_session
+
+                # Mock the database query - no tenant found
+                mock_scalars = Mock()
+                mock_scalars.first.return_value = None
+                mock_session.scalars.return_value = mock_scalars
+
+                # Call the function
+                result = get_tenant_from_hostname()
+
+                # Verify None is returned
+                assert result is None
+
+    def test_index_route_external_domain_with_tenant(self):
+        """Test that external domain with configured tenant redirects to login."""
+        from src.admin.app import create_app
+
+        app, _ = create_app()
+
+        with app.test_client() as client:
+            with patch("src.admin.blueprints.core.get_tenant_from_hostname") as mock_get_tenant:
+                # Mock tenant exists for this external domain
+                mock_tenant = Mock()
+                mock_tenant.tenant_id = "accuweather"
+                mock_tenant.name = "AccuWeather"
+                mock_tenant.subdomain = "accuweather"
+                mock_tenant.virtual_host = "sales-agent.accuweather.com"
+                mock_get_tenant.return_value = mock_tenant
+
+                # Make request with Approximated headers
+                response = client.get(
+                    "/",
+                    headers={
+                        "Host": "backend.example.com",
+                        "Apx-Incoming-Host": "sales-agent.accuweather.com",
+                    },
+                )
+
+                # Should redirect to login (302) since tenant exists
+                assert response.status_code == 302
+                assert "/login" in response.location
+
+    def test_index_route_external_domain_no_tenant(self):
+        """Test that external domain without configured tenant shows signup landing page."""
+        from src.admin.app import create_app
+
+        app, _ = create_app()
+
+        with app.test_client() as client:
+            with patch("src.admin.blueprints.core.get_tenant_from_hostname") as mock_get_tenant:
+                # Mock no tenant exists for this external domain
+                mock_get_tenant.return_value = None
+
+                # Make request with Approximated headers
+                response = client.get(
+                    "/",
+                    headers={
+                        "Host": "backend.example.com",
+                        "Apx-Incoming-Host": "unknown-domain.com",
+                    },
+                )
+
+                # Should show landing page (200) since no tenant configured
+                assert response.status_code == 200
+                assert b"landing" in response.data.lower() or b"signup" in response.data.lower()
+
+    def test_index_route_subdomain_with_tenant(self):
+        """Test that subdomain (*.sales-agent.scope3.com) with tenant redirects to login."""
+        from src.admin.app import create_app
+
+        app, _ = create_app()
+
+        with app.test_client() as client:
+            with patch("src.admin.blueprints.core.get_tenant_from_hostname") as mock_get_tenant:
+                # Mock tenant exists for this subdomain
+                mock_tenant = Mock()
+                mock_tenant.tenant_id = "accuweather"
+                mock_tenant.name = "AccuWeather"
+                mock_tenant.subdomain = "accuweather"
+                mock_get_tenant.return_value = mock_tenant
+
+                # Make request with subdomain
+                response = client.get(
+                    "/",
+                    headers={
+                        "Host": "accuweather.sales-agent.scope3.com",
+                    },
+                )
+
+                # Should redirect to login (302) since tenant exists
+                assert response.status_code == 302
+                assert "/login" in response.location


### PR DESCRIPTION
## Summary

Fixed routing issue where users visiting custom domains via Approximated were incorrectly redirected to the signup page instead of their tenant's home page.

**Example**: `http://sales-agent.accuweather.com` now redirects to login instead of signup

## Root Cause

The `index()` function in `src/admin/blueprints/core.py` always showed the signup landing page for external domains without checking if a tenant was configured for that virtual host.

## Solution

Updated routing logic to:
1. Check if tenant exists for external domain (via `virtual_host` lookup)
2. If tenant exists: redirect to `/login`
3. If no tenant: show signup page (for new tenant onboarding)

## Changes

- `src/admin/blueprints/core.py:64-76` - Updated external domain routing logic
- `tests/unit/test_external_domain_routing.py` - Added 5 comprehensive unit tests

## Testing

All 5 unit tests pass:
- ✅ Tenant lookup via `Apx-Incoming-Host` header
- ✅ No tenant found for unknown external domains
- ✅ Index route redirects to login when tenant exists
- ✅ Index route shows signup when no tenant exists
- ✅ Subdomain routing with tenant

All pre-commit hooks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)