### PR TITLE
fix: Include empty pricing_options in serialization for anonymous users

### DIFF
--- a/src/core/schemas.py
+++ b/src/core/schemas.py
@@ -1277,11 +1277,13 @@ class Product(LibraryProduct):
         adcp_data = {}
         for key, value in data.items():
             # Include core fields always, and non-null optional fields
-            # Exclude empty pricing_options (for anonymous users)
-            if key == "pricing_options" and value == []:
-                continue
+            # Note: pricing_options=[] is valid for anonymous users (no pricing shown)
+            # Per AdCP spec, pricing_options is required but can be empty array
             if key in core_fields or value is not None:
                 adcp_data[key] = value
+            # Include empty pricing_options explicitly (required per AdCP schema)
+            elif key == "pricing_options" and value == []:
+                adcp_data[key] = []
 
         return adcp_data
 


### PR DESCRIPTION
## Summary
Fixed bug where Product with `pricing_options=[]` was completely omitted from JSON serialization, causing client-side schema validation to fail with "expected array, received undefined". Per AdCP spec, pricing_options is required but can be empty array for anonymous users with hidden pricing information.

## Test Plan
- Added regression test: `test_product_with_empty_pricing_options_serializes_as_empty_array()`
- All 1366 unit tests pass
- All 33 integration tests pass
- All 8 integration_v2 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)