### PR TITLE
fix: Use PAT for release-please to trigger downstream workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,6 +21,9 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
+          # Use PAT instead of GITHUB_TOKEN so commits trigger downstream workflows (e.g., Test Suite)
+          # Without this, GitHub's security policy blocks workflow triggers from github-actions[bot] commits
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 

--- a/uv.lock
+++ b/uv.lock
@@ -79,7 +79,7 @@ wheels = [
 
 [[package]]
 name = "adcp-sales-agent"
-version = "0.9.0"
+version = "0.9.1"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-cli" },


### PR DESCRIPTION
## Summary
- Configures release-please to use a PAT (`RELEASE_PLEASE_TOKEN`) instead of `GITHUB_TOKEN`
- Syncs `uv.lock` to match `pyproject.toml` version 0.9.1

## Problem
PR #962 (release 0.9.2) is stuck because the Test Suite workflow never ran. When release-please uses `GITHUB_TOKEN`, commits are made by `github-actions[bot]`. GitHub's security policy prevents workflows from being triggered by these commits to avoid infinite loops.

## Solution
Using a PAT allows the commits to be attributed to a real user, which allows downstream workflows (Test Suite) to trigger automatically on release-please PRs.

## Required Action
After merging, add a repository or organization secret:

| Secret Name | Value | Scope |
|-------------|-------|-------|
| `RELEASE_PLEASE_TOKEN` | Personal Access Token | `repo` scope |

To create the PAT:
1. Go to GitHub Settings → Developer settings → Personal access tokens → Tokens (classic)
2. Generate new token with `repo` scope
3. Add as repository secret: Settings → Secrets and variables → Actions → New repository secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)