### PR TITLE
ci: Add PR title validation for Conventional Commits

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,58 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title follows Conventional Commits
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure which types are allowed
+          # These match release-please-config.json changelog-sections
+          types: |
+            feat
+            fix
+            docs
+            refactor
+            perf
+            chore
+            test
+            ci
+            build
+            style
+            revert
+          # Require a scope? (e.g., feat(api): ...)
+          requireScope: false
+          # Disallow scopes that don't match a given regex
+          # disallowScopes: |
+          #   release
+          # Define the subject pattern (text after the type/scope)
+          subjectPattern: ^.+$
+          subjectPatternError: |
+            The PR title "{title}" doesn't follow Conventional Commits format.
+
+            Please use one of these prefixes:
+            - feat: New features (appears in "Features" section)
+            - fix: Bug fixes (appears in "Bug Fixes" section)
+            - docs: Documentation changes
+            - refactor: Code refactoring (appears in "Code Refactoring" section)
+            - perf: Performance improvements
+            - chore: Maintenance tasks (hidden from changelog)
+            - test: Test changes
+            - ci: CI/CD changes
+            - build: Build system changes
+            - style: Code style changes
+            - revert: Reverts a previous commit
+
+            Example: "feat: Add user authentication"
+          # For work-in-progress PRs, allow wip/WIP prefix
+          wip: true
+          # Validate the subject doesn't start with uppercase
+          # (conventional commits typically use lowercase)
+          validateSingleCommit: false


### PR DESCRIPTION
## Summary
- Adds GitHub Action workflow to validate PR titles follow Conventional Commits format
- Uses `amannn/action-semantic-pull-request@v5` for robust validation with clear error messages
- Ensures all PRs use recognized prefixes (`feat:`, `fix:`, `docs:`, `refactor:`, `perf:`, `chore:`, etc.) so they appear correctly in release-please changelogs

## Test plan
- [ ] Create a PR with invalid title (e.g., "Update something") - should fail
- [ ] Create a PR with valid title (e.g., "feat: Add feature") - should pass
- [ ] Verify WIP prefix is allowed for draft PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)