### PR TITLE
chore: Add more debug logging to trace session loss after OAuth

### DIFF
--- a/src/admin/blueprints/core.py
+++ b/src/admin/blueprints/core.py
@@ -290,6 +290,11 @@ def admin_index():
     """Admin UI entry point - requires authentication."""
     from src.core.config_loader import is_single_tenant_mode
 
+    logger.warning("========== ADMIN_INDEX HIT ==========")
+    logger.warning(f"Session keys: {list(session.keys())}")
+    logger.warning(f"'user' in session: {'user' in session}")
+    logger.warning(f"Incoming cookies: {list(request.cookies.keys())}")
+
     # Single-tenant mode: always redirect to default tenant dashboard
     # (the @require_tenant_access decorator handles auth redirect)
     if is_single_tenant_mode():


### PR DESCRIPTION
Adding debug logging to admin_index and OAuth callback to trace session loss in redirect loop.