### PR TITLE
fix: Remove stale ui-test-assistant MCP server config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,19 +1,5 @@
 {
   "name": "adcp-sales-agent",
   "description": "AdCP Sales Agent MCP tools and services",
-  "mcpServers": {
-    "ui-test-assistant": {
-      "name": "UI Test Assistant",
-      "description": "UI testing tools for AdCP Admin interface",
-      "command": "uv",
-      "args": ["run", "python", "ui_test_server.py"],
-      "cwd": "ui_tests/claude_subagent",
-      "env": {
-        "PYTHONPATH": ".",
-        "BASE_URL": "${BASE_URL:-http://localhost:8002}",
-        "ADMIN_UI_PORT": "${ADMIN_UI_PORT:-8002}",
-        "HEADLESS": "${HEADLESS:-true}"
-      }
-    }
-  }
+  "mcpServers": {}
 }


### PR DESCRIPTION
The ui_tests/ directory was removed in commit 725acf3b as part of a refactoring to use test authentication mode instead of the MCP subagent. This .mcp.json entry references the deleted directory and is no longer needed.

Removes stale configuration that was causing MCP reconnection failures across Conductor workspaces.