### PR TITLE
fix: Only set SESSION_COOKIE_DOMAIN in multi-tenant mode

### DIFF
--- a/docs/deployment/multi-tenant.md
+++ b/docs/deployment/multi-tenant.md
@@ -44,6 +44,8 @@ ADMIN_DOMAIN=admin.sales-agent.yourdomain.com
 SUPER_ADMIN_DOMAIN=yourdomain.com
 ```
 
+> **Session Cookies in Multi-Tenant Mode**: When `ADCP_MULTI_TENANT=true`, session cookies are automatically scoped to `SALES_AGENT_DOMAIN` to work across all tenant subdomains. This allows users to authenticate at `admin.sales-agent.yourdomain.com` and access tenant dashboards at `tenant.sales-agent.yourdomain.com`. In single-tenant mode (default), cookies use the actual request domain instead.
+
 ## Step 3: DNS Configuration
 
 ### Wildcard DNS (for subdomain routing)

--- a/docs/deployment/single-tenant.md
+++ b/docs/deployment/single-tenant.md
@@ -77,6 +77,9 @@ docker pull ghcr.io/adcontextprotocol/salesagent:latest
 | `CREATE_DEMO_TENANT` | Create demo tenant with sample data | `true` |
 | `ENCRYPTION_KEY` | For encrypting sensitive data | Auto-generated |
 | `ADCP_AUTH_TEST_MODE` | Enable test login (no OAuth required) | `false` |
+| `ADCP_MULTI_TENANT` | Enable multi-tenant mode (subdomain routing) | `false` |
+
+> **Session Cookies**: In single-tenant mode (default), session cookies use the actual request domain, allowing the sales agent to work with any custom domain. In multi-tenant mode, cookies are scoped to a base domain to work across tenant subdomains. See [Multi-Tenant Setup](multi-tenant.md) for details.
 
 ## Docker Compose Deployment
 

--- a/src/admin/app.py
+++ b/src/admin/app.py
@@ -37,6 +37,7 @@ from src.admin.blueprints.signals_agents import signals_agents_bp
 from src.admin.blueprints.tenants import tenants_bp
 from src.admin.blueprints.users import users_bp
 from src.admin.blueprints.workflows import workflows_bp
+from src.core.config_loader import is_single_tenant_mode
 from src.core.domain_config import (
     get_session_cookie_domain,
     get_tenant_url,
@@ -119,7 +120,10 @@ def create_app(config=None):
         app.config["SESSION_COOKIE_HTTPONLY"] = False  # Allow EventSource to access cookies
         app.config["SESSION_COOKIE_SAMESITE"] = "None"  # Required for EventSource cross-origin requests
         app.config["SESSION_COOKIE_PATH"] = "/admin/"  # Ensure cookies work for all /admin/* paths
-        app.config["SESSION_COOKIE_DOMAIN"] = get_session_cookie_domain()  # Allow cookies across subdomains for OAuth
+        # Only set cookie domain in multi-tenant mode for subdomain sharing
+        # In single-tenant mode, let Flask use the actual request domain
+        if not is_single_tenant_mode():
+            app.config["SESSION_COOKIE_DOMAIN"] = get_session_cookie_domain()  # Allow cookies across subdomains for OAuth
     else:
         app.config["SESSION_COOKIE_SECURE"] = False  # Allow HTTP in dev
         app.config["SESSION_COOKIE_HTTPONLY"] = True  # Standard setting for dev


### PR DESCRIPTION
## Problem
Login fails in single-tenant deployments (Fly.io, Cloud Run, Docker) because session cookies are rejected due to domain mismatch.

## Root Cause
`src/admin/app.py:122` always sets `SESSION_COOKIE_DOMAIN` to a hardcoded multi-tenant domain (`.sales-agent.scope3.com`), even when `ADCP_MULTI_TENANT=false`.

In single-tenant mode, Flask should use the actual request domain for session cookies instead of a hardcoded domain.

## Fix
- Only set `SESSION_COOKIE_DOMAIN` when `ADCP_MULTI_TENANT=true`
- In single-tenant mode (default), Flask automatically uses the request domain
- Add documentation explaining session cookie behavior in both modes

## Impact
- Fixes authentication for all single-tenant deployments
- No change to multi-tenant behavior
- Tested with Wonderstruck Fly.io deployment

## Testing
1. Deploy to Fly.io with `ADCP_MULTI_TENANT=false` (default)
2. Visit `/login` with `ADCP_AUTH_TEST_MODE=true`
3. Verify login succeeds and session persists
4. Verify cookie domain matches actual deployment domain

Related to #885 (nginx configuration issue for single-machine deployments)