### PR TITLE
chore: Restore Conductor workspace cleanup script

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
     "setup": "scripts/setup/setup_conductor_workspace.sh\ncp $CONDUCTOR_ROOT_PATH/.gam-test-config.json .",
-    "archive": "bash scripts/dev/cleanup_conductor_workspace.sh"
+    "archive": "bash scripts/setup/cleanup_conductor_workspace.sh"
   }
 }

--- a/scripts/setup/cleanup_conductor_workspace.sh
+++ b/scripts/setup/cleanup_conductor_workspace.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# cleanup_conductor_workspace.sh - Clean up resources when archiving a Conductor workspace
+
+echo "Cleaning up Conductor workspace: ${CONDUCTOR_WORKSPACE_NAME:-unknown}"
+
+# Stop any running containers and remove workspace-specific volumes
+if [ -f "docker-compose.yml" ]; then
+    echo "Stopping Docker containers..."
+    docker compose down --remove-orphans 2>/dev/null || true
+
+    # Clean up volumes prefixed with this workspace name
+    if [ -n "$CONDUCTOR_WORKSPACE_NAME" ]; then
+        echo "Removing workspace-specific volumes (${CONDUCTOR_WORKSPACE_NAME}_*)..."
+        docker volume ls -q | grep "^${CONDUCTOR_WORKSPACE_NAME}_" | xargs -r docker volume rm 2>/dev/null || true
+    fi
+fi
+
+echo "Cleanup complete"


### PR DESCRIPTION
Restores `scripts/setup/cleanup_conductor_workspace.sh` to properly clean up workspace resources during Conductor archival. The script stops Docker containers and removes workspace-specific volumes. Simplifies the script to remove the unused port manager dependency since ports are now managed via `CONDUCTOR_PORT`.