### PR TITLE
fix: Run database migrations automatically on docker compose up

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -223,6 +223,54 @@ jobs:
         ADCP_TESTING: true
       run: uv run pytest tests/integration_v2/ -v --tb=short --cov=. --cov-report=term-missing -m "not skip_ci"
 
+  quickstart-test:
+    name: Quickstart Docker Compose Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Test the actual quickstart flow users follow
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Start services with docker compose
+      run: |
+        docker compose up -d --wait --wait-timeout 120
+        echo "Services started, checking logs..."
+
+    - name: Check db-init completed successfully
+      run: |
+        # Verify migrations ran
+        docker compose logs db-init | grep -E "(migrations completed|Migration complete)" || {
+          echo "❌ Migrations did not complete successfully"
+          docker compose logs db-init
+          exit 1
+        }
+        echo "✅ Database migrations completed"
+
+    - name: Verify all services are healthy
+      run: |
+        # Check health endpoints
+        curl -f http://localhost:8000/health || {
+          echo "❌ Health check failed"
+          docker compose logs
+          exit 1
+        }
+        echo "✅ Services are healthy"
+
+    - name: Verify database tables exist
+      run: |
+        # Connect to postgres and check tables
+        docker compose exec -T postgres psql -U adcp_user -d adcp -c "\dt" | grep -E "media_buys|tenants|products" || {
+          echo "❌ Required tables not found"
+          docker compose exec -T postgres psql -U adcp_user -d adcp -c "\dt"
+          exit 1
+        }
+        echo "✅ Database tables created successfully"
+
+    - name: Cleanup
+      if: always()
+      run: docker compose down -v
+
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
@@ -335,15 +383,15 @@ jobs:
   test-summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [smoke-tests, unit-tests, integration-tests, integration-tests-v2, e2e-tests, lint]
+    needs: [smoke-tests, unit-tests, integration-tests, integration-tests-v2, quickstart-test, e2e-tests, lint]
     if: always()
 
     steps:
     - name: Check test results
       run: |
-        if [ "${{ needs.unit-tests.result }}" = "failure" ] || [ "${{ needs.integration-tests.result }}" = "failure" ] || [ "${{ needs.integration-tests-v2.result }}" = "failure" ] || [ "${{ needs.e2e-tests.result }}" = "failure" ] || [ "${{ needs.lint.result }}" = "failure" ]; then
+        if [ "${{ needs.unit-tests.result }}" = "failure" ] || [ "${{ needs.integration-tests.result }}" = "failure" ] || [ "${{ needs.integration-tests-v2.result }}" = "failure" ] || [ "${{ needs.quickstart-test.result }}" = "failure" ] || [ "${{ needs.e2e-tests.result }}" = "failure" ] || [ "${{ needs.lint.result }}" = "failure" ]; then
           echo "❌ Tests failed"
           exit 1
         else
-          echo "✅ All tests passed (smoke, unit, integration, integration-v2, e2e, lint+mypy)"
+          echo "✅ All tests passed (smoke, unit, integration, integration-v2, quickstart, e2e, lint+mypy)"
         fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,26 @@ services:
       timeout: 5s
       retries: 5
 
+  # Run database migrations before starting services
+  db-init:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    entrypoint: []
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      DATABASE_URL: postgresql://adcp_user:secure_password_change_me@postgres:5432/adcp?sslmode=disable
+      PYTHONPATH: "/app"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - .:/app
+      - /app/.venv
+    command: ["python", "scripts/ops/migrate.py"]
+
   proxy:
     image: nginx:stable
     volumes:
@@ -73,6 +93,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      db-init:
+        condition: service_completed_successfully
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
@@ -110,6 +132,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      db-init:
+        condition: service_completed_successfully
     volumes:
       # Mount source code for hot reloading
       - .:/app

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -134,7 +134,7 @@ docker compose build && docker compose up -d
 
 ### "No tenant context" error
 - Ensure you're using the test login credentials
-- Check that migrations ran: `docker compose logs adcp-server | grep migration`
+- Check that migrations ran: `docker compose logs db-init`
 
 ### Port 8000 already in use
 ```bash


### PR DESCRIPTION
## Summary
- Fixes fresh Linux install failing with "relation 'media_buys' does not exist"
- Adds `db-init` service to run migrations before other services start
- Adds CI job to test the quickstart flow end-to-end

## Problem
When running `docker compose up` on a fresh install (Ubuntu/CentOS), the application was failing because the development docker-compose.yml overrides the entrypoint, bypassing the automatic migration step.

## Solution
Added a `db-init` service that:
1. Waits for PostgreSQL to be healthy
2. Runs migrations
3. Exits after completion

Both `adcp-server` and `admin-ui` now depend on `db-init` completing successfully.

## Test plan
- [ ] New CI job "Quickstart Docker Compose Test" passes
- [ ] Manual test: `docker compose down -v && docker compose up -d` on fresh system

🤖 Generated with [Claude Code](https://claude.com/claude-code)