### PR TITLE
refactor: simplify new user setup with well-known token

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,37 +11,40 @@ The AdCP Sales Agent is a server that:
 - **Provides an admin interface** for managing inventory and monitoring campaigns
 - **Handles the full campaign lifecycle** from discovery to reporting
 
-## Quick Start - Choose Your Setup Path
+## Quick Start (3 commands)
 
-### Path 1: Mock Adapter (5 min) - Recommended First Step
+```bash
+git clone https://github.com/adcontextprotocol/salesagent.git && cd salesagent
+cp .env.template .env && docker-compose up -d
+uvx adcp http://localhost:8080/mcp/ --auth test-token list_tools
+```
+
+A default tenant with `test-token` is created automatically. No setup required.
+
+```bash
+# CLI syntax: uvx adcp <url> --auth <token> <tool_name> '<json_args>'
+uvx adcp http://localhost:8080/mcp/ --auth test-token get_products '{"brief":"video"}'
+```
+
+**Admin UI:** http://localhost:8001 (login: `test_super_admin@example.com` / `test123`)
+
+---
+
+## Setup Paths
+
+### Path 1: Mock Adapter (Recommended First Step)
 
 **Perfect for:** Learning AdCP, testing integrations, development
 
+The quick start above uses the mock adapter. To create your own tenant:
+
 ```bash
-# 1. Clone and configure
-git clone https://github.com/adcontextprotocol/salesagent.git
-cd salesagent
-cp .env.template .env
-
-# 2. Set your Gemini API key in .env:
-#    GEMINI_API_KEY=get-free-at-https://aistudio.google.com/apikey
-#    (Test mode is enabled by default - no OAuth setup needed)
-
-# 3. Start services
-docker-compose up -d
-
-# 4. Create test tenant (note the token output!)
-docker-compose exec adcp-server python -m scripts.setup.setup_tenant "Test Publisher" \
+docker-compose exec adcp-server python -m scripts.setup.setup_tenant "My Publisher" \
   --adapter mock \
   --admin-email your-email@example.com
-
-# 5. Test the MCP server with AdCP CLI (use token from step 4)
-uvx adcp http://localhost:8080/mcp/ --auth YOUR_TOKEN list_tools
-
-# 6. Access Admin UI
-open http://localhost:8001
-# Login with: test_super_admin@example.com / test123
 ```
+
+This outputs a principal token you can use immediately.
 
 **Using with Claude Desktop:** Add to your Claude config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
 ```json
@@ -49,7 +52,7 @@ open http://localhost:8001
   "mcpServers": {
     "adcp": {
       "command": "uvx",
-      "args": ["mcp-remote", "http://localhost:8080/mcp/", "--header", "x-adcp-auth: YOUR_TOKEN"]
+      "args": ["mcp-remote", "http://localhost:8080/mcp/", "--header", "x-adcp-auth: test-token"]
     }
   }
 }

--- a/scripts/a2a_query.py
+++ b/scripts/a2a_query.py
@@ -11,7 +11,7 @@ import sys
 import requests
 
 
-def query_a2a(message, token="demo_token_123", endpoint="http://localhost:8091", tenant_id=None):
+def query_a2a(message, token="test-token", endpoint="http://localhost:8091", tenant_id=None):
     """Send an authenticated query to the A2A server."""
 
     # Construct the URL (no token in query string for security)
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     # You can override these with environment variables
     import os
 
-    token = os.getenv("A2A_TOKEN", "demo_token_123")
+    token = os.getenv("A2A_TOKEN", "test-token")
     endpoint = os.getenv("A2A_ENDPOINT", "http://localhost:8091")
     tenant_id = os.getenv("A2A_TENANT_ID", None)
 

--- a/scripts/setup/init_database.py
+++ b/scripts/setup/init_database.py
@@ -119,15 +119,16 @@ def init_db(exit_on_error=False):
             adapter_config = AdapterConfig(tenant_id="default", adapter_type="mock", mock_dry_run=False)
             session.add(adapter_config)
 
-            # Always create a demo principal for testing (used by ADK agent)
-            demo_principal = Principal(
+            # Create default principal with well-known token for easy testing
+            # This token is documented and can be used immediately after docker-compose up
+            default_principal = Principal(
                 tenant_id="default",
-                principal_id="demo_advertiser",
-                name="Demo Advertiser",
-                platform_mappings={"mock": {"advertiser_id": "mock-demo"}},
-                access_token="demo_token_123",
+                principal_id="default_principal",
+                name="Default Principal",
+                platform_mappings={"mock": {"advertiser_id": "mock-default"}},
+                access_token="test-token",  # Well-known token for easy testing
             )
-            session.add(demo_principal)
+            session.add(default_principal)
 
             # Always create basic products for demo/testing
             basic_products = [
@@ -343,37 +344,50 @@ def init_db(exit_on_error=False):
                 )
             else:
                 print(
-                    f"""
-╔══════════════════════════════════════════════════════════════════╗
-║                 🚀 ADCP SALES AGENT INITIALIZED                  ║
-╠══════════════════════════════════════════════════════════════════╣
-║                                                                  ║
-║  A default tenant has been created for quick start:              ║
-║                                                                  ║
-║  🏢 Tenant: Default Publisher                                    ║
-║  🌐 Admin UI: http://localhost:8001/tenant/default/login         ║
-║                                                                  ║
-║  🔑 Admin Token (for legacy API access):                         ║
-║     {admin_token}  ║
-║                                                                  ║
-║  ⚡ Next Steps:                                                  ║
-║     1. Log in to the Admin UI                                    ║
-║     2. Set up your ad server (Ad Server Setup tab)              ║
-║     3. Create principals for your advertisers                    ║
-║                                                                  ║
-║  💡 To create additional tenants:                                ║
-║     python scripts/setup/setup_tenant.py "Publisher Name"        ║
-║                                                                  ║
-╚══════════════════════════════════════════════════════════════════╝
+                    """
+╔══════════════════════════════════════════════════════════════════════════╗
+║                        🚀 ADCP SALES AGENT READY                         ║
+╠══════════════════════════════════════════════════════════════════════════╣
+║                                                                          ║
+║  ⚡ TEST IT NOW:                                                         ║
+║                                                                          ║
+║  # List available tools                                                  ║
+║  uvx adcp http://localhost:8080/mcp/ --auth test-token list_tools        ║
+║                                                                          ║
+║  # Search for products (syntax: <url> --auth <token> <tool> '<json>')    ║
+║  uvx adcp http://localhost:8080/mcp/ --auth test-token \\                ║
+║    get_products '{"brief":"video"}'                                      ║
+║                                                                          ║
+╠══════════════════════════════════════════════════════════════════════════╣
+║                                                                          ║
+║  🏢 Default Tenant: Default Publisher                                    ║
+║  🔑 Principal Token: test-token                                          ║
+║  🌐 Admin UI: http://localhost:8001                                      ║
+║     Login: test_super_admin@example.com / test123                        ║
+║                                                                          ║
+║  📚 Create your own tenant:                                              ║
+║     docker-compose exec adcp-server python \\                            ║
+║       -m scripts.setup.setup_tenant "My Publisher" --adapter mock        ║
+║                                                                          ║
+╚══════════════════════════════════════════════════════════════════════════╝
                 """
                 )
         else:
-            # Tenant already exists - just report readiness
+            # Tenant already exists - show ready message with quick-start info
             from sqlalchemy import func, select
 
             stmt = select(func.count()).select_from(Tenant)
             tenant_count = session.scalar(stmt)
-            print(f"✅ Database ready (default tenant already exists, {tenant_count} tenant(s) total)")
+            print(
+                f"""
+✅ Database ready ({tenant_count} tenant(s))
+
+⚡ Quick test: uvx adcp http://localhost:8080/mcp/ --auth test-token list_tools
+
+🌐 Admin UI: http://localhost:8001
+   Login: test_super_admin@example.com / test123
+"""
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/setup/setup_tenant.py
+++ b/scripts/setup/setup_tenant.py
@@ -40,8 +40,11 @@ def create_tenant(args):
     }
 
     with get_db_session() as session:
-        # Check if tenant exists
-        existing = session.query(Tenant).filter_by(tenant_id=tenant_id).first()
+        # Check if tenant exists (use SQLAlchemy 2.0 syntax)
+        from sqlalchemy import select
+
+        stmt = select(Tenant).filter_by(tenant_id=tenant_id)
+        existing = session.scalars(stmt).first()
         if existing:
             print(f"Error: Tenant '{tenant_id}' already exists")
             sys.exit(1)


### PR DESCRIPTION
Reduce setup friction and make the sales agent immediately usable after cloning.

**Changes:**
- Default principal uses well-known `test-token` instead of random token
- Init script shows copy-pastable commands with correct CLI syntax
- README condensed to 3-command quick start
- Fixed SQLAlchemy 2.0 syntax in setup_tenant.py to eliminate warnings

**User Experience:**
Before: 6+ steps, hunt for tokens in database output
After: `docker-compose up -d` → `uvx adcp http://localhost:8080/mcp/ --auth test-token list_tools`