### PR TITLE
Fix creative status mismatch: pending → pending_review

### DIFF
--- a/src/admin/services/media_buy_readiness_service.py
+++ b/src/admin/services/media_buy_readiness_service.py
@@ -128,7 +128,7 @@ class MediaBuyReadinessService:
                 creatives = list(session.scalars(creatives_stmt).all())
 
             creatives_approved = sum(1 for c in creatives if c.status == "approved")
-            creatives_pending = sum(1 for c in creatives if c.status == "pending")
+            creatives_pending = sum(1 for c in creatives if c.status == "pending_review")
             creatives_rejected = sum(1 for c in creatives if c.status == "rejected")
 
             # Build blocking issues and warnings

--- a/src/core/database/queries.py
+++ b/src/core/database/queries.py
@@ -198,7 +198,7 @@ def get_creatives_needing_human_review(
         .join(CreativeReview, Creative.creative_id == CreativeReview.creative_id)
         .filter(
             Creative.tenant_id == tenant_id,
-            Creative.status == "pending",
+            Creative.status == "pending_review",
             CreativeReview.review_type == "ai",
         )
         .order_by(CreativeReview.reviewed_at.desc())

--- a/templates/creative_management.html
+++ b/templates/creative_management.html
@@ -86,7 +86,7 @@
                     </div>
                 </div>
                 <span class="status-badge status-{{ creative.status }}">
-                    {% if creative.status == 'pending' %}⏳ Pending
+                    {% if creative.status == 'pending_review' %}⏳ Pending Review
                     {% elif creative.status == 'approved' %}✅ Approved
                     {% elif creative.status == 'rejected' %}❌ Rejected
                     {% else %}{{ creative.status|title }}
@@ -160,7 +160,7 @@
 
             <!-- Action Buttons -->
             <div style="display: flex; gap: 0.5rem; margin-top: 1rem; padding-top: 1rem; border-top: 1px solid #e5e7eb;">
-                {% if creative.status == 'pending' %}
+                {% if creative.status == 'pending_review' %}
                 <button onclick="approveCreative('{{ creative.creative_id }}')" class="btn btn-sm btn-primary">
                     ✅ Approve
                 </button>

--- a/tests/unit/test_ai_review.py
+++ b/tests/unit/test_ai_review.py
@@ -111,7 +111,7 @@ class TestAIReviewCreative:
 
         result = _ai_review_creative_impl("test_tenant", "test_creative_123", db_session=mock_db_session)
 
-        assert result["status"] == "pending"
+        assert result["status"] == "pending_review"
         assert result["confidence"] == "medium"
         assert result["confidence_score"] == 0.6
         assert result["policy_triggered"] == "low_confidence_approval"
@@ -135,7 +135,7 @@ class TestAIReviewCreative:
 
         result = _ai_review_creative_impl("test_tenant", "test_creative_123", db_session=mock_db_session)
 
-        assert result["status"] == "pending"
+        assert result["status"] == "pending_review"
         assert result["policy_triggered"] == "sensitive_category"
         assert "political" in result["reason"].lower()
         assert "requires human review" in result["reason"]
@@ -156,7 +156,7 @@ class TestAIReviewCreative:
         result = _ai_review_creative_impl("test_tenant", "test_creative_123", db_session=mock_db_session)
 
         # Note: With confidence=low (0.3), it's < 0.9 threshold, so it goes to pending for human review
-        assert result["status"] == "pending"
+        assert result["status"] == "pending_review"
         assert result["policy_triggered"] == "uncertain_rejection"
         assert result["ai_recommendation"] == "reject"
 
@@ -175,7 +175,7 @@ class TestAIReviewCreative:
 
         result = _ai_review_creative_impl("test_tenant", "test_creative_123", db_session=mock_db_session)
 
-        assert result["status"] == "pending"
+        assert result["status"] == "pending_review"
         assert result["confidence"] == "medium"
         assert result["policy_triggered"] == "uncertain_rejection"
         assert result["ai_recommendation"] == "reject"
@@ -201,7 +201,7 @@ class TestAIReviewCreative:
 
         result = _ai_review_creative_impl("test_tenant", "test_creative_123", db_session=mock_db_session)
 
-        assert result["status"] == "pending"
+        assert result["status"] == "pending_review"
         assert result["policy_triggered"] == "uncertain"
         assert "could not make confident decision" in result["reason"].lower()
 
@@ -214,7 +214,7 @@ class TestAIReviewCreative:
 
         result = _ai_review_creative_impl("test_tenant", "test_creative_123", db_session=mock_db_session)
 
-        assert result["status"] == "pending"
+        assert result["status"] == "pending_review"
         assert result["error"] == "Gemini API key not configured"
         assert "AI review unavailable" in result["reason"]
 
@@ -227,7 +227,7 @@ class TestAIReviewCreative:
 
         result = _ai_review_creative_impl("test_tenant", "test_creative_123", db_session=mock_db_session)
 
-        assert result["status"] == "pending"
+        assert result["status"] == "pending_review"
         assert result["error"] == "Creative review criteria not configured"
         assert "AI review unavailable" in result["reason"]
 
@@ -244,7 +244,7 @@ class TestAIReviewCreative:
 
         result = _ai_review_creative_impl("test_tenant", "test_creative_123", db_session=mock_db_session)
 
-        assert result["status"] == "pending"
+        assert result["status"] == "pending_review"
         assert "error" in result
         assert "AI review failed" in result["reason"]
 
@@ -259,7 +259,7 @@ class TestAIReviewCreative:
 
         result = _ai_review_creative_impl("test_tenant", "test_creative_123", db_session=mock_db_session)
 
-        assert result["status"] == "pending"
+        assert result["status"] == "pending_review"
         assert "error" in result
         assert "API rate limit exceeded" in str(result["error"])
 
@@ -299,7 +299,7 @@ class TestAIReviewCreative:
         result = _ai_review_creative_impl("test_tenant", "test_creative_123", db_session=mock_db_session)
 
         # Below 0.90, should require human review
-        assert result["status"] == "pending"
+        assert result["status"] == "pending_review"
         assert result["policy_triggered"] == "low_confidence_approval"
 
     # Edge Case: Confidence threshold at reject boundary (0.10)
@@ -341,7 +341,7 @@ class TestAIReviewCreative:
 
         result = _ai_review_creative_impl("test_tenant", "test_creative_123", db_session=mock_db_session)
 
-        assert result["status"] == "pending"
+        assert result["status"] == "pending_review"
         assert result["policy_triggered"] == "sensitive_category"
         assert "healthcare" in result["reason"].lower()
 
@@ -360,7 +360,7 @@ class TestAIReviewCreative:
 
         result = _ai_review_creative_impl("test_tenant", "test_creative_123", db_session=mock_db_session)
 
-        assert result["status"] == "pending"
+        assert result["status"] == "pending_review"
         assert result["policy_triggered"] == "sensitive_category"
         assert "financial" in result["reason"].lower()
 
@@ -417,7 +417,7 @@ class TestAIReviewCreative:
 
         result = _ai_review_creative_impl("nonexistent_tenant", "test_creative_123", db_session=session)
 
-        assert result["status"] == "pending"
+        assert result["status"] == "pending_review"
         assert result["error"] == "Tenant not found"
         assert result["reason"] == "Configuration error"
 
@@ -449,7 +449,7 @@ class TestAIReviewCreative:
 
         result = _ai_review_creative_impl("test_tenant", "nonexistent_creative", db_session=session)
 
-        assert result["status"] == "pending"
+        assert result["status"] == "pending_review"
         assert result["error"] == "Creative not found"
         assert result["reason"] == "Configuration error"
 


### PR DESCRIPTION
## Summary

Fixed a critical status mismatch in the approval workflow where the system was checking for `"pending"` status but the official AdCP schema defines the creative status enum as `"pending_review"`. This caused the workflow to fail recognizing creatives awaiting human review.

## Changes

- Updated all status checks across the approval system, AI review logic, and UI templates to use correct `"pending_review"` status
- Fixed 4 files: creatives.py, media_buy_readiness_service.py, queries.py, and creative_management.html template
- Updated 14 related test assertions to expect the correct status value

## Test Plan

All unit tests pass except for 2 pre-existing schema compatibility failures unrelated to this change. The creative status fixes have been validated with updated AI review tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)