### PR TITLE
fix: increase sync_id length from 50 to 100

### DIFF
--- a/alembic/versions/e8223bd175df_increase_sync_job_id_length.py
+++ b/alembic/versions/e8223bd175df_increase_sync_job_id_length.py
@@ -1,0 +1,36 @@
+"""increase_sync_job_id_length
+
+Revision ID: e8223bd175df
+Revises: 445171389125
+Create Date: 2025-11-24 17:59:03.448623
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e8223bd175df'
+down_revision: Union[str, Sequence[str], None] = '445171389125'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.alter_column('sync_jobs', 'sync_id',
+               existing_type=sa.String(length=50),
+               type_=sa.String(length=100),
+               existing_nullable=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Note: This downgrade might fail if there are IDs longer than 50 chars
+    # We generally don't support downgrading data-loss migrations, but for completeness:
+    op.alter_column('sync_jobs', 'sync_id',
+               existing_type=sa.String(length=100),
+               type_=sa.String(length=50),
+               existing_nullable=False)

--- a/src/core/database/models.py
+++ b/src/core/database/models.py
@@ -1304,7 +1304,7 @@ class GAMLineItem(Base):
 class SyncJob(Base):
     __tablename__ = "sync_jobs"
 
-    sync_id: Mapped[str] = mapped_column(String(50), primary_key=True)
+    sync_id: Mapped[str] = mapped_column(String(100), primary_key=True)
     tenant_id: Mapped[str] = mapped_column(
         String(50), ForeignKey("tenants.tenant_id", ondelete="CASCADE"), nullable=False
     )

--- a/tests/integration/test_sync_job_model.py
+++ b/tests/integration/test_sync_job_model.py
@@ -1,0 +1,44 @@
+import pytest
+from datetime import datetime
+from sqlalchemy import select
+from src.core.database.models import SyncJob, Tenant
+from src.core.database.database_session import get_db_session
+
+@pytest.mark.requires_db
+def test_sync_job_id_length(integration_db):
+    """Test that SyncJob accepts IDs longer than 50 characters (up to 100)."""
+    with get_db_session() as session:
+        # Create a tenant first (FK dependency)
+        tenant = Tenant(
+            tenant_id="tenant_1",
+            name="Test Tenant",
+            subdomain="test-tenant",
+            virtual_host="test.example.com"
+        )
+        session.add(tenant)
+        session.commit()
+
+        # Create SyncJob with long ID
+        # sync_id length = 5 + 36 + 1 + 10 = 52 chars is what failed
+        # Let's test with 60 chars
+        long_sync_id = "sync_" + "a" * 55 
+        assert len(long_sync_id) == 60
+
+        sync_job = SyncJob(
+            sync_id=long_sync_id,
+            tenant_id="tenant_1",
+            adapter_type="google_ad_manager",
+            sync_type="inventory",
+            status="running",
+            started_at=datetime.now(),
+            triggered_by="test"
+        )
+        session.add(sync_job)
+        session.commit()
+
+        # Verify it was saved
+        stmt = select(SyncJob).filter_by(sync_id=long_sync_id)
+        saved_job = session.scalars(stmt).first()
+        assert saved_job is not None
+        assert saved_job.sync_id == long_sync_id
+


### PR DESCRIPTION
Ticket: https://linear.app/scope3-projects/issue/SCO-454/inventory-sync-causes-500-errors-on-planet9-tenant

Actual error from production:
```
{
    "error": "(psycopg2.errors.StringDataRightTruncation) value too long for type character varying(50)\n\n[SQL: INSERT INTO sync_jobs (sync_id, tenant_id, adapter_type, sync_type, status, started_at, completed_at, summary, error_message, triggered_by, triggered_by_id, progress) VALUES (%(sync_id)s, %(tenant_id)s, %(adapter_type)s, %(sync_type)s, %(status)s, %(started_at)s, %(completed_at)s, %(summary)s, %(error_message)s, %(triggered_by)s, %(triggered_by_id)s, %(progress)s::JSONB)]\n[parameters: {'sync_id': 'sync_145615c2-250f-4620-89d7-4854ecb35306_1763988915', 'tenant_id': '145615c2-250f-4620-89d7-4854ecb35306', 'adapter_type': 'google_ad_manager', 'sync_type': 'inventory', 'status': 'running', 'started_at': datetime.datetime(2025, 11, 24, 12, 55, 15, 502390, tzinfo=datetime.timezone.utc), 'completed_at': None, 'summary': None, 'error_message': None, 'triggered_by': 'admin_ui', 'triggered_by_id': 'system', 'progress': '{\"phase\": \"Starting\", \"sync_types\": null, \"custom_targeting_limit\": null, \"audience_segment_limit\": null}'}]\n(Background on this error at: https://sqlalche.me/e/20/9h9h)"
}
``` 

The sync_id generated for the job was 52 characters long (e.g., sync_145615c2-250f-4620-89d7-4854ecb35306_1763988915), but the database column sync_jobs.sync_id was defined as VARCHAR(50). This caused the StringDataRightTruncation error in PostgreSQL