### PR TITLE
fix: Use pull_request_target for PR title check on fork PRs

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,7 +1,7 @@
 name: PR Title Check
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
 jobs:


### PR DESCRIPTION
## Summary
- Fixes PR title check failing with "Resource not accessible by integration" for PRs from forks

## Problem
The `pull_request` trigger has limited permissions for fork PRs, causing the semantic PR title check to fail even when the title is correctly formatted.

## Solution
Switch to `pull_request_target` which runs in the context of the base repo and has the necessary permissions.

**Security note**: This is safe because the action only reads PR metadata (title) and doesn't checkout or execute any code from the PR.

## Test plan
- [x] After merging, re-run the PR title check on #901 to verify it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)