### PR TITLE
Fix Docker container name references in documentation

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -248,7 +248,7 @@ uv run pytest tests/integration/
 uv run pytest --cov=. --cov-report=html
 
 # Inside Docker
-docker exec -it adcp-server pytest
+docker-compose exec adcp-server pytest
 ```
 
 ### Test Categories
@@ -552,7 +552,7 @@ class MyClass:
 docker-compose logs -f adcp-server
 
 # Execute commands in container
-docker exec -it adcp-buy-server-adcp-server-1 bash
+docker-compose exec adcp-server bash
 
 # Check container health
 docker ps
@@ -594,7 +594,7 @@ curl -H "x-adcp-auth: your_token" \
 
 ```bash
 # Connect to PostgreSQL
-docker exec -it adcp-buy-server-postgres-1 psql -U adcp_user -d adcp
+docker-compose exec postgres psql -U adcp_user -d adcp
 
 # Common queries
 SELECT * FROM tenants;

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -146,14 +146,14 @@ DB_TYPE=sqlite
 
 ```bash
 # Create publisher/tenant with access control
-docker exec -it adcp-server python setup_tenant.py "Publisher Name" \
+docker-compose exec adcp-server python setup_tenant.py "Publisher Name" \
   --adapter google_ad_manager \
   --gam-network-code 123456 \
   --domain publisher.com \
   --admin-email admin@publisher.com
 
 # Create with mock adapter for testing
-docker exec -it adcp-server python setup_tenant.py "Test Publisher" \
+docker-compose exec adcp-server python setup_tenant.py "Test Publisher" \
   --adapter mock \
   --admin-email test@example.com
 ```
@@ -330,10 +330,10 @@ docker-compose up -d
 docker-compose logs -f
 
 # Enter container
-docker exec -it adcp-server bash
+docker-compose exec adcp-server bash
 
 # Backup database
-docker exec postgres pg_dump -U adcp_user adcp > backup.sql
+docker-compose exec postgres pg_dump -U adcp_user adcp > backup.sql
 ```
 
 ## Test Authentication Mode
@@ -461,5 +461,5 @@ curl http://localhost:8080/health
 curl http://localhost:8001/health
 
 # Database
-docker exec postgres pg_isready
+docker-compose exec postgres pg_isready
 ```

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -154,14 +154,14 @@ echo $GOOGLE_CLIENT_SECRET
 # Go to Advertisers tab → Copy token
 
 # Or check database
-docker exec -it postgres psql -U adcp_user adcp -c \
+docker-compose exec postgres psql -U adcp_user adcp -c \
   "SELECT principal_id, access_token FROM principals;"
 ```
 
 #### MCP Returns Empty Products Array
 ```bash
 # Check if products exist for the tenant
-docker exec -it postgres psql -U adcp_user adcp -c \
+docker-compose exec postgres psql -U adcp_user adcp -c \
   "SELECT COUNT(*) FROM products WHERE tenant_id='your_tenant_id';"
 
 # Create products using Admin UI or database script
@@ -171,7 +171,7 @@ docker exec -it postgres psql -U adcp_user adcp -c \
 #### "Missing or invalid x-adcp-auth header" with Valid Token
 ```bash
 # Verify tenant is active
-docker exec -it postgres psql -U adcp_user adcp -c \
+docker-compose exec postgres psql -U adcp_user adcp -c \
   "SELECT is_active FROM tenants WHERE tenant_id='your_tenant_id';"
 
 # Check if using SSE transport (may not forward headers properly)
@@ -183,10 +183,10 @@ docker exec -it postgres psql -U adcp_user adcp -c \
 #### "Column doesn't exist" Error
 ```bash
 # Run migrations
-docker exec -it adcp-server python migrate.py
+docker-compose exec adcp-server python migrate.py
 
 # Check migration status
-docker exec -it adcp-server python migrate.py status
+docker-compose exec adcp-server python migrate.py status
 
 # If migrations fail, check for overlapping revisions
 grep -r "revision = " alembic/versions/
@@ -198,7 +198,7 @@ grep -r "revision = " alembic/versions/
 docker ps | grep postgres
 
 # Test connection
-docker exec -it postgres psql -U adcp_user adcp -c "SELECT 1;"
+docker-compose exec postgres psql -U adcp_user adcp -c "SELECT 1;"
 
 # Check environment variable
 echo $DATABASE_URL
@@ -225,7 +225,7 @@ lsof -i :8001
 #### Permission Denied Errors
 ```bash
 # Fix volume permissions
-docker exec -it adcp-server chown -R $(id -u):$(id -g) /app
+docker-compose exec adcp-server chown -R $(id -u):$(id -g) /app
 
 # Or run with user ID
 docker-compose run --user $(id -u):$(id -g) adcp-server
@@ -242,14 +242,14 @@ python setup_tenant.py "Publisher" \
   --gam-refresh-token NEW_TOKEN
 
 # Verify in database
-docker exec -it postgres psql -U adcp_user adcp -c \
+docker-compose exec postgres psql -U adcp_user adcp -c \
   "SELECT gam_refresh_token FROM adapter_configs;"
 ```
 
 #### Network Code Mismatch
 ```bash
 # Update network code
-docker exec -it postgres psql -U adcp_user adcp -c \
+docker-compose exec postgres psql -U adcp_user adcp -c \
   "UPDATE adapter_configs SET gam_network_code='123456' WHERE tenant_id='tenant_id';"
 ```
 
@@ -361,7 +361,7 @@ environment:
   - FLASK_ENV=development
 
 # Check templates
-docker exec -it admin-ui python -c \
+docker-compose exec admin-ui python -c \
   "from admin_ui import app; app.jinja_env.compile('template.html')"
 ```
 
@@ -382,11 +382,11 @@ echo $FLASK_SECRET_KEY
 #### Slow Database Queries
 ```bash
 # Check query performance
-docker exec -it postgres psql -U adcp_user adcp -c \
+docker-compose exec postgres psql -U adcp_user adcp -c \
   "EXPLAIN ANALYZE SELECT * FROM media_buys WHERE tenant_id='test';"
 
 # Add indexes if needed
-docker exec -it postgres psql -U adcp_user adcp -c \
+docker-compose exec postgres psql -U adcp_user adcp -c \
   "CREATE INDEX idx_media_buys_tenant ON media_buys(tenant_id);"
 ```
 
@@ -420,10 +420,10 @@ curl http://localhost:8080/health
 curl http://localhost:8001/health
 
 # Database health
-docker exec postgres pg_isready
+docker-compose exec postgres pg_isready
 
 # Container health
-docker inspect adcp-server | grep Health
+docker-compose ps adcp-server
 ```
 
 ## Getting Help
@@ -468,7 +468,7 @@ docker-compose logs -f adcp-server
 docker-compose logs -f admin-ui
 
 # Inside container
-docker exec -it adcp-server tail -f /tmp/mcp_server.log
+docker-compose exec adcp-server tail -f /tmp/mcp_server.log
 ```
 
 ### Audit Logs
@@ -490,10 +490,10 @@ curl http://localhost:8080/health
 curl http://localhost:8001/health
 
 # Database status
-docker exec postgres pg_isready
+docker-compose exec postgres pg_isready
 
 # Container status
-docker ps
+docker-compose ps
 ```
 
 ## Operations Troubleshooting

--- a/docs/adapters/mock-adapter-guide.md
+++ b/docs/adapters/mock-adapter-guide.md
@@ -73,7 +73,7 @@ Via Admin UI or product configuration:
 
 ```bash
 # Inside Docker container
-docker exec -it adcp-server python setup_tenant.py "Test Publisher" \
+docker-compose exec adcp-server python setup_tenant.py "Test Publisher" \
   --adapter mock \
   --subdomain test-pub
 
@@ -93,7 +93,7 @@ docker exec -it adcp-server python setup_tenant.py "Test Publisher" \
 
 **Via Database:**
 ```bash
-docker exec -it adcp-postgres psql -U adcp_user -d adcp_sales_agent
+docker-compose exec postgres psql -U adcp_user -d adcp
 SELECT access_token FROM principals WHERE tenant_id = 'test-pub';
 ```
 
@@ -402,7 +402,7 @@ The mock adapter enforces realistic validation:
 **Check:**
 ```bash
 # Verify tenant has mock adapter enabled
-docker exec -it adcp-postgres psql -U adcp_user -d adcp_sales_agent \
+docker-compose exec postgres psql -U adcp_user -d adcp \
   -c "SELECT tenant_id, adapter_config FROM tenants WHERE tenant_id = 'your-tenant';"
 ```
 
@@ -435,7 +435,7 @@ docker-compose logs -f adcp-server | grep "📊\|📤\|🚀"
 
 **Check principal configuration:**
 ```bash
-docker exec -it adcp-postgres psql -U adcp_user -d adcp_sales_agent \
+docker-compose exec postgres psql -U adcp_user -d adcp \
   -c "SELECT platform_mappings FROM principals WHERE principal_id = 'your-principal';"
 ```
 
@@ -559,10 +559,10 @@ For questions or issues:
 
 ```bash
 # Create test tenant with mock adapter
-docker exec -it adcp-server python setup_tenant.py "Test" --adapter mock
+docker-compose exec adcp-server python setup_tenant.py "Test" --adapter mock
 
 # Get access token
-docker exec -it adcp-postgres psql -U adcp_user -d adcp_sales_agent \
+docker-compose exec postgres psql -U adcp_user -d adcp \
   -c "SELECT access_token FROM principals WHERE tenant_id = 'test';"
 
 # Test with curl (MCP)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -45,8 +45,8 @@ The reference implementation at https://adcp-sales-agent.fly.dev is hosted on Fl
 
 3. **Initialize database:**
    ```bash
-   docker exec -it adcp-buy-server-adcp-server-1 python migrate.py
-   docker exec -it adcp-buy-server-adcp-server-1 python init_database.py
+   docker-compose exec adcp-server python migrate.py
+   docker-compose exec adcp-server python init_database.py
    ```
 
 4. **Access services:**
@@ -91,11 +91,10 @@ docker-compose down
 docker-compose down -v
 
 # Enter container
-docker exec -it adcp-buy-server-adcp-server-1 bash
+docker-compose exec adcp-server bash
 
 # Backup database
-docker exec adcp-buy-server-postgres-1 \
-  pg_dump -U adcp_user adcp > backup.sql
+docker-compose exec postgres pg_dump -U adcp_user adcp > backup.sql
 ```
 
 ## Fly.io Deployment (Reference Implementation)
@@ -278,7 +277,7 @@ DB_TYPE=sqlite
 
 ```bash
 # Docker deployment
-docker exec -it adcp-buy-server-adcp-server-1 python setup_tenant.py \
+docker-compose exec adcp-server python setup_tenant.py \
   "Publisher Name" \
   --adapter google_ad_manager \
   --gam-network-code 123456 \
@@ -290,7 +289,7 @@ fly ssh console -C "python setup_tenant.py 'Publisher Name' \
   --gam-network-code 123456"
 
 # Mock adapter for testing
-python setup_tenant.py "Test Publisher" --adapter mock
+docker-compose exec adcp-server python setup_tenant.py "Test Publisher" --adapter mock
 ```
 
 ### Managing Principals (Advertisers)
@@ -342,7 +341,7 @@ curl http://localhost:8080/health
 curl http://localhost:8001/health
 
 # PostgreSQL health (Docker)
-docker exec adcp-buy-server-postgres-1 pg_isready
+docker-compose exec postgres pg_isready
 ```
 
 ### Monitoring Metrics
@@ -397,7 +396,7 @@ server {
 #### PostgreSQL Backup
 ```bash
 # Docker
-docker exec adcp-buy-server-postgres-1 \
+docker-compose exec postgres \
   pg_dump -U adcp_user adcp > backup_$(date +%Y%m%d).sql
 
 # Fly.io
@@ -407,7 +406,7 @@ fly postgres backup create --app adcp-db
 #### PostgreSQL Restore
 ```bash
 # Docker
-docker exec -i adcp-buy-server-postgres-1 \
+docker-compose exec -T postgres \
   psql -U adcp_user adcp < backup.sql
 
 # Fly.io
@@ -600,13 +599,13 @@ To enable maintenance mode:
 
 ```bash
 # Full backup
-docker exec postgres pg_dump -U adcp_user adcp > backup.sql
+docker-compose exec postgres pg_dump -U adcp_user adcp > backup.sql
 
 # Compressed backup
-docker exec postgres pg_dump -U adcp_user adcp | gzip > backup.sql.gz
+docker-compose exec postgres pg_dump -U adcp_user adcp | gzip > backup.sql.gz
 
 # Restore
-docker exec -i postgres psql -U adcp_user adcp < backup.sql
+docker-compose exec -T postgres psql -U adcp_user adcp < backup.sql
 ```
 
 ### SQLite Backup

--- a/scripts/setup/create_scribd_tenant.sh
+++ b/scripts/setup/create_scribd_tenant.sh
@@ -3,7 +3,7 @@
 
 echo "Creating Scribd tenant..."
 
-docker exec abu-dhabi-adcp-server-1 python setup_tenant.py "Scribd" \
+docker-compose exec adcp-server python setup_tenant.py "Scribd" \
   --subdomain scribd \
   --adapter google_ad_manager \
   --gam-network-code 22797863291 \
@@ -11,11 +11,11 @@ docker exec abu-dhabi-adcp-server-1 python setup_tenant.py "Scribd" \
 
 echo ""
 echo "To configure GAM for Scribd:"
-echo "1. Visit http://localhost:8003"
+echo "1. Visit http://localhost:8001"
 echo "2. Login as super admin"
 echo "3. Click on 'Scribd' tenant"
 echo "4. Go to 'Ad Server Setup'"
 echo "5. Complete the OAuth flow"
 echo ""
 echo "Or use the mock adapter instead:"
-echo "docker exec abu-dhabi-adcp-server-1 python setup_tenant.py 'Scribd' --subdomain scribd --adapter mock"
+echo "docker-compose exec adcp-server python setup_tenant.py 'Scribd' --subdomain scribd --adapter mock"

--- a/tests/README.md
+++ b/tests/README.md
@@ -246,13 +246,13 @@ def clean_db():
 
 ```bash
 # Run tests in container
-docker exec -it adcp-server pytest tests/unit/
+docker-compose exec adcp-server pytest tests/unit/
 
 # Run with coverage
-docker exec -it adcp-server pytest --cov=. --cov-report=term-missing
+docker-compose exec adcp-server pytest --cov=. --cov-report=term-missing
 
 # Run specific test file
-docker exec -it adcp-server pytest tests/integration/test_main.py -v
+docker-compose exec adcp-server pytest tests/integration/test_main.py -v
 ```
 
 ## Performance Testing

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -266,7 +266,7 @@ curl http://localhost:8003/health  # Admin
 ### Database Access
 ```bash
 # Connect to PostgreSQL
-docker exec -it set-up-production-tenants-postgres-1 psql -U adcp_user -d adcp
+docker-compose exec postgres psql -U adcp_user -d adcp
 
 # View test data
 SELECT * FROM tenants WHERE subdomain = 'e2e-test';
@@ -331,7 +331,7 @@ docker-compose up -d
 #### Authentication Errors
 ```bash
 # Create new test principal
-docker exec -it set-up-production-tenants-adcp-server-1 \
+docker-compose exec adcp-server \
   python setup_tenant.py "Test Publisher" --adapter mock
 ```
 
@@ -341,7 +341,7 @@ docker exec -it set-up-production-tenants-adcp-server-1 \
 docker-compose ps postgres
 
 # Verify connection
-docker exec -it set-up-production-tenants-adcp-server-1 \
+docker-compose exec adcp-server \
   python -c "from src.core.database.connection import get_db_session; print('Connected')"
 ```
 


### PR DESCRIPTION
## Summary

Replace `docker exec` with `docker-compose exec` throughout documentation and scripts to use service names instead of dynamically-generated container names. This resolves the "No such container" error when running tenant setup and other Docker commands in different workspaces.

Docker Compose names containers with a project-based prefix (e.g., `honolulu-v4-adcp-server-1`), but using `docker-compose exec adcp-server` references the service name which remains consistent across all workspaces.

## Test plan

- [x] All unit tests pass
- [x] All integration tests pass  
- [x] Documentation is now consistent
- [x] Scripts use the correct Docker Compose pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)