### PR TITLE
Add IPR agreement workflow using centralized AdCP signatures

### DIFF
--- a/.github/workflows/ipr-agreement.yml
+++ b/.github/workflows/ipr-agreement.yml
@@ -1,0 +1,57 @@
+name: IPR Agreement
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  ipr-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: (github.event.comment.body == 'I have read the IPR Policy' || github.event_name == 'pull_request_target')
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.IPR_PAT }}
+        with:
+          path-to-signatures: 'signatures/ipr-signatures.json'
+          path-to-document: 'https://github.com/adcontextprotocol/adcp/blob/main/IPR_POLICY.md'
+          branch: 'main'
+          remote-organization-name: 'adcontextprotocol'
+          remote-repository-name: 'adcp'
+          allowlist: 'bot*,dependabot*,renovate*,github-actions*'
+
+          custom-notsigned-prcomment: |
+            ## IPR Policy Agreement Required
+
+            Thank you for your contribution! Before we can accept your pull request, you must agree to our [Intellectual Property Rights Policy](https://github.com/adcontextprotocol/adcp/blob/main/IPR_POLICY.md).
+
+            By making a Contribution, you agree that:
+            - You grant the Foundation a perpetual, irrevocable, worldwide, non-exclusive, royalty-free copyright license to your Contribution
+            - You grant a patent license under any Necessary Claims
+            - You represent that you own or have sufficient rights to grant these licenses
+
+            **To agree, please comment below with the exact phrase:**
+
+            ```
+            I have read the IPR Policy
+            ```
+
+            You can read the full [IPR Policy here](https://github.com/adcontextprotocol/adcp/blob/main/IPR_POLICY.md).
+
+          custom-pr-sign-comment: 'I have read the IPR Policy'
+
+          custom-allsigned-prcomment: |
+            All contributors have agreed to the [IPR Policy](https://github.com/adcontextprotocol/adcp/blob/main/IPR_POLICY.md). Thank you!
+
+          lock-pullrequest-aftermerge: false
+          use-dco-flag: false


### PR DESCRIPTION
## Summary
- Adds IPR Policy agreement enforcement for all contributors using the contributor-assistant GitHub Action
- Signatures are stored centrally in `adcontextprotocol/adcp` repository, so contributors only need to sign once across all AdCP-related repos
- Contributors who have already signed in the AdCP repo will automatically pass the check

## Test plan
- [ ] Open this PR and verify the IPR check runs
- [ ] If you haven't signed the IPR policy before, verify the bot comments asking you to sign
- [ ] If you have signed before, verify the check passes automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)