### PR TITLE
fix: Construct FormatId from DB creative's agent_url and format columns

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "filelock>=3.20.3",  # GHSA-qmgc-5h2g-mvrw
     "urllib3>=2.6.3",  # GHSA-38jv-5279-wg99
     "werkzeug>=3.1.5",  # GHSA-87hc-h4r5-73f7
+    "jaraco-context>=6.1.0",  # GHSA-58pv-8j8x-9vj2
 ]
 
 

--- a/src/core/tools/media_buy_create.py
+++ b/src/core/tools/media_buy_create.py
@@ -2282,8 +2282,13 @@ async def _create_media_buy_impl(
                                         creative = creatives_map.get(creative_id)
                                         if creative:
                                             # Simple binary check: does creative's format_id match product?
+                                            # Construct FormatId from database creative's agent_url and format columns
+                                            # (DBCreative stores these as separate string columns, not a FormatId object)
+                                            creative_format_id = FormatId(
+                                                agent_url=creative.agent_url, id=creative.format
+                                            )
                                             format_is_valid, format_error = validate_creative_format_against_product(
-                                                creative_format_id=creative.format,
+                                                creative_format_id=creative_format_id,
                                                 product=product_for_format_validation,
                                             )
 
@@ -3029,8 +3034,13 @@ async def _create_media_buy_impl(
                                     creative = creatives_by_id.get(creative_id)
                                     if creative:
                                         # Simple binary check: does creative's format_id match product?
+                                        # Construct FormatId from database creative's agent_url and format columns
+                                        # (DBCreative stores these as separate string columns, not a FormatId object)
+                                        creative_format_id = FormatId(
+                                            agent_url=creative.agent_url, id=creative.format
+                                        )
                                         format_is_valid, format_error = validate_creative_format_against_product(
-                                            creative_format_id=creative.format,
+                                            creative_format_id=creative_format_id,
                                             product=product_format_check,
                                         )
 

--- a/tests/unit/test_creative_format_validation_bug.py
+++ b/tests/unit/test_creative_format_validation_bug.py
@@ -1,0 +1,172 @@
+"""Test for creative format validation bug fix.
+
+This test verifies the fix for the bug where validate_creative_format_against_product
+was called with creative.format (a string) instead of a FormatId object, causing:
+    AttributeError: 'str' object has no attribute 'agent_url'
+
+The database Creative model stores:
+- agent_url: str (e.g., "https://creative.adcontextprotocol.org/")
+- format: str (e.g., "display_970x250_image")
+
+But validate_creative_format_against_product expects a FormatId object with both
+agent_url and id attributes.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.core.helpers.creative_helpers import validate_creative_format_against_product
+from src.core.schemas import FormatId
+
+
+class TestCreativeFormatValidationBug:
+    """Tests for the creative format validation bug fix."""
+
+    def test_validate_with_string_format_raises_attribute_error(self):
+        """Reproduce the bug: passing a string instead of FormatId raises AttributeError.
+
+        This test demonstrates the bug before the fix.
+        The code was passing creative.format (a string like "display_970x250_image")
+        instead of a FormatId object.
+        """
+        # Simulate what the database returns: format as a plain string
+        creative_format_string = "display_970x250_image"
+
+        # Create a mock product with format_ids
+        mock_product = MagicMock()
+        mock_product.format_ids = [
+            FormatId(agent_url="https://creative.adcontextprotocol.org/", id="display_970x250_image")
+        ]
+        mock_product.product_id = "test_product_1"
+        mock_product.name = "Test Product"
+
+        # This should raise AttributeError because string has no .agent_url
+        with pytest.raises(AttributeError, match="'str' object has no attribute 'agent_url'"):
+            validate_creative_format_against_product(
+                creative_format_id=creative_format_string,  # Bug: passing string instead of FormatId
+                product=mock_product,
+            )
+
+    def test_validate_with_format_id_object_works(self):
+        """Verify the fix: passing a proper FormatId object works correctly.
+
+        This test demonstrates the correct behavior after the fix.
+        The code should construct a FormatId from creative.agent_url and creative.format.
+        """
+        # Simulate what the database returns
+        creative_agent_url = "https://creative.adcontextprotocol.org/"
+        creative_format = "display_970x250_image"
+
+        # Construct FormatId from database fields (this is the fix)
+        creative_format_id = FormatId(agent_url=creative_agent_url, id=creative_format)
+
+        # Create a mock product with matching format_ids
+        mock_product = MagicMock()
+        mock_product.format_ids = [
+            FormatId(agent_url="https://creative.adcontextprotocol.org/", id="display_970x250_image")
+        ]
+        mock_product.product_id = "test_product_1"
+        mock_product.name = "Test Product"
+
+        # This should work and return valid=True
+        is_valid, error = validate_creative_format_against_product(
+            creative_format_id=creative_format_id,
+            product=mock_product,
+        )
+
+        assert is_valid is True
+        assert error is None
+
+    def test_validate_with_format_id_object_mismatch(self):
+        """Verify validation correctly detects format mismatch."""
+        # Creative has a different format than product supports
+        creative_format_id = FormatId(
+            agent_url="https://creative.adcontextprotocol.org/", id="video_300x250"  # Different format
+        )
+
+        # Product only supports display format
+        mock_product = MagicMock()
+        mock_product.format_ids = [
+            FormatId(agent_url="https://creative.adcontextprotocol.org/", id="display_970x250_image")
+        ]
+        mock_product.product_id = "test_product_1"
+        mock_product.name = "Test Product"
+
+        # Should return invalid with error message
+        is_valid, error = validate_creative_format_against_product(
+            creative_format_id=creative_format_id,
+            product=mock_product,
+        )
+
+        assert is_valid is False
+        assert error is not None
+        assert "video_300x250" in error
+        assert "display_970x250_image" in error
+
+    def test_validate_with_different_agent_url_mismatch(self):
+        """Verify validation correctly detects agent_url mismatch."""
+        # Creative from different agent
+        creative_format_id = FormatId(
+            agent_url="https://other-agent.example.com/",  # Different agent
+            id="display_970x250_image",
+        )
+
+        # Product expects format from different agent
+        mock_product = MagicMock()
+        mock_product.format_ids = [
+            FormatId(agent_url="https://creative.adcontextprotocol.org/", id="display_970x250_image")
+        ]
+        mock_product.product_id = "test_product_1"
+        mock_product.name = "Test Product"
+
+        # Should return invalid because agent_url doesn't match
+        is_valid, error = validate_creative_format_against_product(
+            creative_format_id=creative_format_id,
+            product=mock_product,
+        )
+
+        assert is_valid is False
+        assert error is not None
+
+    def test_validate_with_empty_product_format_ids_accepts_all(self):
+        """Verify products with no format restrictions accept all creatives."""
+        creative_format_id = FormatId(
+            agent_url="https://creative.adcontextprotocol.org/", id="any_format"
+        )
+
+        # Product with no format restrictions
+        mock_product = MagicMock()
+        mock_product.format_ids = []  # No restrictions
+        mock_product.product_id = "test_product_1"
+        mock_product.name = "Test Product"
+
+        # Should accept any creative
+        is_valid, error = validate_creative_format_against_product(
+            creative_format_id=creative_format_id,
+            product=mock_product,
+        )
+
+        assert is_valid is True
+        assert error is None
+
+    def test_validate_with_none_product_format_ids_accepts_all(self):
+        """Verify products with None format_ids accept all creatives."""
+        creative_format_id = FormatId(
+            agent_url="https://creative.adcontextprotocol.org/", id="any_format"
+        )
+
+        # Product with None format_ids
+        mock_product = MagicMock()
+        mock_product.format_ids = None  # No restrictions
+        mock_product.product_id = "test_product_1"
+        mock_product.name = "Test Product"
+
+        # Should accept any creative
+        is_valid, error = validate_creative_format_against_product(
+            creative_format_id=creative_format_id,
+            product=mock_product,
+        )
+
+        assert is_valid is True
+        assert error is None

--- a/uv.lock
+++ b/uv.lock
@@ -79,7 +79,7 @@ wheels = [
 
 [[package]]
 name = "adcp-sales-agent"
-version = "0.7.0"
+version = "0.9.0"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-cli" },
@@ -103,6 +103,7 @@ dependencies = [
     { name = "google-generativeai" },
     { name = "googleads" },
     { name = "httpx" },
+    { name = "jaraco-context" },
     { name = "jinja2" },
     { name = "logfire" },
     { name = "markdown" },
@@ -191,6 +192,7 @@ requires-dist = [
     { name = "google-generativeai", specifier = ">=0.5.4" },
     { name = "googleads", specifier = "==46.0.0" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "jaraco-context", specifier = ">=6.1.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "jsonref", marker = "extra == 'dev'", specifier = ">=1.1.0" },
     { name = "logfire", specifier = ">=4.16.0" },
@@ -1884,11 +1886,11 @@ wheels = [
 
 [[package]]
 name = "jaraco-context"
-version = "6.0.2"
+version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8d/7d/41acf8e22d791bde812cb6c2c36128bb932ed8ae066bcb5e39cb198e8253/jaraco_context-6.0.2.tar.gz", hash = "sha256:953ae8dddb57b1d791bf72ea1009b32088840a7dd19b9ba16443f62be919ee57", size = 14994, upload-time = "2025-12-24T19:21:35.784Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/9c/a788f5bb29c61e456b8ee52ce76dbdd32fd72cd73dd67bc95f42c7a8d13c/jaraco_context-6.1.0.tar.gz", hash = "sha256:129a341b0a85a7db7879e22acd66902fda67882db771754574338898b2d5d86f", size = 15850, upload-time = "2026-01-13T02:53:53.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/0c/1e0096ced9c55f9c6c6655446798df74165780375d3f5ab5f33751e087ae/jaraco_context-6.0.2-py3-none-any.whl", hash = "sha256:55fc21af4b4f9ca94aa643b6ee7fe13b1e4c01abf3aeb98ca4ad9c80b741c786", size = 6988, upload-time = "2025-12-24T19:21:34.557Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/48/aa685dbf1024c7bd82bede569e3a85f82c32fd3d79ba5fea578f0159571a/jaraco_context-6.1.0-py3-none-any.whl", hash = "sha256:a43b5ed85815223d0d3cfdb6d7ca0d2bc8946f28f30b6f3216bda070f68badda", size = 7065, upload-time = "2026-01-13T02:53:53.031Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes the `AttributeError: 'str' object has no attribute 'agent_url'` error during `create_media_buy` when creatives are assigned to packages.

## Root Cause

The `validate_creative_format_against_product()` function in `creative_helpers.py` expects a `FormatId` object with `agent_url` and `id` attributes. However, the code in `media_buy_create.py` was passing `creative.format` (a plain string) from the database model instead of constructing a proper `FormatId` object.

**Database Creative model** stores format info as two separate columns:
- `agent_url`: str (e.g., `'https://creative.adcontextprotocol.org/'`)
- `format`: str (e.g., `'display_970x250_image'`)

**Bug locations** (both were passing `creative.format` string instead of `FormatId` object):
- Line ~2286 (pending approval flow)
- Line ~3033 (auto-approval flow)

## Fix

Construct a `FormatId` object from the database creative's `agent_url` and `format` columns before calling the validation function:

```python
creative_format_id = FormatId(agent_url=creative.agent_url, id=creative.format)
format_is_valid, format_error = validate_creative_format_against_product(
    creative_format_id=creative_format_id,
    product=product_for_format_validation,
)
```

## Testing

- Added unit tests that reproduce the bug and verify the fix
- All 1411 unit tests pass (excluding pre-existing flaky webhook tests)

## Verification Query

The bug was confirmed by checking the database schema:
```sql
SELECT creative_id, agent_url, format, LENGTH(format) as format_length
FROM creatives WHERE creative_id = '970x250displaycreati_bgp8jjos';
```

Result showed `format` is a plain string (`display_970x250_image`, 21 chars), not a JSON object with `agent_url`.
<img width="1210" height="545" alt="image" src="https://github.com/user-attachments/assets/c8af755f-2088-41be-87da-07b11e08db6e" />
