### PR TITLE
fix: wrap service account credentials with GoogleCredentialsClient

### DIFF
--- a/src/admin/blueprints/inventory.py
+++ b/src/admin/blueprints/inventory.py
@@ -233,9 +233,11 @@ def get_targeting_values(tenant_id, key_id):
                     credentials = google_service_account.Credentials.from_service_account_file(
                         temp_key_path, scopes=["https://www.googleapis.com/auth/dfp"]
                     )
+                    # Wrap in GoogleCredentialsClient for AdManagerClient compatibility
+                    oauth2_client = oauth2.GoogleCredentialsClient(credentials)
                     # Create Ad Manager client with service account
                     gam_ad_manager_client = ad_manager.AdManagerClient(
-                        credentials, "AdCP Sales Agent", network_code=adapter_config.gam_network_code
+                        oauth2_client, "AdCP Sales Agent", network_code=adapter_config.gam_network_code
                     )
                 finally:
                     # Clean up temp file


### PR DESCRIPTION
## Problem
The targeting values endpoint (`/admin/api/tenant/{tenant_id}/targeting/values/{key_id}`) was returning 500 errors for tenants using service account authentication (like the Weather Company tenant).

## Root Cause
In PR #723, we added service account authentication support to this endpoint. However, we were passing raw `google.oauth2.service_account.Credentials` directly to `ad_manager.AdManagerClient()`.

The googleads library requires credentials to be wrapped in `oauth2.GoogleCredentialsClient` to provide the `CreateHttpHeader()` method that the GAM API client expects.

**Error:**
```
AttributeError: 'Credentials' object has no attribute 'CreateHttpHeader'
```

## Solution
Added the `oauth2.GoogleCredentialsClient(credentials)` wrapper, matching the pattern used in:
- `src/services/background_sync_service.py` (line 214)
- `src/adapters/gam/auth.py` (lines 100, 111)
- `src/adapters/gam/utils/health_check.py` (line 86)
- `src/admin/blueprints/gam.py` (line 878)

## Testing
Verified the fix works by:
1. Confirming Weather tenant has service account configured: ✅
2. Testing the exact error path in production SSH console: ✅
3. Confirming the fix resolves the `CreateHttpHeader()` error: ✅

## Impact
- **Fixes:** https://sales-agent.scope3.com/admin/api/tenant/weather/targeting/values/289457
- **Affects:** All tenants using service account authentication when loading custom targeting key values
- **Risk:** Low - single-line fix following established pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)