### PR TITLE
fix: correct inventory search endpoint and parameters in unified view

### DIFF
--- a/templates/inventory_unified.html
+++ b/templates/inventory_unified.html
@@ -1121,13 +1121,13 @@ function searchInventory() {
     const status = document.getElementById('inventoryStatus').value;
 
     const params = new URLSearchParams();
-    if (query) params.append('query', query);
+    if (query) params.append('search', query);
     if (inventoryType) params.append('type', inventoryType);
     if (status) params.append('status', status);
 
     // Use scriptRoot for proxy deployment support
     const scriptRoot = '{{ request.script_root }}' || '';
-    fetch(scriptRoot + `/api/tenant/${tenantId}/inventory/search?${params.toString()}`, {
+    fetch(scriptRoot + `/api/tenant/${tenantId}/inventory-list?${params.toString()}`, {
         credentials: 'same-origin'
     })
         .then(response => {
@@ -1146,7 +1146,7 @@ function searchInventory() {
             }
 
             // Display search results
-            displaySearchResults(data.results || []);
+            displaySearchResults(data.items || []);
         })
         .catch(error => {
             if (error.message !== 'Session expired') {


### PR DESCRIPTION
Ticket: https://linear.app/scope3-projects/issue/SCO-465/inventory-and-profiles-page-search-inventory-function-errors-out

Fixed an issue where searching in the Inventory & Profiles page resulted in a "Unexpected token '<'" error. The frontend was attempting to call a non-existent API endpoint (/inventory/search), causing the server to return a 404 HTML page instead of the expected JSON.

**Changes**
- Updated inventory_unified.html to use the existing API endpoint: /api/tenant/{id}/inventory-list.
- Renamed the query parameter from query to search to match the API signature.
- Updated the response handler to use data.items instead of data.results.