### PR TITLE
fix: Clear session before OAuth to prevent stale cookie conflicts

### DIFF
--- a/src/admin/blueprints/auth.py
+++ b/src/admin/blueprints/auth.py
@@ -441,11 +441,21 @@ def google_auth():
 
     logger.warning(f"========== FINAL OAuth redirect URI: {redirect_uri} ==========")
 
+    # Clear any existing session to start fresh for OAuth
+    # This ensures we don't have conflicting session state
+    session.clear()
+
     # Simple OAuth flow - no tenant context preservation needed
     response = oauth.google.authorize_redirect(redirect_uri)
 
     # Log what's in the session after Authlib stores the state
     logger.warning(f"Session keys after authorize_redirect: {list(session.keys())}")
+
+    # CRITICAL: Mark the session as modified to ensure Flask saves it
+    # Authlib stores OAuth state in session, but the redirect response may not
+    # trigger Flask's session save mechanism automatically
+    session.modified = True
+
     # Log the Set-Cookie header that will be sent
     set_cookie_header = response.headers.get("Set-Cookie", "")
     logger.warning(f"Set-Cookie header (first 200 chars): {set_cookie_header[:200] if set_cookie_header else 'NONE'}")


### PR DESCRIPTION
## Summary
- Clear session before OAuth to prevent stale cookie conflicts
- Add `session.modified = True` to ensure Flask saves the updated session
- Root cause: Browser was sending old stale session cookie that didn't contain OAuth state

## Root Cause Analysis
From production logs (PR #923 debug logging):

1. **OAuth initiation:**
   - `Session keys after authorize_redirect: ['_state_google_YKWa7...']` - State IS stored correctly
   - But Set-Cookie wasn't being sent because Flask thought session was unchanged

2. **OAuth callback:**
   - `Session keys at start: []` - Session is EMPTY
   - `Incoming cookies: ['session', ...]` - Cookie IS present
   - `Raw session cookie: .eJx1jElr...` - This is OLD stale cookie

The browser had a stale session cookie from before OAuth started. When OAuth stored the state in session, Flask wasn't sending a new Set-Cookie header because the session wasn't marked as modified. The browser continued using the old cookie which didn't have the OAuth state.

## Fix
1. `session.clear()` - Clear any existing session before OAuth starts
2. `session.modified = True` - Force Flask to save the session even if it thinks nothing changed

This ensures the browser gets a fresh session cookie with the OAuth state.

## Test plan
- [x] Unit tests pass
- [x] Integration tests pass
- [ ] Manual test: OAuth flow at https://sales-agent.scope3.com/admin/login should complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)