### PR TITLE
fix: populate custom targeting keys when editing products

### DIFF
--- a/src/admin/blueprints/products.py
+++ b/src/admin/blueprints/products.py
@@ -1426,6 +1426,25 @@ def edit_product(tenant_id, product_id):
                 cpm = first_pricing["rate"]
                 price_guidance = first_pricing["price_guidance"]
 
+            # Parse implementation_config
+            implementation_config = (
+                product.implementation_config
+                if isinstance(product.implementation_config, dict)
+                else json.loads(product.implementation_config) if product.implementation_config else {}
+            )
+
+            # Parse targeting_template - build from implementation_config if not set
+            targeting_template = (
+                product.targeting_template
+                if isinstance(product.targeting_template, dict)
+                else json.loads(product.targeting_template) if product.targeting_template else {}
+            )
+
+            # If targeting_template doesn't have key_value_pairs but implementation_config has custom_targeting_keys,
+            # populate targeting_template from implementation_config for backwards compatibility
+            if not targeting_template.get("key_value_pairs") and implementation_config.get("custom_targeting_keys"):
+                targeting_template["key_value_pairs"] = implementation_config["custom_targeting_keys"]
+
             product_dict = {
                 "product_id": product.product_id,
                 "name": product.name,
@@ -1444,11 +1463,8 @@ def edit_product(tenant_id, product_id):
                     if isinstance(product.countries, list)
                     else json.loads(product.countries) if product.countries else []
                 ),
-                "implementation_config": (
-                    product.implementation_config
-                    if isinstance(product.implementation_config, dict)
-                    else json.loads(product.implementation_config) if product.implementation_config else {}
-                ),
+                "implementation_config": implementation_config,
+                "targeting_template": targeting_template,
             }
 
             product_dict["pricing_options"] = pricing_options_list


### PR DESCRIPTION
## Summary

Fixed issue where custom targeting keys weren't showing as pre-selected when editing a product. The keys were saved correctly but the edit form wasn't displaying them.

## Problem

When you:
1. Create a product with custom targeting keys (e.g., sport=basketball)
2. Save the product
3. Edit the product again

The custom targeting dropdown was empty instead of showing the previously selected keys.

## Root Cause

The `edit_product` GET handler wasn't passing `targeting_template` to the template. The custom targeting keys were stored in `implementation_config.custom_targeting_keys`, but the form expects them in `targeting_template.key_value_pairs`.

## Fix

Added logic to populate `targeting_template` from `implementation_config` when loading the edit form:

1. Parse both `targeting_template` and `implementation_config` from product
2. If `targeting_template.key_value_pairs` is empty but `implementation_config.custom_targeting_keys` exists, copy the keys
3. Pass the populated `targeting_template` to the template

This provides backwards compatibility for products that have keys stored only in `implementation_config`.

## Test Coverage

- ✅ Unit tests: 861 passed
- ✅ Integration tests: 32 passed  
- ✅ Integration V2 tests: 28 passed
- ✅ All pre-commit hooks passed

## Result

- ✅ Custom targeting keys now show as pre-selected when editing products
- ✅ Form correctly displays existing key/value pairs
- ✅ Backwards compatible with existing products

🤖 Generated with Claude Code