### PR TITLE
fix: inventory profile save URL and property_mode handling

### DIFF
--- a/src/admin/blueprints/inventory_profiles.py
+++ b/src/admin/blueprints/inventory_profiles.py
@@ -206,7 +206,10 @@ def add_inventory_profile(tenant_id: str):
                 return redirect(url_for("inventory_profiles.add_inventory_profile", tenant_id=tenant_id))
 
             # Parse publisher properties based on property_mode
-            publisher_properties = []
+            # NOTE: New unified inventory page sends either:
+            # - property_mode = "all" or "specific" with full publisher_properties JSON
+            # - or legacy modes: "tags", "property_ids", "full"
+            publisher_properties: list[dict] = []
             property_mode = form_data.get("property_mode", "tags")
 
             with get_db_session() as prop_session:
@@ -278,8 +281,10 @@ def add_inventory_profile(tenant_id: str):
                         }
                     ]
 
-                elif property_mode == "full":
-                    # Legacy full mode: Parse JSON from textarea
+                elif property_mode in {"full", "all", "specific"}:
+                    # "full" is legacy textarea JSON mode
+                    # "all"/"specific" are used by the unified inventory page and
+                    # send complete publisher_properties JSON in the form field.
                     publisher_properties_json = form_data.get("publisher_properties", "").strip()
                     if publisher_properties_json:
                         try:

--- a/templates/components/inventory_profile_editor.html
+++ b/templates/components/inventory_profile_editor.html
@@ -393,9 +393,11 @@ Then call: window.inventoryProfileEditor.open(profileData)
         formPayload.append('publisher_properties', JSON.stringify(publisherProperties));
         formPayload.append('property_mode', propertyMode);
 
-        const url = currentProfile
-            ? `/tenant/${config.tenantId}/inventory-profiles/${currentProfile.id}/edit`
-            : `/tenant/${config.tenantId}/inventory-profiles/add`;
+        const url = scriptRoot + (
+            currentProfile
+                ? `/tenant/${config.tenantId}/inventory-profiles/${currentProfile.id}/edit`
+                : `/tenant/${config.tenantId}/inventory-profiles/add`
+        );
 
         try {
             const response = await fetch(url, {
@@ -410,8 +412,24 @@ Then call: window.inventoryProfileEditor.open(profileData)
                 if (window.loadProfiles) window.loadProfiles();
                 if (window.location.reload) window.location.reload();
             } else {
-                const error = await response.json();
-                alert('Error saving profile: ' + (error.error || 'Unknown error'));
+                // Try to parse JSON error first, but fall back to plain text to
+                // avoid "Unexpected token" errors when the response isn't JSON.
+                let message = `HTTP ${response.status} ${response.statusText}`;
+                const contentType = response.headers.get('content-type') || '';
+                try {
+                    if (contentType.includes('application/json')) {
+                        const error = await response.json();
+                        message = error.error || error.message || message;
+                    } else {
+                        const text = await response.text();
+                        if (text) {
+                            message = text;
+                        }
+                    }
+                } catch (e) {
+                    // Swallow JSON/text parsing errors and use default message
+                }
+                alert('Error saving profile: ' + message);
             }
         } catch (error) {
             alert('Error saving profile: ' + error.message);


### PR DESCRIPTION
Ticket: https://linear.app/scope3-projects/issue/SCO-467/inventory-profile-creation-pressing-save-results-in-an-error

- Fix inventory profile save URL to respect request.script_root so the modal POSTs to `/admin/tenant/<tenant_id>/inventory-profiles/...` instead of a bare `/tenant/...` path that returned 404 behind the proxy.
- Align backend with new editor payload by accepting `property_mode` values all and specific and parsing `publisher_properties` JSON from the unified inventory page.
- Improve error handling in the editor so non-JSON responses no longer cause Unexpected token errors and instead surface a readable message.