### PR TITLE
feat: Simplify targeting selector to match existing UI patterns

### DIFF
--- a/templates/add_product.html
+++ b/templates/add_product.html
@@ -540,12 +540,11 @@
         <!-- Targeting Configuration Widget -->
         <h3 style="margin-top: 2rem;">Targeting Configuration (Optional)</h3>
         <div class="alert" style="background: #fff3cd; border-left: 4px solid #ffc107; padding: 1rem; margin-bottom: 1rem;">
-            <strong>💡 Tip:</strong> Configure targeting to define the default audience and placement criteria for this product.
-            This helps buyers understand who will see their ads and where they'll appear.
+            <strong>💡 Tip:</strong> Configure custom targeting (key-value pairs) to define who will see ads for this product.
         </div>
 
-        {# Targeting widget with external JavaScript #}
-        {% include 'components/targeting_selector_widget.html' %}
+        {# Simple targeting selector - matches existing UI patterns #}
+        {% include 'components/targeting_selector_simple.html' %}
         <input type="hidden" id="targeting-data" name="targeting_template" value="">
 
         <div style="margin-top: 2rem;">
@@ -554,15 +553,6 @@
         </div>
     </form>
 </div>
-
-<script>
-// Initialize targeting widget after page load
-document.addEventListener('DOMContentLoaded', function() {
-    if (typeof TargetingWidget !== 'undefined') {
-        window.targetingWidget = new TargetingWidget('{{ tenant_id }}');
-    }
-});
-</script>
 
 <script>
 function updatePricingFields() {

--- a/templates/components/targeting_selector_simple.html
+++ b/templates/components/targeting_selector_simple.html
@@ -1,0 +1,264 @@
+<!-- Simple Targeting Selector Widget
+
+     Clean, inline key-value selector that matches the existing UI patterns.
+     No complex tabs or interfaces - just simple dropdowns and selection.
+-->
+
+<style>
+.targeting-selector {
+    border: 1px solid #dee2e6;
+    border-radius: 4px;
+    padding: 1.5rem;
+    background: white;
+    margin: 1rem 0;
+}
+
+.targeting-selector h4 {
+    margin-top: 0;
+    margin-bottom: 1rem;
+    color: #333;
+    font-size: 1.1rem;
+}
+
+.targeting-section {
+    margin-bottom: 1.5rem;
+}
+
+.targeting-section label {
+    display: block;
+    font-weight: 500;
+    margin-bottom: 0.5rem;
+    color: #555;
+}
+
+.targeting-section select {
+    width: 100%;
+    padding: 0.5rem;
+    border: 1px solid #ced4da;
+    border-radius: 4px;
+    font-size: 0.95rem;
+}
+
+.targeting-section select[multiple] {
+    height: 150px;
+}
+
+.selected-items {
+    margin-top: 0.5rem;
+    padding: 0.5rem;
+    background: #f8f9fa;
+    border-radius: 4px;
+    min-height: 40px;
+}
+
+.selected-item {
+    display: inline-block;
+    background: #007bff;
+    color: white;
+    padding: 0.25rem 0.75rem;
+    border-radius: 3px;
+    margin: 0.25rem;
+    font-size: 0.85rem;
+}
+
+.selected-item button {
+    background: none;
+    border: none;
+    color: white;
+    margin-left: 0.5rem;
+    cursor: pointer;
+    font-weight: bold;
+}
+
+.loading {
+    color: #666;
+    font-style: italic;
+}
+
+.error {
+    color: #dc3545;
+    padding: 0.5rem;
+    background: #f8d7da;
+    border-radius: 4px;
+}
+</style>
+
+<div class="targeting-selector">
+    <h4>🎯 Custom Targeting</h4>
+
+    <!-- Key-Value Pairs -->
+    <div class="targeting-section">
+        <label for="targeting-key-select">Select Custom Targeting Key</label>
+        <select id="targeting-key-select" onchange="loadKeyValues(this.value)">
+            <option value="">-- Select a key --</option>
+        </select>
+
+        <div id="targeting-values-container" style="display: none; margin-top: 1rem;">
+            <label for="targeting-values-select">Select Values</label>
+            <select id="targeting-values-select" multiple onchange="addSelectedValues()">
+                <!-- Populated dynamically -->
+            </select>
+            <small style="color: #666; display: block; margin-top: 0.25rem;">
+                Hold Ctrl/Cmd to select multiple values
+            </small>
+        </div>
+    </div>
+
+    <!-- Selected Key-Value Pairs Display -->
+    <div class="targeting-section">
+        <label>Selected Targeting</label>
+        <div id="selected-targeting-display" class="selected-items">
+            <span style="color: #999;">No targeting selected</span>
+        </div>
+    </div>
+</div>
+
+<script>
+// Simple targeting widget - matches existing UI patterns
+let selectedTargeting = {};
+let availableKeys = [];
+let availableValues = {};
+
+// Load custom targeting keys on page load
+document.addEventListener('DOMContentLoaded', async function() {
+    try {
+        const tenantId = '{{ tenant_id }}';
+        const response = await fetch(`/api/tenant/${tenantId}/targeting/all`);
+        const data = await response.json();
+
+        availableKeys = data.custom_targeting_keys || [];
+
+        // Populate keys dropdown
+        const keySelect = document.getElementById('targeting-key-select');
+        availableKeys.forEach(key => {
+            const option = document.createElement('option');
+            option.value = key.id;
+            option.textContent = key.display_name || key.name;
+            keySelect.appendChild(option);
+        });
+
+        // Load existing targeting if present
+        const existingData = document.getElementById('targeting-data').value;
+        if (existingData && existingData !== '{}') {
+            try {
+                selectedTargeting = JSON.parse(existingData).key_value_pairs || {};
+                updateDisplay();
+            } catch (e) {
+                console.error('Error parsing existing targeting:', e);
+            }
+        }
+    } catch (error) {
+        console.error('Error loading targeting keys:', error);
+        document.getElementById('targeting-key-select').innerHTML =
+            '<option value="">Error loading keys</option>';
+    }
+});
+
+// Load values for selected key
+async function loadKeyValues(keyId) {
+    if (!keyId) {
+        document.getElementById('targeting-values-container').style.display = 'none';
+        return;
+    }
+
+    const container = document.getElementById('targeting-values-container');
+    const valuesSelect = document.getElementById('targeting-values-select');
+
+    container.style.display = 'block';
+    valuesSelect.innerHTML = '<option disabled>Loading...</option>';
+
+    try {
+        const tenantId = '{{ tenant_id }}';
+        const response = await fetch(`/api/tenant/${tenantId}/targeting/values/${keyId}`);
+        const data = await response.json();
+
+        availableValues[keyId] = data.values || [];
+
+        // Populate values dropdown
+        valuesSelect.innerHTML = '';
+        data.values.forEach(value => {
+            const option = document.createElement('option');
+            option.value = value.id;
+            option.textContent = value.display_name || value.name;
+            option.dataset.keyId = keyId;
+            option.dataset.keyName = value.key_name || '';
+            option.dataset.valueName = value.name;
+            valuesSelect.appendChild(option);
+        });
+    } catch (error) {
+        console.error('Error loading values:', error);
+        valuesSelect.innerHTML = '<option disabled>Error loading values</option>';
+    }
+}
+
+// Add selected values to targeting
+function addSelectedValues() {
+    const valuesSelect = document.getElementById('targeting-values-select');
+    const selectedOptions = Array.from(valuesSelect.selectedOptions);
+
+    selectedOptions.forEach(option => {
+        const keyId = option.dataset.keyId;
+        const keyName = option.dataset.keyName;
+        const valueId = option.value;
+        const valueName = option.dataset.valueName;
+
+        // Initialize key array if doesn't exist
+        if (!selectedTargeting[keyName]) {
+            selectedTargeting[keyName] = [];
+        }
+
+        // Add value if not already present
+        if (!selectedTargeting[keyName].includes(valueName)) {
+            selectedTargeting[keyName].push(valueName);
+        }
+    });
+
+    updateDisplay();
+    updateHiddenField();
+}
+
+// Update visual display of selected targeting
+function updateDisplay() {
+    const display = document.getElementById('selected-targeting-display');
+
+    if (Object.keys(selectedTargeting).length === 0) {
+        display.innerHTML = '<span style="color: #999;">No targeting selected</span>';
+        return;
+    }
+
+    let html = '';
+    for (const [key, values] of Object.entries(selectedTargeting)) {
+        values.forEach(value => {
+            html += `
+                <span class="selected-item">
+                    ${key}: ${value}
+                    <button type="button" onclick="removeTargeting('${key}', '${value}')">&times;</button>
+                </span>
+            `;
+        });
+    }
+
+    display.innerHTML = html;
+}
+
+// Remove a targeting key-value pair
+function removeTargeting(key, value) {
+    if (selectedTargeting[key]) {
+        selectedTargeting[key] = selectedTargeting[key].filter(v => v !== value);
+        if (selectedTargeting[key].length === 0) {
+            delete selectedTargeting[key];
+        }
+    }
+    updateDisplay();
+    updateHiddenField();
+}
+
+// Update hidden field with current targeting data
+function updateHiddenField() {
+    const hiddenField = document.getElementById('targeting-data');
+    const targetingData = {
+        key_value_pairs: selectedTargeting
+    };
+    hiddenField.value = JSON.stringify(targetingData);
+}
+</script>

--- a/templates/edit_product.html
+++ b/templates/edit_product.html
@@ -123,12 +123,11 @@
         <!-- Targeting Configuration Widget -->
         <h3 style="margin-top: 2rem;">Targeting Configuration (Optional)</h3>
         <div class="alert" style="background: #fff3cd; border-left: 4px solid #ffc107; padding: 1rem; margin-bottom: 1rem;">
-            <strong>💡 Tip:</strong> Configure targeting to define the default audience and placement criteria for this product.
-            This helps buyers understand who will see their ads and where they'll appear.
+            <strong>💡 Tip:</strong> Configure custom targeting (key-value pairs) to define who will see ads for this product.
         </div>
 
-        {# Targeting widget with external JavaScript #}
-        {% include 'components/targeting_selector_widget.html' %}
+        {# Simple targeting selector - matches existing UI patterns #}
+        {% include 'components/targeting_selector_simple.html' %}
         <input type="hidden" id="targeting-data" name="targeting_template" value="{{ product.targeting_template | tojson if product.targeting_template else '{}' }}">
 
         <div style="margin-top: 2rem;">
@@ -137,23 +136,6 @@
         </div>
     </form>
 </div>
-
-<script>
-// Initialize targeting widget with existing data
-document.addEventListener('DOMContentLoaded', function() {
-    if (typeof TargetingWidget !== 'undefined') {
-        window.targetingWidget = new TargetingWidget('{{ tenant_id }}');
-
-        // Load existing targeting data if present
-        const existingTargeting = {{ product.targeting_template | tojson if product.targeting_template else '{}' }};
-        if (existingTargeting && Object.keys(existingTargeting).length > 0) {
-            // TODO: Populate widget with existing data
-            targetingWidget.selectedTargeting = existingTargeting;
-            targetingWidget.updateSummary();
-        }
-    }
-});
-</script>
 
 <script>
 function updatePricingFields() {


### PR DESCRIPTION
## Summary

Replace the complex tabbed targeting widget with a clean, inline selector that matches your existing UI patterns (like ad units/placements).

## Problem
The previous implementation had:
- Complex tabbed interface with dual-pane selector
- Awkward inventory browser-style interface
- Didn't match existing product form patterns

## Solution
New simplified widget that provides:
- Single dropdown to select custom targeting key
- Multi-select dropdown for values (appears after key selection)
- Visual display of selected key-value pairs with remove buttons
- Real-time GAM API queries for values
- Embedded JavaScript in template (no external dependencies)
- Clean, simple UX matching existing patterns

## Changes
- Created `templates/components/targeting_selector_simple.html` - Clean dropdown-based selector
- Updated `templates/add_product.html` to use simple widget
- Updated `templates/edit_product.html` to use simple widget
- Removed old TargetingWidget JavaScript initialization

## User Experience
1. Select a custom targeting key from dropdown
2. Multi-select values for that key
3. See selected pairs visually with easy removal
4. Data automatically saved to hidden form field

## Testing
✅ Unit tests passed (861 passed)
✅ Pre-commit hooks passed
✅ No external dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)