### PR TITLE
fix: display and save custom targeting keys in product inventory

### DIFF
--- a/templates/products.html
+++ b/templates/products.html
@@ -155,12 +155,25 @@
                     {% endif %}
                 </td>
                 <td>
-                    {% if product.inventory_count > 0 %}
+                    {% if product.inventory_details.total > 0 %}
                         <a href="{{ url_for('products.edit_product', tenant_id=tenant_id, product_id=product.product_id) }}#inventory"
-                           class="badge"
-                           style="background: #28a745; color: white; text-decoration: none;"
+                           style="text-decoration: none; display: block;"
                            title="Click to view assigned inventory">
-                            {{ product.inventory_count }} assigned
+                            {% if product.inventory_details.ad_units > 0 %}
+                                <span class="badge" style="background: #28a745; margin-right: 0.25rem;">
+                                    {{ product.inventory_details.ad_units }} ad unit{{ 's' if product.inventory_details.ad_units != 1 else '' }}
+                                </span>
+                            {% endif %}
+                            {% if product.inventory_details.placements > 0 %}
+                                <span class="badge" style="background: #17a2b8; margin-right: 0.25rem;">
+                                    {{ product.inventory_details.placements }} placement{{ 's' if product.inventory_details.placements != 1 else '' }}
+                                </span>
+                            {% endif %}
+                            {% if product.inventory_details.custom_keys > 0 %}
+                                <span class="badge" style="background: #6f42c1; color: white; margin-right: 0.25rem;">
+                                    {{ product.inventory_details.custom_keys }} custom key{{ 's' if product.inventory_details.custom_keys != 1 else '' }}
+                                </span>
+                            {% endif %}
                         </a>
                     {% else %}
                         <span style="color: #999;">None</span>


### PR DESCRIPTION
## Summary

Fixed two critical issues with product inventory management:

1. **Inventory display not showing breakdown** - The inventory column only showed "None" or a total count, not a breakdown by type
2. **Custom targeting keys not saving** - Custom key/value pairs were stored in config but not tracked as inventory mappings

## Changes

### 1. Enhanced Inventory Display
- Changed from simple count to breakdown by type (ad_units, placements, custom_keys)
- Updated products list template with colored badges for each inventory type:
  - Green badge for ad units
  - Blue badge for placements  
  - Purple badge for custom keys
- Now displays: "3 ad units", "1 placement", "2 custom keys"

### 2. Fixed Custom Key Saving in Add Product
- Create ProductInventoryMapping records for custom targeting keys
- Store with inventory_type="custom_key" and inventory_id="key=value"
- Ensures custom keys are properly tracked in the database

### 3. Fixed Custom Key Saving in Edit Product
- Added inventory mapping sync when product is edited
- Deletes all existing mappings and recreates them from implementation_config
- Ensures all three inventory types (ad units, placements, custom keys) stay in sync

## Test Coverage

- ✅ Unit tests: 861 passed
- ✅ Integration tests: 32 passed
- ✅ Integration V2 tests: 28 passed
- ✅ All pre-commit hooks passed
- ✅ Black formatting applied
- ✅ Ruff linting passed
- ✅ mypy type checking passed

## Result

Users can now:
- ✅ Save custom targeting key/value pairs when creating/editing products
- ✅ See them displayed in the inventory column on the products list
- ✅ View complete breakdown showing ad units, placements, and custom keys

�� Generated with Claude Code