### PR TITLE
fix: Sync custom targeting keys to adapter_config during inventory sync

### DIFF
--- a/src/services/background_sync_service.py
+++ b/src/services/background_sync_service.py
@@ -339,6 +339,11 @@ def _run_sync_thread(
             discovery.custom_targeting_values.clear()  # Clear from memory
             logger.info(f"[{sync_id}] Wrote {targeting_count} targeting keys to database")
 
+            # Also update adapter_config.custom_targeting_keys for GAMTargetingManager
+            # This mapping is used by resolve_custom_targeting_key_id() during Media Buy approval
+            inventory_service._update_adapter_config_targeting_keys(tenant_id)
+            logger.info(f"[{sync_id}] Updated adapter_config targeting key mapping")
+
             # Phase 5: Audience Segments (fetch → write → clear memory)
             # NOTE: Audience segments ALWAYS use full sync because GAM API doesn't support
             # lastModifiedDateTime filtering (returns ParseError.UNPARSABLE).


### PR DESCRIPTION
## Problem
Erin had issue when approving a media buy for GAM , error message
```
Media buy approved but adapter creation failed: Adapter creation failed: AXE include key 'axei' not found in GAM. Create the custom targeting key in GAM UI and sync using 'Sync Custom Targeting Keys' button.
```
Event after the targeting key updated in the GAM IU, still showing the same error.

**The root cause is below:** 
When clicking 'Sync Targeting Data' in the Targeting Browser:
1. Keys are written to `gam_inventory` table (for UI display) ✅
2. But `adapter_config.custom_targeting_keys` column is NOT updated ❌
3. Media Buy approval calls `GAMTargetingManager.resolve_custom_targeting_key_id()` which reads from `adapter_config.custom_targeting_keys`
4. Result: "AXE include key 'axei' not found in GAM" error even though keys exist

## Solution

After writing custom targeting keys to `gam_inventory`, also update `adapter_config.custom_targeting_keys` with the key name → GAM ID mapping.

## Changes

- Added `_update_adapter_config_targeting_keys()` method to `gam_inventory_service.py`
- Called the method in `background_sync_service.py` after writing targeting keys to database

## Testing

- All existing unit tests pass
- Imports verified working
- Manual testing: Click 'Sync Targeting Data' → `adapter_config.custom_targeting_keys` should now be populated