### PR TITLE
docs: Clarify SUPER_ADMIN_EMAILS is optional with per-tenant OIDC

### DIFF
--- a/alembic/versions/30acc1daf358_merge_migration_heads.py
+++ b/alembic/versions/30acc1daf358_merge_migration_heads.py
@@ -1,0 +1,29 @@
+"""Merge migration heads
+
+Revision ID: 30acc1daf358
+Revises: a2a336ecb71d, add_auth_setup_mode
+Create Date: 2025-12-31 00:07:20.405890
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "30acc1daf358"
+down_revision: Union[str, Sequence[str], None] = ("a2a336ecb71d", "add_auth_setup_mode")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/docs/deployment/walkthroughs/gcp.md
+++ b/docs/deployment/walkthroughs/gcp.md
@@ -35,9 +35,9 @@ Or use the [Cloud SQL Console](https://console.cloud.google.com/sql/instances/cr
 
 Note the **Connection name** from the instance overview (e.g., `your-project:us-central1:adcp-sales-agent`).
 
-## Step 3: Deploy in Test Mode
+## Step 3: Deploy
 
-Deploy with test mode enabled to verify everything works before configuring OAuth.
+Deploy the application. Authentication is configured **per-tenant** via the Admin UI after deployment.
 
 ### Option A: Use Prebuilt Image (Recommended)
 
@@ -54,15 +54,12 @@ gcloud run deploy adcp-sales-agent \
   --no-cpu-throttling \
   --min-instances=1 \
   --add-cloudsql-instances YOUR_PROJECT:us-central1:adcp-sales-agent \
-  --set-env-vars "ADCP_AUTH_TEST_MODE=true" \
-  --set-env-vars "SUPER_ADMIN_EMAILS=your-email@example.com" \
   --set-env-vars "DATABASE_URL=postgresql://postgres:YOUR_PASSWORD@/salesagent?host=/cloudsql/YOUR_PROJECT:us-central1:adcp-sales-agent"
 ```
 
 Replace:
 - `YOUR_PROJECT`: Your GCP project ID
 - `YOUR_PASSWORD`: The password you set when creating the Cloud SQL instance
-- `your-email@example.com`: Your email address for super admin access
 
 ### Option B: Build Your Own Image
 
@@ -83,8 +80,6 @@ gcloud run deploy adcp-sales-agent \
   --no-cpu-throttling \
   --min-instances=1 \
   --add-cloudsql-instances YOUR_PROJECT:us-central1:adcp-sales-agent \
-  --set-env-vars "ADCP_AUTH_TEST_MODE=true" \
-  --set-env-vars "SUPER_ADMIN_EMAILS=your-email@example.com" \
   --set-env-vars "DATABASE_URL=postgresql://postgres:YOUR_PASSWORD@/salesagent?host=/cloudsql/YOUR_PROJECT:us-central1:adcp-sales-agent"
 ```
 
@@ -94,42 +89,45 @@ gcloud run deploy adcp-sales-agent \
 
 Note your service URL from the output (e.g., `https://adcp-sales-agent-abc123-uc.a.run.app`).
 
-## Step 4: Verify Deployment
+## Step 4: Initial Setup
 
 1. Open `https://YOUR-SERVICE-URL.run.app/admin`
-2. Click the test login button (in test mode, no OAuth is required)
+2. Log in with test credentials (Setup Mode is enabled by default for new tenants):
+   - Email: `test_super_admin@example.com`
+   - Password: `test123`
 3. Verify you can access the Admin UI
 
-## Step 5: Configure OAuth (Production)
+## Step 5: Configure SSO (Production)
 
-Once verified, add OAuth for production use.
+Configure SSO via the Admin UI for production use.
 
-### Option A: Google OAuth
+1. Go to **Users & Access** in the Admin UI
+2. Configure your SSO provider (Google, Microsoft, Okta, Auth0, Keycloak, or any OIDC provider)
+3. Add redirect URI to your provider: `https://YOUR-SERVICE-URL.run.app/auth/oidc/callback`
+4. Test your SSO login
+5. Disable Setup Mode once SSO is working
 
-1. Go to [Google Cloud Console - OAuth credentials](https://console.cloud.google.com/apis/credentials)
-2. Click **Create Credentials** > **OAuth client ID**
-3. Select **Web application**
-4. Add redirect URI: `https://YOUR-SERVICE-URL.run.app/auth/google/callback`
+See [SSO Setup Guide](../../user-guide/sso-setup.md) for detailed provider-specific instructions.
 
-Update your deployment:
+### Legacy: Environment Variable OAuth (Optional)
 
+For backward compatibility, you can also configure OAuth via environment variables:
+
+**Google OAuth:**
 ```bash
 gcloud run services update adcp-sales-agent \
   --region us-central1 \
   --update-env-vars "GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com" \
-  --update-env-vars "GOOGLE_CLIENT_SECRET=your-client-secret" \
-  --remove-env-vars "ADCP_AUTH_TEST_MODE"
+  --update-env-vars "GOOGLE_CLIENT_SECRET=your-client-secret"
 ```
 
-### Option B: Other OIDC Providers (Okta, Auth0, Azure AD)
-
+**Other OIDC Providers (Okta, Auth0, Azure AD):**
 ```bash
 gcloud run services update adcp-sales-agent \
   --region us-central1 \
   --update-env-vars "OAUTH_CLIENT_ID=your-client-id" \
   --update-env-vars "OAUTH_CLIENT_SECRET=your-client-secret" \
-  --update-env-vars "OAUTH_DISCOVERY_URL=https://your-provider/.well-known/openid-configuration" \
-  --remove-env-vars "ADCP_AUTH_TEST_MODE"
+  --update-env-vars "OAUTH_DISCOVERY_URL=https://your-provider/.well-known/openid-configuration"
 ```
 
 ## Step 6: Custom Domain (Optional)
@@ -148,11 +146,12 @@ If using a custom domain, add it as an additional redirect URI in your OAuth cre
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `DATABASE_URL` | Yes | Cloud SQL connection string |
-| `SUPER_ADMIN_EMAILS` | Yes | Comma-separated admin emails |
 | `GEMINI_API_KEY` | No | Platform-level AI key (tenants can configure their own) |
-| `GOOGLE_CLIENT_ID` | Prod | Google OAuth client ID |
-| `GOOGLE_CLIENT_SECRET` | Prod | Google OAuth client secret |
-| `ADCP_AUTH_TEST_MODE` | No | Set `true` for initial testing |
+| `SUPER_ADMIN_EMAILS` | No | Legacy: Comma-separated admin emails (use per-tenant SSO instead) |
+| `GOOGLE_CLIENT_ID` | No | Legacy: Google OAuth client ID (use per-tenant SSO instead) |
+| `GOOGLE_CLIENT_SECRET` | No | Legacy: Google OAuth client secret |
+
+Authentication is configured **per-tenant** via the Admin UI. See [SSO Setup Guide](../../user-guide/sso-setup.md).
 
 ## Troubleshooting
 

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -26,11 +26,10 @@ The Admin UI (accessible at `/admin`) provides:
 
 | Role | Access |
 |------|--------|
-| **Super Admin** | Full system access, manage all tenants |
-| **Tenant Admin** | Manage products, advertisers, and campaigns for one tenant |
+| **Tenant Admin** | Full access to manage products, advertisers, campaigns, and users for one tenant |
 | **Tenant User** | Read-only access to view products and campaigns |
 
-Super admins are configured via the `SUPER_ADMIN_EMAILS` environment variable.
+Users and access levels are managed **per-tenant** via the **Users & Access** page in the Admin UI. See [SSO Setup](sso-setup.md) for configuring authentication.
 
 ## Guides
 

--- a/scripts/deploy/run_all_services.py
+++ b/scripts/deploy/run_all_services.py
@@ -27,9 +27,8 @@ def validate_required_env():
 
     missing = []
 
-    # Super admin access - at least one must be set
-    if not os.environ.get("SUPER_ADMIN_EMAILS") and not os.environ.get("SUPER_ADMIN_DOMAINS"):
-        missing.append("SUPER_ADMIN_EMAILS or SUPER_ADMIN_DOMAINS")
+    # Note: SUPER_ADMIN_EMAILS is optional - per-tenant OIDC with Setup Mode is the default auth flow.
+    # New tenants start with auth_setup_mode=true, allowing test credentials to configure SSO.
 
     # Database URL is required
     if not os.environ.get("DATABASE_URL"):
@@ -46,10 +45,6 @@ def validate_required_env():
             print(f"   - {var}")
         print("")
         print("📖 See docs/deployment.md for configuration details.")
-        print("")
-        print("Quick fix for Fly.io:")
-        print('  fly secrets set SUPER_ADMIN_EMAILS="your-email@example.com"')
-        print("")
         sys.exit(1)
 
     print("✅ Required environment variables are set")

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -137,10 +137,8 @@ def validate_configuration() -> None:
             # Configuration validation happens automatically via Pydantic
             pass
 
-        # Validate critical configuration (SUPER_ADMIN_EMAILS required)
         # Note: GEMINI_API_KEY is optional - tenants configure their own AI keys
-        if not config.superadmin.emails:
-            raise ValueError("Missing required environment variable: SUPER_ADMIN_EMAILS")
+        # Note: SUPER_ADMIN_EMAILS is optional - per-tenant OIDC with Setup Mode is the default auth flow
 
         print("✅ Configuration validation passed")
         print(f"   GAM OAuth: {'✅ Configured' if config.gam_oauth.client_id else '❌ Not configured'}")
@@ -148,7 +146,9 @@ def validate_configuration() -> None:
         print(
             f"   Gemini API: {'✅ Configured' if config.gemini_api_key else '⚪ Not configured (tenants use own keys)'}"
         )
-        print(f"   Super Admin: {'✅ Configured' if config.superadmin.emails else '❌ Not configured'}")
+        print(
+            f"   Super Admin: {'✅ Configured' if config.superadmin.emails else '⚪ Not configured (use per-tenant OIDC)'}"
+        )
 
     except Exception as e:
         raise RuntimeError(f"Configuration validation failed: {str(e)}") from e

--- a/src/core/startup.py
+++ b/src/core/startup.py
@@ -44,23 +44,15 @@ def validate_startup_requirements() -> None:
     This is useful for health checks and lightweight validation.
     """
     try:
-        import os
-
         from src.core.config import get_config
 
         # Just check that config can be loaded
-        config = get_config()
+        get_config()
 
-        # In test mode, super admin validation is skipped (test accounts are used)
-        test_mode = os.environ.get("ADCP_AUTH_TEST_MODE", "").lower() == "true"
-        if not test_mode:
-            # Super admin access - at least one must be set
-            super_admin_emails = os.environ.get("SUPER_ADMIN_EMAILS", "")
-            super_admin_domains = os.environ.get("SUPER_ADMIN_DOMAINS", "")
-            if not super_admin_emails and not super_admin_domains:
-                raise ValueError(
-                    "SUPER_ADMIN_EMAILS or SUPER_ADMIN_DOMAINS is required. " "Set at least one to grant admin access."
-                )
+        # Note: SUPER_ADMIN_EMAILS is no longer required at startup.
+        # Per-tenant OIDC with Setup Mode is the default authentication flow.
+        # New tenants start with auth_setup_mode=true, allowing test credentials
+        # to log in and configure SSO via the Admin UI.
 
         logger.info("Startup requirements validation passed")
 


### PR DESCRIPTION
## Summary

For single-tenant deployments, SUPER_ADMIN_EMAILS is no longer required at startup. Per-tenant OIDC with Setup Mode is the default authentication flow. New tenants start with `auth_setup_mode=true`, allowing test credentials to log in and configure SSO via the Admin UI.

## Changes

- Remove SUPER_ADMIN_EMAILS validation from startup code (config.py, startup.py, run_all_services.py)
- Update deployment walkthroughs (Fly.io, GCP) to show per-tenant SSO as the primary flow
- Mark SUPER_ADMIN_EMAILS as legacy/optional in documentation
- Update user guide to reflect per-tenant user management

## Testing

All unit, integration, and integration_v2 tests pass.