### PR TITLE
Fix dead documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,9 @@ cp .env.secrets.template .env.secrets
 ## Documentation
 
 - **[Setup Guide](docs/SETUP.md)** - Installation and configuration
-- **[API Reference](docs/api.md)** - MCP tools and REST endpoints
 - **[Development Guide](docs/DEVELOPMENT.md)** - Local development and contributing
-- **[Testing Guide](docs/testing.md)** - Running and writing tests
+- **[Testing Guide](docs/testing/README.md)** - Running and writing tests
 - **[Deployment Guide](docs/deployment.md)** - Production deployment options
-- **[Setup Guide](docs/SETUP.md)** - Admin UI and tenant setup
 - **[Troubleshooting Guide](docs/TROUBLESHOOTING.md)** - Monitoring and debugging
 - **[Architecture](docs/ARCHITECTURE.md)** - System design and database schema
 


### PR DESCRIPTION
Fixes #676

## Changes
- ❌ Removed non-existent `docs/api.md` link from README Documentation section
- ✅ Fixed `docs/testing.md` link to point to `docs/testing/README.md` (actual path)
- 🧹 Removed duplicate Setup Guide link

## Verification
All documentation links now point to existing files:
- ✅ docs/SETUP.md
- ✅ docs/DEVELOPMENT.md  
- ✅ docs/testing/README.md
- ✅ docs/deployment.md
- ✅ docs/TROUBLESHOOTING.md
- ✅ docs/ARCHITECTURE.md

## Testing
- Pre-commit hooks: ✅ Passed
- Unit tests: ✅ Passed (861 passed)
- Integration tests: ✅ Passed (32 passed)
- Integration v2 tests: ✅ Passed (28 passed)