### PR TITLE
fix: ignore url not configured when use mock adapters

### DIFF
--- a/src/admin/blueprints/publisher_partners.py
+++ b/src/admin/blueprints/publisher_partners.py
@@ -195,15 +195,6 @@ def sync_publisher_partners(tenant_id: str) -> Response | tuple[Response, int]:
             if not tenant:
                 return jsonify({"error": "Tenant not found"}), 404
 
-            # Get our agent URL - use virtual_host if configured, otherwise construct from subdomain
-            if tenant.virtual_host:
-                agent_url: str = f"https://{tenant.virtual_host}"
-            else:
-                maybe_url = get_tenant_url(tenant.subdomain)
-                if not maybe_url:
-                    return jsonify({"error": "Agent URL not configured (SALES_AGENT_DOMAIN not set)"}), 500
-                agent_url = maybe_url
-
             # Get all publisher partners
             stmt_partners = select(PublisherPartner).filter_by(tenant_id=tenant_id)
             partners = session.scalars(stmt_partners).all()
@@ -332,6 +323,15 @@ def sync_publisher_partners(tenant_id: str) -> Response | tuple[Response, int]:
                         "tags_created": tags_created,
                     }
                 )
+
+            # Get our agent URL - use virtual_host if configured, otherwise construct from subdomain
+            if tenant.virtual_host:
+                agent_url: str = f"https://{tenant.virtual_host}"
+            else:
+                maybe_url = get_tenant_url(tenant.subdomain)
+                if not maybe_url:
+                    return jsonify({"error": "Agent URL not configured (SALES_AGENT_DOMAIN not set)"}), 500
+                agent_url = maybe_url
 
             # Fetch authorization for each publisher (real verification for non-mock tenants)
             logger.info(f"Fetching authorizations for {len(partners)} publishers")


### PR DESCRIPTION
- Moved agent URL retrieval after the auto-verification block 
- This allows the function to return early with auto-verified results for mock/dev environments
- Only production tenants with real adapters need the agent URL for actual adagents.json verification
- Prevents "Agent URL not configured" errors when using mock adapters in testing scenarios

