### PR TITLE
fix: Add null safety checks for audience.type and audience.segment_type

### DIFF
--- a/templates/targeting_browser.html
+++ b/templates/targeting_browser.html
@@ -529,17 +529,17 @@ function renderAudiences() {
                 <div class="card-body">
                     <div class="d-flex justify-content-between align-items-start mb-2">
                         <h5 class="card-title">${audience.name}</h5>
-                        <span class="badge bg-${audience.type === 'FIRST_PARTY' ? 'success' : 'info'}">
+                        ${audience.type ? `<span class="badge bg-${audience.type === 'FIRST_PARTY' ? 'success' : 'info'}">
                             ${audience.type.replace('_', ' ')}
-                        </span>
+                        </span>` : ''}
                     </div>
                     ${audience.description ? `<p class="card-text small">${audience.description}</p>` : ''}
                     <div class="mt-auto">
                         ${audience.size ? `<p class="mb-1"><small>Size: ${audience.size.toLocaleString()}</small></p>` : ''}
                         ${audience.data_provider_name ? `<p class="mb-1"><small>Provider: ${audience.data_provider_name}</small></p>` : ''}
                         <p class="mb-0">
-                            <span class="badge bg-secondary">${audience.segment_type}</span>
-                            ${audience.status !== 'ACTIVE' ? `<span class="badge bg-warning">${audience.status}</span>` : ''}
+                            ${audience.segment_type ? `<span class="badge bg-secondary">${audience.segment_type}</span>` : ''}
+                            ${audience.status && audience.status !== 'ACTIVE' ? `<span class="badge bg-warning">${audience.status}</span>` : ''}
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
## Problem
The targeting browser was throwing a JavaScript error when rendering audiences that don't have a `type` property:
```
TypeError: undefined is not an object (evaluating 'audience.type.replace')
```

Console logs showed:
- 255 custom targeting keys loaded successfully
- Error occurred on line 533 of targeting browser when rendering audiences
- Some audiences from GAM don't include `type`, `segment_type`, or `status` fields

## Solution
Added conditional rendering for audience properties that may be undefined:

**Changes in `templates/targeting_browser.html`:**
1. **Line 532-534**: Only render type badge if `audience.type` exists
2. **Line 541**: Only render segment_type badge if `audience.segment_type` exists  
3. **Line 542**: Added null check for `audience.status` before comparing

**Before:**
```javascript
<span class="badge">${audience.type.replace('_', ' ')}</span>
<span class="badge">${audience.segment_type}</span>
${audience.status !== 'ACTIVE' ? ... : ''}
```

**After:**
```javascript
${audience.type ? `<span class="badge">${audience.type.replace('_', ' ')}</span>` : ''}
${audience.segment_type ? `<span class="badge">${audience.segment_type}</span>` : ''}
${audience.status && audience.status !== 'ACTIVE' ? ... : ''}
```

## Impact
- ✅ Targeting browser now renders all audiences without JavaScript errors
- ✅ Audiences without type/segment_type/status simply don't show those badges
- ✅ No impact on functionality - purely defensive coding

## Testing
- Verified error was on line 533 with `audience.type.replace`
- Added null checks for all audience properties that could be undefined
- Change is template-only, no backend logic affected

Related to PR #681 which fixed similar field name mismatch in product targeting selector.