### PR TITLE
docs: Update quickstart to use published Docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ The AdCP Sales Agent is a server that:
 ## Quick Start (3 commands)
 
 ```bash
-git clone https://github.com/adcontextprotocol/salesagent.git && cd salesagent
-cp .env.template .env && docker-compose up -d
+curl -O https://raw.githubusercontent.com/adcontextprotocol/salesagent/main/docker-compose.prod.yml
+docker compose -f docker-compose.prod.yml up -d
 uvx adcp http://localhost:8080/mcp/ --auth test-token list_tools
 ```
 
@@ -28,6 +28,16 @@ uvx adcp http://localhost:8080/mcp/ --auth test-token get_products '{"brief":"vi
 
 **Admin UI:** http://localhost:8001 (login: `test_super_admin@example.com` / `test123`)
 
+### Using a Specific Version
+
+For production, pin to a specific version:
+
+```bash
+# Available at ghcr.io/adcontextprotocol/salesagent
+# Tags: latest, 0, 0.1, 0.1.0 (see all versions at GitHub Packages)
+docker pull ghcr.io/adcontextprotocol/salesagent:0.1.0
+```
+
 ---
 
 ## Setup Paths
@@ -39,7 +49,8 @@ uvx adcp http://localhost:8080/mcp/ --auth test-token get_products '{"brief":"vi
 The quick start above uses the mock adapter. To create your own tenant:
 
 ```bash
-docker-compose exec adcp-server python -m scripts.setup.setup_tenant "My Publisher" \
+docker compose -f docker-compose.prod.yml exec adcp-server \
+  python -m scripts.setup.setup_tenant "My Publisher" \
   --adapter mock \
   --admin-email your-email@example.com
 ```

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,76 @@
+# Production Docker Compose - uses pre-built images from GitHub Container Registry
+#
+# Quick start:
+#   docker compose -f docker-compose.prod.yml up -d
+#
+# Pin to a specific version for production:
+#   IMAGE_TAG=0.1.0 docker compose -f docker-compose.prod.yml up -d
+#
+# Available tags: latest, 0, 0.1, 0.1.0
+# See all versions: https://github.com/adcontextprotocol/salesagent/pkgs/container/salesagent
+
+services:
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_DB: adcp
+      POSTGRES_USER: adcp_user
+      POSTGRES_PASSWORD: secure_password_change_me
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U adcp_user -d adcp"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  adcp-server:
+    image: ghcr.io/adcontextprotocol/salesagent:${IMAGE_TAG:-latest}
+    environment:
+      DATABASE_URL: postgresql://adcp_user:secure_password_change_me@postgres:5432/adcp?sslmode=disable
+      SKIP_NGINX: "true"
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      SUPER_ADMIN_EMAILS: ${SUPER_ADMIN_EMAILS:-}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "${ADCP_SALES_PORT:-8080}:8080"
+      - "${A2A_PORT:-8091}:8091"
+    volumes:
+      - ./audit_logs:/app/audit_logs
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  admin-ui:
+    image: ghcr.io/adcontextprotocol/salesagent:${IMAGE_TAG:-latest}
+    command: python -m src.admin.server
+    environment:
+      DATABASE_URL: postgresql://adcp_user:secure_password_change_me@postgres:5432/adcp?sslmode=disable
+      SKIP_NGINX: "true"
+      ADMIN_UI_PORT: ${ADMIN_UI_PORT:-8001}
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      SUPER_ADMIN_EMAILS: ${SUPER_ADMIN_EMAILS:-}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
+      ADCP_AUTH_TEST_MODE: ${ADCP_AUTH_TEST_MODE:-true}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "${ADMIN_UI_PORT:-8001}:${ADMIN_UI_PORT:-8001}"
+    volumes:
+      - ./audit_logs:/app/audit_logs
+    healthcheck:
+      test: ["CMD", "sh", "-c", "curl -f http://localhost:${ADMIN_UI_PORT:-8001}/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+volumes:
+  postgres_data:

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -2,6 +2,29 @@
 
 ## Quick Start (Docker)
 
+### Option A: Pre-built Images (Fastest)
+
+```bash
+# 1. Download compose file
+curl -O https://raw.githubusercontent.com/adcontextprotocol/salesagent/main/docker-compose.prod.yml
+
+# 2. Start services
+docker compose -f docker-compose.prod.yml up -d
+
+# 3. Test the MCP endpoint
+uvx adcp http://localhost:8080/mcp/ --auth test-token list_tools
+
+# 4. Access Admin UI (test login: test_super_admin@example.com / test123)
+open http://localhost:8001
+```
+
+For production, pin to a specific version:
+```bash
+IMAGE_TAG=0.1.0 docker compose -f docker-compose.prod.yml up -d
+```
+
+### Option B: Build from Source (For Development)
+
 ```bash
 # 1. Clone the repository
 git clone https://github.com/adcontextprotocol/salesagent.git

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,9 +5,10 @@
 The AdCP Sales Agent reference implementation is designed to be hosted anywhere. This guide covers several deployment options.
 
 **Deployment Flexibility:**
+- **Pre-built Docker images** available at `ghcr.io/adcontextprotocol/salesagent`
 - This is a **standard Python application** that can run on any infrastructure
 - **Docker recommended** but not required
-- **Database agnostic** - works with PostgreSQL (production) or SQLite (dev/testing)
+- **PostgreSQL required** for production deployments
 - We'll support your deployment approach as best we can
 
 **Common Deployment Options:**
@@ -21,20 +22,83 @@ The AdCP Sales Agent reference implementation is designed to be hosted anywhere.
 **Reference Implementation:**
 The reference implementation at https://adcp-sales-agent.fly.dev is hosted on Fly.io, but this is just one option.
 
+## Docker Images
+
+Pre-built Docker images are published to GitHub Container Registry on every release.
+
+### Available Tags
+
+| Tag | Description | Use Case |
+|-----|-------------|----------|
+| `latest` | Most recent release | Quick evaluation |
+| `0` | Latest major version 0.x.x | Auto-update within major |
+| `0.1` | Latest minor version 0.1.x | Auto-update within minor |
+| `0.1.0` | Specific patch version | Production (recommended) |
+
+### Pulling Images
+
+```bash
+# Latest release
+docker pull ghcr.io/adcontextprotocol/salesagent:latest
+
+# Pin to specific version (recommended for production)
+docker pull ghcr.io/adcontextprotocol/salesagent:0.1.0
+
+# Pin to minor version (gets patch updates)
+docker pull ghcr.io/adcontextprotocol/salesagent:0.1
+```
+
+### Version Pinning Strategy
+
+| Environment | Recommended Tag | Rationale |
+|-------------|-----------------|-----------|
+| **Production** | `0.1.0` (specific version) | Predictable, tested deployments |
+| **Staging** | `0.1` (minor version) | Test patch updates before prod |
+| **Development** | `latest` or build from source | Latest features |
+
+See all available versions: https://github.com/adcontextprotocol/salesagent/pkgs/container/salesagent
+
 ## Docker Deployment (Recommended)
 
 ### Prerequisites
 - Docker and Docker Compose installed
-- Environment variables configured
-- Google OAuth credentials (for Admin UI)
+- Environment variables configured (optional for evaluation)
+- Google OAuth credentials (for Admin UI in production)
 
-### Quick Start
+### Option A: Pre-built Images (Recommended)
+
+The fastest way to get started using published images:
+
+```bash
+# Download the production compose file
+curl -O https://raw.githubusercontent.com/adcontextprotocol/salesagent/main/docker-compose.prod.yml
+
+# Start services
+docker compose -f docker-compose.prod.yml up -d
+
+# Verify it's running
+curl http://localhost:8080/health
+```
+
+**Pin to a specific version for production:**
+```bash
+IMAGE_TAG=0.1.0 docker compose -f docker-compose.prod.yml up -d
+```
+
+**Access services:**
+- MCP Server: http://localhost:8080/mcp/
+- Admin UI: http://localhost:8001 (test login: `test_super_admin@example.com` / `test123`)
+- PostgreSQL: localhost:5432
+
+### Option B: Build from Source
+
+For development or customization:
 
 1. **Clone and configure:**
    ```bash
    git clone https://github.com/adcontextprotocol/salesagent.git
    cd salesagent
-   cp .env.example .env
+   cp .env.template .env
    # Edit .env with your configuration
    ```
 
@@ -43,13 +107,7 @@ The reference implementation at https://adcp-sales-agent.fly.dev is hosted on Fl
    docker-compose up -d
    ```
 
-3. **Initialize database:**
-   ```bash
-   docker-compose exec adcp-server python migrate.py
-   docker-compose exec adcp-server python init_database.py
-   ```
-
-4. **Access services:**
+3. **Access services:**
    - MCP Server: http://localhost:8080/mcp/
    - Admin UI: http://localhost:8001
    - PostgreSQL: localhost:5432


### PR DESCRIPTION
## Summary

Now that we're publishing versioned container images to GitHub Container Registry (`ghcr.io/adcontextprotocol/salesagent`), update the documentation and quickstart to use pre-built images for faster onboarding.

This provides two paths:
- **Option A (Recommended)**: Pull pre-built image - no build, no git clone, fast evaluation
- **Option B (Development)**: Build from source - for local customization and development

## Changes

- Create `docker-compose.prod.yml` using published images with version pinning support
- Update README quickstart: 3-command start using pre-built image
- Update SETUP.md with two distinct paths (pre-built vs source)
- Update deployment.md with comprehensive versioning strategy:
  - **Production**: Pin to patch version (e.g., `0.1.0`) for predictability
  - **Staging**: Pin to minor version (e.g., `0.1`) to test patches
  - **Development**: Use `latest` or build from source
- Use PostgreSQL 17-alpine for improved performance and security
- Clarify PostgreSQL is required for production (not optional)

## Test Plan

- [x] Pre-commit hooks pass (all checks green)
- [x] Unit tests pass
- [x] Image tags verified at ghcr.io/adcontextprotocol/salesagent
- [x] docker-compose.prod.yml verified with correct environment variable handling
- [x] Documentation links valid