### PR TITLE
fix: Fix/format ids type handling for the format_ids in the products table

### DIFF
--- a/src/core/product_conversion.py
+++ b/src/core/product_conversion.py
@@ -198,7 +198,6 @@ def convert_product_model_to_schema(product_model) -> Product:
 
     # format_ids: Use effective_format_ids which auto-resolves from profile if set
     # Products must have at least one format_id to be valid for media buys
-    # Note: Returns dicts from database JSONB, handled by extract_format_key() in media_buy_create.py
     effective_formats = product_model.effective_format_ids or []
     if not effective_formats:
         raise ValueError(

--- a/src/core/tools/media_buy_create.py
+++ b/src/core/tools/media_buy_create.py
@@ -2411,7 +2411,6 @@ async def _create_media_buy_impl(
                 # Build set of requested format keys for comparison
                 requested_format_keys: set[tuple[str | None, str]] = set()
                 for fmt in matching_package.format_ids:
-                    # matching_package.format_ids are FormatId objects from request
                     normalized_url = str(fmt.agent_url).rstrip("/") if fmt.agent_url else None
                     requested_format_keys.add((normalized_url, fmt.id))
 


### PR DESCRIPTION
## Problem
AttributeError: 'dict' object has no attribute 'agent_url' when creating media buys.

- Staging error link: https://scope3.slack.com/archives/C097XMRQVV3/p1766439254008799
- Sales agent log link: https://sales-agent.scope3.com/admin/tenant/default/media-buy/mb_50568140504e (all the way to the bottom)

## Root Cause
pkg_product.format_ids comes from database JSONB → returns dicts
matching_package.format_ids comes from request validation → returns FormatId objects
Code was using .agent_url on both, but dicts need ["agent_url"]
## Fix
Use appropriate access pattern for each source:
```
# Database JSONB -> (dicts)
fmt["agent_url"], fmt["id"]

# Request (FormatId objects)  
fmt.agent_url, fmt.id
```

<img width="1240" height="597" alt="image" src="https://github.com/user-attachments/assets/c533fd97-61d8-4de0-bc2c-8019b5f1405b" />

## Validation
```
python test_format_id_types.py
```