### PR TITLE
fix: show both name and ID for placements consistently

### DIFF
--- a/templates/add_product_gam.html
+++ b/templates/add_product_gam.html
@@ -115,7 +115,7 @@
         </div>
 
         <!-- Format selection actions (shown with formats) -->
-        <div id="format-actions" style="display: {% if product and product.formats %}flex{% else %}none{% endif %}; gap: 0.5rem; margin-bottom: 1rem; align-items: center; flex-wrap: wrap;">
+        <div id="format-actions" style="display: flex; gap: 0.5rem; margin-bottom: 1rem; align-items: center; flex-wrap: wrap;">
             <button type="button" id="select-all-formats-btn" class="btn btn-secondary btn-sm" onclick="selectAllFormats()">
                 ✓ Select All
             </button>
@@ -128,8 +128,8 @@
             <span style="color: #666; font-size: 0.85rem; margin-left: 0.5rem;">Select formats that match your inventory</span>
         </div>
 
-        <!-- Formats container (hidden until ad units selected, or shown if editing product with formats) -->
-        <div id="formats-container" style="display: {% if product and product.formats %}grid{% else %}none{% endif %}; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 1rem; margin-bottom: 1rem; max-height: 500px; overflow-y: auto; padding: 1rem; background: #f9f9f9; border: 1px solid #ddd; border-radius: 4px;">
+        <!-- Formats container (always visible) -->
+        <div id="formats-container" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 1rem; margin-bottom: 1rem; max-height: 500px; overflow-y: auto; padding: 1rem; background: #f9f9f9; border: 1px solid #ddd; border-radius: 4px;">
             {% for format in formats %}
             <label class="format-card"
                    data-format-id="{{ format.id }}"


### PR DESCRIPTION
## Summary
Fixed three UI display issues in the product editor:
1. Show both name and ID for placements consistently in modal picker and selected display badges
2. Fix creative formats not displaying after selecting inventory (grid layout)
3. Fix creative formats hidden by default (should always be visible)

## Changes
- **Modal picker**: Added placement ID in gray text after name: `Name (ID)`
- **Selected badges**: Added placement ID in gray text after name: `Name (ID)`
- **Formats container grid layout**: Changed display style from 'block' to 'grid' when showing formats
- **Formats always visible**: Removed Jinja conditionals that hid formats by default - formats now visible on page load

## Why
**Issue 1 - Placement display inconsistency**: Previously, the selected badges showed just the ID (or name depending on loading state), while the modal showed just the name. This inconsistency made it hard to verify you were looking at the same placement. Now both locations show both pieces of information in a consistent format.

**Issue 2 - Formats not rendering**: The formats container was using `display: 'block'` when it needed `display: 'grid'` to work with the grid-template-columns layout. This caused formats to not render properly after selecting inventory.

**Issue 3 - Formats hidden by default**: The Jinja template had conditionals that only showed formats if editing a product with existing formats. This contradicted PR #688 which intended to 'always show creative formats'. Now formats are visible immediately on page load for both create and edit modes.

## Testing
- ✅ 861 unit tests passed
- ✅ 32 integration tests passed  
- ✅ 28 integration_v2 tests passed
- ✅ Manual testing: Formats now visible at http://localhost:8001 on product editor
- Manual testing needed: Verify both modal and selected display show `Name (ID)`

## Screenshots
N/A - UI text formatting and layout changes