### PR TITLE
feat: Display sales agent version in agent card

### DIFF
--- a/alembic/versions/a2a336ecb71d_merge_migration_heads.py
+++ b/alembic/versions/a2a336ecb71d_merge_migration_heads.py
@@ -1,0 +1,29 @@
+"""Merge migration heads
+
+Revision ID: a2a336ecb71d
+Revises: 46b1bf1c82c5, channel_to_channels
+Create Date: 2025-12-30 05:20:04.956199
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a2a336ecb71d"
+down_revision: Union[str, Sequence[str], None] = ("46b1bf1c82c5", "channel_to_channels")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass


### PR DESCRIPTION
## Summary
- Agent card now displays the actual sales agent version from pyproject.toml instead of hardcoded "1.0.0"
- Added `_get_sales_agent_version()` helper that tries importlib.metadata first (production) then falls back to reading pyproject.toml (development)
- Merged migration heads to resolve pre-existing database schema conflict

## Test plan
- All 1313 unit tests pass
- All 33 integration tests pass
- All 15 integration_v2 tests pass
- Agent card version correctly shows "0.4.1" (from pyproject.toml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)