### PR TITLE
Fix delivery webhook scheduler startup burst and deduplication

### DIFF
--- a/src/services/delivery_webhook_scheduler.py
+++ b/src/services/delivery_webhook_scheduler.py
@@ -66,7 +66,11 @@ class DeliveryWebhookScheduler:
             logger.info("Delivery webhook scheduler stopped")
 
     async def _run_scheduler(self) -> None:
-        """Main scheduler loop - runs on a fixed hourly cadence."""
+        """Main scheduler loop - runs on a fixed hourly cadence.
+
+        Sends immediately on startup (duplicate check prevents re-sending if
+        already sent in last 24 hours), then continues on hourly cadence.
+        """
         while self.is_running:
             try:
                 await self._send_reports()
@@ -75,7 +79,7 @@ class DeliveryWebhookScheduler:
             except Exception as e:
                 logger.error(f"Error in delivery webhook scheduler: {e}", exc_info=True)
             finally:
-                # Wait 1 hour before next batch, even if there was an error
+                # Wait before next batch
                 await asyncio.sleep(SLEEP_INTERVAL_SECONDS)
 
     async def _send_reports(self) -> None:

--- a/src/services/protocol_webhook_service.py
+++ b/src/services/protocol_webhook_service.py
@@ -231,7 +231,12 @@ class ProtocolWebhookService:
                 logger.info(f"Successfully sent webhook for task {task_id} (status: {response.status_code})")
 
                 # Write to webhook_delivery_log (success)
-                if task_type == "delivery_report" and media_buy_id and tenant_id and principal_id:
+                if (
+                    task_type in ("delivery_report", "media_buy_delivery")
+                    and media_buy_id
+                    and tenant_id
+                    and principal_id
+                ):
                     try:
                         with get_db_session() as session:
                             log_entry = WebhookDeliveryLog(
@@ -274,7 +279,12 @@ class ProtocolWebhookService:
                     logger.error(f"Webhook failed for task {task_id} with client error {status_code} - not retrying")
 
                     # Write to webhook_delivery_log (failed)
-                    if task_type == "delivery_report" and media_buy_id and tenant_id and principal_id:
+                    if (
+                        task_type in ("delivery_report", "media_buy_delivery")
+                        and media_buy_id
+                        and tenant_id
+                        and principal_id
+                    ):
                         try:
                             with get_db_session() as session:
                                 log_entry = WebhookDeliveryLog(
@@ -314,7 +324,12 @@ class ProtocolWebhookService:
                     )
 
                     # Write to webhook_delivery_log (retrying)
-                    if task_type == "delivery_report" and media_buy_id and tenant_id and principal_id:
+                    if (
+                        task_type in ("delivery_report", "media_buy_delivery")
+                        and media_buy_id
+                        and tenant_id
+                        and principal_id
+                    ):
                         try:
                             with get_db_session() as session:
                                 next_retry = datetime.now(UTC).replace(microsecond=0)
@@ -347,7 +362,12 @@ class ProtocolWebhookService:
                     logger.error(f"Webhook failed for task {task_id} after {max_attempts} attempts: HTTP {status_code}")
 
                     # Write to webhook_delivery_log (failed after all retries)
-                    if task_type == "delivery_report" and media_buy_id and tenant_id and principal_id:
+                    if (
+                        task_type in ("delivery_report", "media_buy_delivery")
+                        and media_buy_id
+                        and tenant_id
+                        and principal_id
+                    ):
                         try:
                             with get_db_session() as session:
                                 log_entry = WebhookDeliveryLog(
@@ -396,7 +416,12 @@ class ProtocolWebhookService:
                     )
 
                     # Write to webhook_delivery_log (failed)
-                    if task_type == "delivery_report" and media_buy_id and tenant_id and principal_id:
+                    if (
+                        task_type in ("delivery_report", "media_buy_delivery")
+                        and media_buy_id
+                        and tenant_id
+                        and principal_id
+                    ):
                         try:
                             with get_db_session() as session:
                                 log_entry = WebhookDeliveryLog(
@@ -430,7 +455,12 @@ class ProtocolWebhookService:
                 logger.error(f"Unexpected error sending webhook for task {task_id}: {e}")
 
                 # Write to webhook_delivery_log (unexpected failure)
-                if task_type == "delivery_report" and media_buy_id and tenant_id and principal_id:
+                if (
+                    task_type in ("delivery_report", "media_buy_delivery")
+                    and media_buy_id
+                    and tenant_id
+                    and principal_id
+                ):
                     try:
                         with get_db_session() as session:
                             log_entry = WebhookDeliveryLog(


### PR DESCRIPTION
Fixes duplicate prevention for delivery webhooks.

The duplicate prevention never worked because webhook logs were only written for `task_type == "delivery_report"` but the scheduler uses `task_type="media_buy_delivery"`. This caused webhooks to be re-sent on every server restart since no log records existed to check against.

**Fix:** Accept both task types in webhook logging conditions. Now webhooks are sent on startup only if not already sent in last 24 hours - exactly the intended behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)