### PR TITLE
fix: Correct API field name mismatch in targeting selector widget

### DIFF
--- a/templates/components/targeting_selector_simple.html
+++ b/templates/components/targeting_selector_simple.html
@@ -126,7 +126,7 @@ document.addEventListener('DOMContentLoaded', async function() {
         const response = await fetch(`/api/tenant/${tenantId}/targeting/all`);
         const data = await response.json();
 
-        availableKeys = data.custom_targeting_keys || [];
+        availableKeys = data.customKeys || [];
 
         // Populate keys dropdown
         const keySelect = document.getElementById('targeting-key-select');


### PR DESCRIPTION
Fixes the targeting selector dropdown not showing the 255 custom targeting keys from GAM.

## Problem
The targeting selector widget wasn't loading custom targeting keys. The dropdown stayed empty showing only "-- Select a key --" placeholder, even though 255 keys were synced from GAM.

## Root Cause
Field name mismatch between API response and widget JavaScript:
- **API returns:** `customKeys` (line 136 of inventory.py)
- **Widget expected:** `custom_targeting_keys` (line 129 of widget)

The API endpoint `/api/tenant/{id}/targeting/all` returns the keys in a field called `customKeys`, but the widget was looking for `custom_targeting_keys`.

## Fix
Changed widget JavaScript to use `data.customKeys` instead of `data.custom_targeting_keys` to match the actual API response format.

## Result
✅ Widget will now correctly populate dropdown with all 255 custom targeting keys
✅ Users can select keys and load values
✅ Custom targeting configuration now works as intended

## Testing
Once deployed, refresh the edit product page and the dropdown should show all available targeting keys from GAM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)