### PR TITLE
fix: Add v2.x backward compatibility for pricing_options and clean up production logs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 
 dependencies = [
-    "adcp>=3.0.0",
+    "adcp>=3.1.0",
     "fastmcp>=2.14.0", # Minimum for MCP 2025-11-25 spec and all security patches
     "google-generativeai>=0.5.4",
     "google-cloud-iam>=2.19.1",

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -67,6 +67,7 @@ from src.core.auth_utils import get_principal_from_token
 from src.core.config_loader import get_current_tenant
 from src.core.database.models import PushNotificationConfig as DBPushNotificationConfig
 from src.core.domain_config import get_a2a_server_url, get_sales_agent_domain
+from src.core.product_conversion import add_v2_compat_to_products
 from src.core.schemas import CreativeStatusEnum
 from src.core.testing_hooks import AdCPTestContext
 from src.core.tool_context import ToolContext
@@ -2168,9 +2169,11 @@ class AdCPRequestHandler(RequestHandler):
                 ctx=self._tool_context_to_mcp_context(tool_context),
             )
 
-            # Convert to A2A response format
+            # Convert to A2A response format with v2.x backward compatibility
+            products = [product.model_dump() for product in response.products]
+            products = add_v2_compat_to_products(products)
             return {
-                "products": [product.model_dump() for product in response.products],
+                "products": products,
                 "message": str(response),  # Use __str__ method for human-readable message
             }
 

--- a/src/admin/blueprints/core.py
+++ b/src/admin/blueprints/core.py
@@ -293,10 +293,7 @@ def admin_index():
     """Admin UI entry point - requires authentication."""
     from src.core.config_loader import is_single_tenant_mode
 
-    logger.warning("========== ADMIN_INDEX HIT ==========")
-    logger.warning(f"Session keys: {list(session.keys())}")
-    logger.warning(f"'user' in session: {'user' in session}")
-    logger.warning(f"Incoming cookies: {list(request.cookies.keys())}")
+    logger.debug("admin_index hit, session_keys=%s, has_user=%s", list(session.keys()), "user" in session)
 
     # Single-tenant mode: always redirect to default tenant dashboard
     # (the @require_tenant_access decorator handles auth redirect)

--- a/src/core/audit_logger.py
+++ b/src/core/audit_logger.py
@@ -43,10 +43,14 @@ audit_logger.setLevel(logging.INFO)
 audit_logger.addHandler(audit_handler)
 audit_logger.addHandler(error_handler)
 
-# Also log to console for debugging
-console_handler = logging.StreamHandler()
-console_handler.setFormatter(logging.Formatter(LOG_FORMAT, DATE_FORMAT))
-audit_logger.addHandler(console_handler)
+# In development, also log to console for debugging
+# In production, the root logger already handles console output with JSON formatting
+import os
+
+if not os.environ.get("FLY_APP_NAME") and not os.environ.get("PRODUCTION"):
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(logging.Formatter(LOG_FORMAT, DATE_FORMAT))
+    audit_logger.addHandler(console_handler)
 
 
 class AuditLogger:

--- a/uv.lock
+++ b/uv.lock
@@ -62,7 +62,7 @@ http-server = [
 
 [[package]]
 name = "adcp"
-version = "3.0.0"
+version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "a2a-sdk" },
@@ -72,14 +72,14 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/21/a6c5705e6838525c0c7cedec3903519bd0dcbeb990577e43ea1190f8b5d9/adcp-3.0.0.tar.gz", hash = "sha256:496d526780e825a02c5048c44f0220cf58fa2e306af489a6f0f2662e14148b51", size = 242084, upload-time = "2026-01-26T13:36:35.309Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/3f/b58e5f1bbdf7fbade34291bac2899e196e53ff5d8b2aee80ef62fba73971/adcp-3.1.0.tar.gz", hash = "sha256:9133d8d9d210822bd9f055838be7f0688bd6a3f4bdf75b316bce2f27effffcfe", size = 243588, upload-time = "2026-01-26T20:32:54.741Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/2a/5de6edb52548e7ad7f3d40d47ed38d83ea6629da611cb21758110559cf33/adcp-3.0.0-py3-none-any.whl", hash = "sha256:8b5c65e3e3668470f2126c196ae3dac395af85249c66b92c95331860610a6758", size = 305239, upload-time = "2026-01-26T13:36:33.572Z" },
+    { url = "https://files.pythonhosted.org/packages/51/9e/f12fa04b8fb3cc53ce43ba59b3d8346600d5531fab7c5a628f26cac16c7c/adcp-3.1.0-py3-none-any.whl", hash = "sha256:8dee1b2dba109bbaecea6ca444276f89f774c862b19eb64602436ae11026b270", size = 305748, upload-time = "2026-01-26T20:32:53.659Z" },
 ]
 
 [[package]]
 name = "adcp-sales-agent"
-version = "0.9.3"
+version = "1.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-cli" },
@@ -172,7 +172,7 @@ dev = [
 requires-dist = [
     { name = "a2a-cli", specifier = ">=0.2.0" },
     { name = "a2a-sdk", extras = ["http-server"], specifier = ">=0.3.19" },
-    { name = "adcp", specifier = ">=3.0.0" },
+    { name = "adcp", specifier = ">=3.1.0" },
     { name = "aiohttp", specifier = ">=3.9.0" },
     { name = "alembic", specifier = ">=1.13.0" },
     { name = "allure-pytest", marker = "extra == 'ui-tests'", specifier = "==2.13.5" },


### PR DESCRIPTION
## Summary

- Ensures older AdCP JS clients (v2.5.x) work with the v3.0 sales agent by adding backward-compatible fields during serialization
- Cleans up production logging noise (console.print, MCP library traces, debug logs)
- Updates adcp library to 3.1.0

## Changes

**V2.x Backward Compatibility:**
- Add `is_fixed` and `rate` fields during serialization via `add_v2_compat_to_pricing_options`
- Ensure `price_guidance.floor` is present when `floor_price` is set
- Apply v2 compat to both MCP (products.py) and A2A (adcp_a2a_server.py) responses

**Logging Cleanup:**
- Replace `console.print()` calls with structured logging in auth.py
- Add `ClientDisconnectFilter` to suppress MCP library stack traces in production
- Make console audit handler conditional on development environment
- Reduce admin session/auth debug logs from WARNING to DEBUG level

## Test plan
- [x] Run AdCP contract tests - 55 tests pass
- [x] Run unit tests - 1457 tests pass
- [x] Run integration tests - 50 tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)