### PR TITLE
docs: Add PR naming guideline to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ This guide helps you work effectively with the AdCP sales agent codebase. Key pr
 3. **Follow the patterns** - 7 critical patterns below are non-negotiable
 4. **When stuck** - Check `/docs` for detailed explanations
 5. **Pre-commit hooks are your friend** - They catch most issues automatically
+6. **Name your PRs correctly** - they need to pass .github/workflows/pr-title-check.yml
 
 ### Common Task Patterns
 - **Adding a new AdCP tool**: Extend library schema → Add `_impl()` function → Add MCP wrapper → Add A2A raw function → Add tests


### PR DESCRIPTION
Added a guideline for naming PRs to the contribution instructions.