### PR TITLE
fix: Use www-data user in nginx and Debian-based image

### DIFF
--- a/config/nginx/nginx-simple.conf
+++ b/config/nginx/nginx-simple.conf
@@ -1,7 +1,7 @@
 # Simplified nginx config for Docker Compose (path-based routing only)
 # For multi-tenant subdomain routing, use nginx.conf
 
-user nginx;
+user www-data;
 worker_processes auto;
 error_log /var/log/nginx/error.log warn;
 pid /var/run/nginx.pid;

--- a/docker-compose.multi-tenant.yml
+++ b/docker-compose.multi-tenant.yml
@@ -37,7 +37,7 @@ services:
 
   # Full nginx with subdomain routing
   proxy:
-    image: nginx:alpine
+    image: nginx:stable
     volumes:
       # Use multi-tenant nginx config with Docker service names
       - ./config/nginx/nginx-multi-tenant.conf:/etc/nginx/nginx.conf:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
 
   # Nginx proxy for unified routing on port 8000
   proxy:
-    image: nginx:alpine
+    image: nginx:stable
     volumes:
       - ./config/nginx/nginx-simple.conf:/etc/nginx/nginx.conf:ro
     depends_on:


### PR DESCRIPTION
## Summary

Fixed nginx startup failure in 0.2 release by using the correct user and base image. The production Dockerfile uses Debian-based Python which creates the `www-data` user, not `nginx`. Updated all Docker Compose configs to use `nginx:stable` (Debian) instead of `nginx:alpine` for consistency between local and production deployments.

## Changes

- `nginx-simple.conf`: Changed `user nginx;` to `user www-data;` (matches Debian package)
- `docker-compose.yml`: Changed nginx image from `nginx:alpine` to `nginx:stable`
- `docker-compose.multi-tenant.yml`: Changed nginx image from `nginx:alpine` to `nginx:stable`

## Fixes

Resolves container startup failure: `getpwnam("nginx") failed in /etc/nginx/nginx.conf:4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)