### PR TITLE
fix: 'Select All' buttons in Create Product page by fixing JS scope

### DIFF
--- a/templates/add_product_gam.html
+++ b/templates/add_product_gam.html
@@ -2229,6 +2229,9 @@ function filterGAMFormats() {
         });
     }
 })();
+</script>
+{% endif %}
+<script>
 
 // Initialize pricing options on page load
 {% if product %}
@@ -2456,7 +2459,6 @@ function showToast(message, type = 'info') {
         </div>
     </div>
 </div>
-{% endif %}
 
 <style>
 /* Size chips styling */


### PR DESCRIPTION
Ticket: https://linear.app/scope3-projects/issue/SCO-471/create-product-page-select-all-deselect-all-buttons-do-not-work

In the "Add Product" page (admin/tenant/{tenant}/products/add), the "Select All" and "Deselect All" buttons in the Creative Formats section were not working. This was because the JavaScript functions controlling these buttons were accidentally wrapped inside a conditional block that only executed when editing an existing product, not when creating a new one.

This PR moves the relevant JavaScript functions (selectAllFormats, deselectAllFormats, selectAllMatchingFormats) and the Format Info modal outside of the conditional block. This ensures they are always loaded and available, fixing the button functionality for both creating and editing products.