### PR TITLE
fix: Restore deleted migration to fix Fly.io deploy

### DIFF
--- a/alembic/versions/30acc1daf358_merge_migration_heads.py
+++ b/alembic/versions/30acc1daf358_merge_migration_heads.py
@@ -1,0 +1,29 @@
+"""Merge migration heads
+
+Revision ID: 30acc1daf358
+Revises: a2a336ecb71d, add_auth_setup_mode
+Create Date: 2025-12-31 00:07:20.405890
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "30acc1daf358"
+down_revision: Union[str, Sequence[str], None] = ("a2a336ecb71d", "add_auth_setup_mode")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/alembic/versions/g1h2i3j4k5l6_merge_orphan_branch.py
+++ b/alembic/versions/g1h2i3j4k5l6_merge_orphan_branch.py
@@ -1,0 +1,34 @@
+"""Merge orphan branch into main
+
+Revision ID: g1h2i3j4k5l6
+Revises: f3bac4654620, 30acc1daf358
+Create Date: 2026-01-01 21:30:00.000000
+
+This migration merges the orphan branch (30acc1daf358) back into main.
+
+The migration 30acc1daf358 was accidentally deleted from the codebase but
+had already been applied to the production database. This merge migration
+brings both branches back together into a single head.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "g1h2i3j4k5l6"
+down_revision: Union[str, Sequence[str], None] = ("f3bac4654620", "30acc1daf358")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass


### PR DESCRIPTION
## Summary
- Restores the deleted `30acc1daf358` migration file that was already applied to production
- Adds merge migration `g1h2i3j4k5l6` to rejoin the orphan branch with the mainline

## Context
The migration `30acc1daf358_merge_migration_heads.py` was deleted from the codebase in PR #911 but had already been applied to the Fly.io production database. This caused alembic to fail during deploy with:

```
Can't locate revision identified by '30acc1daf358'
```

## Test plan
- [x] Unit tests pass (1329 passed)
- [x] Integration tests pass
- [x] `alembic heads` shows single head (`g1h2i3j4k5l6`)
- [ ] Deploy to Fly.io and verify migrations run successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)