### PR TITLE
ci: allow IPR workflow write access to the repo

### DIFF
--- a/.github/workflows/ipr-agreement.yml
+++ b/.github/workflows/ipr-agreement.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   actions: write
-  contents: read
+  contents: write
   pull-requests: write
   statuses: write
 


### PR DESCRIPTION
Add `contents: write` permissions to the IPR workflow

