### PR TITLE
feat: Make SSO optional for multi-tenant deployments

### DIFF
--- a/docs/deployment/environment-variables.md
+++ b/docs/deployment/environment-variables.md
@@ -140,6 +140,13 @@ For GAM adapter integration:
 | `SALES_AGENT_DOMAIN` | - | Base domain for tenant subdomains (e.g., `sales-agent.example.com`) |
 | `BASE_DOMAIN` | - | Top-level domain for cookies (e.g., `example.com`) |
 
+### SSO Requirements by Deployment Mode
+
+The SSO requirement varies based on deployment mode:
+
+- **Single-tenant mode** (default): SSO is **critical** - required before accepting orders. Each deployment needs its own authentication.
+- **Multi-tenant mode** (`ADCP_MULTI_TENANT=true`): SSO is **optional** per-tenant. The platform manages authentication centrally, so individual tenants can skip SSO configuration.
+
 ---
 
 ## Environment & Deployment

--- a/docs/deployment/multi-tenant.md
+++ b/docs/deployment/multi-tenant.md
@@ -155,6 +155,8 @@ Before a tenant can create media buys, they need:
 3. **Products**: At least one product configured (Products page)
 4. **Advertisers**: At least one advertiser/principal (Advertisers page)
 
+**Note:** In multi-tenant mode, SSO is **optional** per-tenant. The platform manages authentication centrally, so individual tenants can skip SSO configuration. In single-tenant mode, SSO is required before accepting orders.
+
 The Admin UI shows a setup checklist for each tenant.
 
 ## Subdomain Routing


### PR DESCRIPTION
## Summary
- Makes SSO configuration optional for tenants in multi-tenant mode (`ADCP_MULTI_TENANT=true`)
- SSO remains critical and required in single-tenant mode (default behavior)
- Platform manages authentication centrally in multi-tenant mode, so individual tenants can skip SSO configuration

## Changes
- Add `_is_multi_tenant_mode()` helper function to check deployment mode
- Conditionally place SSO in critical vs optional task lists based on mode
- Update both single-query and bulk-query patterns in setup checklist service
- Update unit and integration tests with explicit mode testing
- Update deployment documentation

## Test plan
- [x] Unit tests pass (6 tests for setup checklist mock adapter)
- [x] Full unit test suite passes (1355 tests)
- [x] Integration tests pass
- [ ] CI tests pass
- [ ] Manual verification: single-tenant mode shows SSO as critical
- [ ] Manual verification: multi-tenant mode shows SSO as optional

🤖 Generated with [Claude Code](https://claude.com/claude-code)