### PR TITLE
chore: rebrand Prebid Sales Agent references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -501,7 +501,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2025-01-29
 
-Initial release of the AdCP Sales Agent reference implementation.
+Initial release of the Prebid Sales Agent reference implementation.
 
 ### Added
 - MCP server implementation with AdCP v2.3 support

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
-# AdCP Sales Agent - Development Guide
+# Prebid Sales Agent - Development Guide
 
 ## 🤖 For Claude (AI Assistant)
 
-This guide helps you work effectively with the AdCP sales agent codebase. Key principles:
+This guide helps you work effectively with the Prebid Sales Agent codebase maintained under Prebid.org. Key principles:
 
 ### Working with This Codebase
 1. **Always read before writing** - Use Read/Glob to understand existing patterns
@@ -134,7 +134,7 @@ Never hardcode `/api/endpoint` - breaks with nginx prefix.
 
 ## Project Overview
 
-Python-based AdCP sales agent with:
+Python-based Prebid Sales Agent with:
 - **MCP Server**: FastMCP tools for AI agents (via nginx at `/mcp/`)
 - **Admin UI**: Google OAuth secured interface (via nginx at `/admin/` or `/tenant/<name>`)
 - **A2A Server**: python-a2a agent-to-agent communication (via nginx at `/a2a`)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# AdCP Sales Agent
+# Prebid Sales Agent
 
-A reference implementation of the [Ad Context Protocol (AdCP)](https://adcontextprotocol.org) sales agent, enabling AI agents to buy advertising inventory through a standardized MCP interface.
+A reference implementation of the [Ad Context Protocol (AdCP)](https://adcontextprotocol.org) sales agent, enabling AI agents to buy advertising inventory through a standardized MCP interface. This codebase is maintained under Prebid.org as the Prebid Sales Agent reference implementation.
 
 ## What is this?
 
-The AdCP Sales Agent is a server that:
+The Prebid Sales Agent is a server that:
 - **Exposes advertising inventory** to AI agents via MCP (Model Context Protocol) and A2A (Agent-to-Agent)
 - **Integrates with ad servers** like Google Ad Manager
 - **Provides an admin interface** for managing inventory and campaigns
@@ -194,7 +194,7 @@ docker compose logs adcp-server | head -50
 ## Protocol Support
 
 ### MCP (Model Context Protocol)
-The primary interface for AI agents to interact with the AdCP Sales Agent. Uses FastMCP with HTTP/SSE transport.
+The primary interface for AI agents to interact with the Prebid Sales Agent. Uses FastMCP with HTTP/SSE transport.
 
 ### A2A (Agent-to-Agent Protocol)
 JSON-RPC 2.0 compliant server for agent-to-agent communication:

--- a/docs/adapters/README.md
+++ b/docs/adapters/README.md
@@ -1,6 +1,6 @@
 # Adapters
 
-Adapters connect the AdCP Sales Agent to ad servers. Choose the adapter that matches your ad server platform.
+Adapters connect the Prebid Sales Agent to ad servers. Choose the adapter that matches your ad server platform.
 
 ## Available Adapters
 

--- a/docs/adapters/gam/README.md
+++ b/docs/adapters/gam/README.md
@@ -1,6 +1,6 @@
 # Google Ad Manager (GAM) Adapter
 
-Connect the AdCP Sales Agent to Google Ad Manager to create and manage line items programmatically.
+Connect the Prebid Sales Agent to Google Ad Manager to create and manage line items programmatically.
 
 ## Getting Started
 

--- a/docs/adapters/gam/gcp-provisioning.md
+++ b/docs/adapters/gam/gcp-provisioning.md
@@ -28,7 +28,7 @@ Partners add these to their GAM
 
 ```bash
 # Create a new GCP project (or use existing)
-gcloud projects create adcp-sales-agent-prod --name="AdCP Sales Agent Production"
+gcloud projects create adcp-sales-agent-prod --name="Prebid Sales Agent Production"
 
 # Set as default project
 gcloud config set project adcp-sales-agent-prod
@@ -42,7 +42,7 @@ This is the service account that your application will run as to create other se
 # Create the management service account
 gcloud iam service-accounts create adcp-manager \
     --display-name="AdCP Service Account Manager" \
-    --description="Service account used by AdCP Sales Agent to create partner service accounts"
+    --description="Service account used by Prebid Sales Agent to create partner service accounts"
 
 # Get the email
 export SA_EMAIL="adcp-manager@adcp-sales-agent-prod.iam.gserviceaccount.com"

--- a/docs/adapters/gam/product-configuration.md
+++ b/docs/adapters/gam/product-configuration.md
@@ -1,6 +1,6 @@
 # GAM Product Configuration Guide
 
-Complete guide for configuring Google Ad Manager (GAM) product trafficking settings in the AdCP Sales Agent.
+Complete guide for configuring Google Ad Manager (GAM) product trafficking settings in the Prebid Sales Agent.
 
 ---
 

--- a/docs/adapters/gam/service-account-setup.md
+++ b/docs/adapters/gam/service-account-setup.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The AdCP Sales Agent supports two authentication methods for Google Ad Manager:
+The Prebid Sales Agent supports two authentication methods for Google Ad Manager:
 
 1. **OAuth (Refresh Token)** - User-based authentication requiring manual token refresh
 2. **Service Account** - Automated authentication using Google Cloud service accounts (recommended for production)
@@ -159,7 +159,7 @@ If you haven't set these up yet, see your system administrator or cloud platform
 4. Click **Create Service Account**
 5. Enter details:
    - **Name**: `adcp-sales-agent` (or your preferred name)
-   - **Description**: `Service account for AdCP Sales Agent GAM integration`
+   - **Description**: `Service account for Prebid Sales Agent GAM integration`
 6. Click **Create and Continue**
 7. Skip role assignment (will assign in GAM directly)
 8. Click **Done**
@@ -185,7 +185,7 @@ If you haven't set these up yet, see your system administrator or cloud platform
    - This restricts access to only those advertisers for better security
 7. Click **Save**
 
-### Step 4: Configure in AdCP Sales Agent
+### Step 4: Configure in Prebid Sales Agent
 
 #### Via Admin UI:
 
@@ -342,7 +342,7 @@ A: Yes, but it's not recommended. Each tenant should have its own service accoun
 
 **Q: What happens if the service account key is leaked?**
 
-A: Delete the compromised key immediately in Google Cloud Console, create a new key, and update the configuration in AdCP Sales Agent.
+A: Delete the compromised key immediately in Google Cloud Console, create a new key, and update the configuration in Prebid Sales Agent.
 
 **Q: Can I switch between OAuth and service account without losing data?**
 

--- a/docs/deployment/environment-variables.md
+++ b/docs/deployment/environment-variables.md
@@ -1,6 +1,6 @@
 # Environment Variables Reference
 
-Complete reference for all environment variables supported by the AdCP Sales Agent.
+Complete reference for all environment variables supported by the Prebid Sales Agent.
 
 ## Quick Start
 

--- a/docs/deployment/multi-tenant.md
+++ b/docs/deployment/multi-tenant.md
@@ -1,6 +1,6 @@
 # Multi-Tenant Setup Guide
 
-This guide covers setting up the AdCP Sales Agent in multi-tenant mode, where a single deployment hosts multiple publishers with subdomain-based routing.
+This guide covers setting up the Prebid Sales Agent in multi-tenant mode, where a single deployment hosts multiple publishers with subdomain-based routing.
 
 > **Prerequisites**: This guide assumes you have a working single-tenant deployment. See [Single-Tenant Deployment](single-tenant.md) for Docker images, environment variables, and basic setup.
 

--- a/docs/deployment/single-tenant.md
+++ b/docs/deployment/single-tenant.md
@@ -1,6 +1,6 @@
 # Single-Tenant Deployment
 
-Single-tenant mode is the default and recommended for most publishers deploying their own AdCP Sales Agent.
+Single-tenant mode is the default and recommended for most publishers deploying their own Prebid Sales Agent.
 
 ## Overview
 

--- a/docs/deployment/walkthroughs/fly.md
+++ b/docs/deployment/walkthroughs/fly.md
@@ -1,6 +1,6 @@
 # Fly.io Deployment
 
-This walkthrough covers deploying the AdCP Sales Agent to Fly.io. The reference implementation at https://adcp-sales-agent.fly.dev uses this setup.
+This walkthrough covers deploying the Prebid Sales Agent to Fly.io. The reference implementation maintained by Prebid uses this setup.
 
 > **Single-Tenant by Default**: Fly.io deployments run in single-tenant mode by default, which is appropriate for most publishers deploying their own sales agent. Session cookies use the actual request domain, so authentication works with any custom domain. For multi-tenant mode with subdomain routing, see [Multi-Tenant Setup](../multi-tenant.md).
 

--- a/docs/deployment/walkthroughs/fly.toml.template
+++ b/docs/deployment/walkthroughs/fly.toml.template
@@ -1,4 +1,4 @@
-# fly.toml - Fly.io deployment configuration for AdCP Sales Agent
+# fly.toml - Fly.io deployment configuration for Prebid Sales Agent
 #
 # This is a TEMPLATE. Copy to your project root and customize:
 #   cp docs/deployment/walkthroughs/fly.toml.template fly.toml

--- a/docs/deployment/walkthroughs/gcp.md
+++ b/docs/deployment/walkthroughs/gcp.md
@@ -1,6 +1,6 @@
 # GCP Cloud Run Deployment
 
-This walkthrough covers deploying the AdCP Sales Agent to Google Cloud Run with Cloud SQL PostgreSQL.
+This walkthrough covers deploying the Prebid Sales Agent to Google Cloud Run with Cloud SQL PostgreSQL.
 
 ## Prerequisites
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,6 +1,6 @@
 # Development Guide
 
-Documentation for contributors to the AdCP Sales Agent codebase.
+Documentation for contributors to the Prebid Sales Agent codebase, maintained under Prebid.org.
 
 ## Getting Started
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,6 @@
-# AdCP Sales Agent Documentation
+# Prebid Sales Agent Documentation
+
+The Prebid Sales Agent is the Prebid.org reference implementation of an AdCP-compliant sales agent.
 
 ## Quick Start
 
@@ -94,7 +96,7 @@ docs/
 
 ```
 ┌─────────────────┐     ┌──────────────────┐
-│   AI Agent      │────▶│  AdCP Sales Agent│
+│   AI Agent      │────▶│  Prebid Sales Agent│
 └─────────────────┘     └──────────────────┘
                               │
                 ┌─────────────┼─────────────┐

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -1,6 +1,6 @@
 # User Guide
 
-Once you have the AdCP Sales Agent deployed, this guide covers how to configure and use it.
+Once you have the Prebid Sales Agent deployed, this guide covers how to configure and use it.
 
 ## First Steps
 

--- a/docs/user-guide/creatives.md
+++ b/docs/user-guide/creatives.md
@@ -1,6 +1,6 @@
 # Creative Management
 
-Creatives are the ad assets (images, videos, HTML) that run in campaigns. The AdCP Sales Agent provides a creative approval workflow.
+Creatives are the ad assets (images, videos, HTML) that run in campaigns. The Prebid Sales Agent provides a creative approval workflow.
 
 ## Creative Workflow
 

--- a/docs/user-guide/products.md
+++ b/docs/user-guide/products.md
@@ -1,6 +1,6 @@
 # Product Management
 
-Products define what inventory you're selling through the AdCP Sales Agent. Each product maps to a line item template in your ad server.
+Products define what inventory you're selling through the Prebid Sales Agent. Each product maps to a line item template in your ad server.
 
 ## Creating Products
 

--- a/docs/user-guide/sso-setup.md
+++ b/docs/user-guide/sso-setup.md
@@ -18,7 +18,7 @@ New tenants start in **Setup Mode**, which enables test credentials for initial 
 
 ## Overview
 
-The AdCP Sales Agent supports any OIDC-compliant identity provider:
+The Prebid Sales Agent supports any OIDC-compliant identity provider:
 
 - **Google Workspace** - For organizations using Google
 - **Microsoft Entra ID (Azure AD)** - For Microsoft 365 organizations
@@ -64,7 +64,7 @@ Before configuring SSO, you'll need:
 4. Click **Create Credentials** > **OAuth client ID**
 5. If prompted, configure the OAuth consent screen first:
    - User Type: **Internal** (for your organization only) or **External**
-   - App name: "AdCP Sales Agent" (or your preferred name)
+   - App name: "Prebid Sales Agent" (or your preferred name)
    - User support email: Your admin email
    - Authorized domains: Add your domain
    - Scopes: Add `openid`, `email`, `profile`
@@ -72,7 +72,7 @@ Before configuring SSO, you'll need:
 #### Step 2: Configure OAuth Client
 
 1. Application type: **Web application**
-2. Name: "AdCP Sales Agent SSO"
+2. Name: "Prebid Sales Agent SSO"
 3. Authorized redirect URIs: Add your tenant's redirect URI
    - Example: `https://your-tenant.sales-agent.example.com/admin/auth/oidc/callback`
 4. Click **Create**
@@ -99,7 +99,7 @@ Before configuring SSO, you'll need:
 2. Navigate to **Microsoft Entra ID** > **App registrations**
 3. Click **New registration**
 4. Configure:
-   - Name: "AdCP Sales Agent"
+   - Name: "Prebid Sales Agent"
    - Supported account types: Choose based on your needs
      - **Single tenant**: Only your organization
      - **Multitenant**: Any Microsoft organization
@@ -155,7 +155,7 @@ Replace `{tenant-id}` with your Directory (tenant) ID.
 
 #### Step 2: Configure Application
 
-1. App integration name: "AdCP Sales Agent"
+1. App integration name: "Prebid Sales Agent"
 2. Grant type: Ensure **Authorization Code** is selected
 3. Sign-in redirect URIs: Add your tenant's redirect URI
 4. Sign-out redirect URIs: (optional) Add your logout URL
@@ -190,7 +190,7 @@ Replace `your-domain` with your Okta domain.
 2. Go to **Applications** > **Applications**
 3. Click **Create Application**
 4. Configure:
-   - Name: "AdCP Sales Agent"
+   - Name: "Prebid Sales Agent"
    - Application Type: **Regular Web Applications**
 5. Click **Create**
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,1 @@
-"""Source code directory for AdCP Sales Agent."""
+"""Source code directory for Prebid Sales Agent."""

--- a/src/a2a_server/__init__.py
+++ b/src/a2a_server/__init__.py
@@ -1,4 +1,4 @@
-"""A2A Server integration for AdCP Sales Agent."""
+"""A2A Server integration for Prebid Sales Agent."""
 
 from .adcp_a2a_server import main
 

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-AdCP Sales Agent A2A Server using official a2a-sdk library.
+Prebid Sales Agent A2A Server using official a2a-sdk library.
 Supports both standard A2A message format and JSON-RPC 2.0.
 """
 
@@ -2317,7 +2317,7 @@ def create_agent_card() -> AgentCard:
     """Create the agent card describing capabilities.
 
     Returns:
-        AgentCard with AdCP Sales Agent capabilities
+        AgentCard with Prebid Sales Agent capabilities
     """
     # Use configured domain for agent card
     # Note: This will be overridden dynamically in the endpoint handlers
@@ -2345,7 +2345,7 @@ def create_agent_card() -> AgentCard:
 
     # Create the agent card with minimal required fields
     agent_card = AgentCard(
-        name="AdCP Sales Agent",
+        name="Prebid Sales Agent",
         description="AI agent for programmatic advertising campaigns via AdCP protocol",
         version=sales_agent_version,
         protocol_version="1.0",

--- a/src/adapters/gam/client.py
+++ b/src/adapters/gam/client.py
@@ -65,7 +65,7 @@ class GAMClientManager:
 
             # Create AdManager client
             ad_manager_client = ad_manager.AdManagerClient(
-                credentials, "AdCP Sales Agent", network_code=self.network_code
+                credentials, "Prebid Sales Agent", network_code=self.network_code
             )
 
             logger.info(

--- a/src/adapters/gam/managers/workflow.py
+++ b/src/adapters/gam/managers/workflow.py
@@ -478,7 +478,7 @@ class GAMWorkflowManager:
                                 "short": False,
                             },
                         ],
-                        "footer": "AdCP Sales Agent",
+                        "footer": "Prebid Sales Agent",
                         "ts": int(datetime.now().timestamp()),
                     }
                 ]

--- a/src/admin/__init__.py
+++ b/src/admin/__init__.py
@@ -1,1 +1,1 @@
-"""Admin UI module - Flask application for managing AdCP Sales Agent."""
+"""Admin UI module - Flask application for managing Prebid Sales Agent."""

--- a/src/admin/blueprints/gam.py
+++ b/src/admin/blueprints/gam.py
@@ -609,7 +609,7 @@ def get_gam_custom_targeting_keys(tenant_id):
 
             # Create GAM client
             client = ad_manager.AdManagerClient(
-                oauth2_client, "AdCP Sales Agent", network_code=adapter_config.gam_network_code
+                oauth2_client, "Prebid Sales Agent", network_code=adapter_config.gam_network_code
             )
 
             # Initialize GAM inventory discovery

--- a/src/admin/blueprints/inventory.py
+++ b/src/admin/blueprints/inventory.py
@@ -252,7 +252,7 @@ def get_targeting_values(tenant_id, key_id):
                     oauth2_client = oauth2.GoogleCredentialsClient(credentials)
                     # Create Ad Manager client with service account
                     gam_ad_manager_client = ad_manager.AdManagerClient(
-                        oauth2_client, "AdCP Sales Agent", network_code=adapter_config.gam_network_code
+                        oauth2_client, "Prebid Sales Agent", network_code=adapter_config.gam_network_code
                     )
                 finally:
                     # Clean up temp file
@@ -272,7 +272,7 @@ def get_targeting_values(tenant_id, key_id):
                 )
                 # Create Ad Manager client
                 gam_ad_manager_client = ad_manager.AdManagerClient(
-                    oauth2_client, "AdCP Sales Agent", network_code=adapter_config.gam_network_code
+                    oauth2_client, "Prebid Sales Agent", network_code=adapter_config.gam_network_code
                 )
 
             # Create inventory discovery instance

--- a/src/admin/blueprints/tenants.py
+++ b/src/admin/blueprints/tenants.py
@@ -528,13 +528,13 @@ def test_slack(tenant_id):
             response = requests.post(
                 tenant.slack_webhook_url,
                 json={
-                    "text": f"🎉 Test message from AdCP Sales Agent for {tenant.name}",
+                    "text": f"🎉 Test message from Prebid Sales Agent for {tenant.name}",
                     "blocks": [
                         {
                             "type": "section",
                             "text": {
                                 "type": "mrkdwn",
-                                "text": f"*Test Notification*\nThis is a test message from the AdCP Sales Agent for *{tenant.name}*.",
+                                "text": f"*Test Notification*\nThis is a test message from the Prebid Sales Agent for *{tenant.name}*.",
                             },
                         },
                         {

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,5 +1,5 @@
 """
-Core MCP server components for the AdCP Sales Agent.
+Core MCP server components for the Prebid Sales Agent.
 
 This module contains the core functionality for the MCP server including:
 - MCP server implementation (main.py)

--- a/src/core/audit_logger.py
+++ b/src/core/audit_logger.py
@@ -1,5 +1,5 @@
 """
-Audit logging module for AdCP Sales Agent platform.
+Audit logging module for Prebid Sales Agent platform.
 
 Implements security-compliant logging with:
 - Timestamps

--- a/src/core/auth.py
+++ b/src/core/auth.py
@@ -1,4 +1,4 @@
-"""Authentication functions for AdCP Sales Agent.
+"""Authentication functions for Prebid Sales Agent.
 
 This module provides authentication and principal resolution functions used
 by both MCP and A2A protocols.

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -1,4 +1,4 @@
-"""Configuration management for AdCP Sales Agent.
+"""Configuration management for Prebid Sales Agent.
 
 Provides Pydantic-based configuration classes for type-safe, validated configuration
 management using environment variables.

--- a/src/core/database/__init__.py
+++ b/src/core/database/__init__.py
@@ -1,4 +1,4 @@
-"""Database module for AdCP Sales Agent Server.
+"""Database module for Prebid Sales Agent Server.
 
 This module contains all database-related functionality including:
 - Database configuration and connection management

--- a/src/core/database/database_session.py
+++ b/src/core/database/database_session.py
@@ -1,5 +1,5 @@
 """
-Standardized database session management for the AdCP Sales Agent.
+Standardized database session management for the Prebid Sales Agent.
 
 This module provides a consistent, thread-safe approach to database session
 management across the entire application.

--- a/src/core/helpers/__init__.py
+++ b/src/core/helpers/__init__.py
@@ -1,4 +1,4 @@
-"""Helper modules for AdCP Sales Agent.
+"""Helper modules for Prebid Sales Agent.
 
 This package contains modular helper functions extracted from main.py for better maintainability:
 - adapter_helpers: Adapter instance creation and configuration

--- a/src/core/startup.py
+++ b/src/core/startup.py
@@ -1,4 +1,4 @@
-"""Startup configuration and validation for AdCP Sales Agent."""
+"""Startup configuration and validation for Prebid Sales Agent."""
 
 import logging
 
@@ -21,7 +21,7 @@ def initialize_application() -> None:
         # This ensures production environments get JSON logs
         setup_structured_logging()
 
-        logger.info("Initializing AdCP Sales Agent...")
+        logger.info("Initializing Prebid Sales Agent...")
 
         # Setup OAuth-specific logging
         setup_oauth_logging()

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,5 +1,5 @@
 """
-Service modules for the AdCP Sales Agent Server.
+Service modules for the Prebid Sales Agent Server.
 
 This package contains business logic services that handle specific functionality
 like AI-powered product generation, creative format management, targeting capabilities,

--- a/src/services/background_sync_service.py
+++ b/src/services/background_sync_service.py
@@ -213,7 +213,7 @@ def _run_sync_thread(
                     )
                     oauth2_client = oauth2.GoogleCredentialsClient(credentials)
                     client = ad_manager.AdManagerClient(
-                        oauth2_client, "AdCP Sales Agent", network_code=adapter_config.gam_network_code
+                        oauth2_client, "Prebid Sales Agent", network_code=adapter_config.gam_network_code
                     )
                 finally:
                     try:
@@ -227,7 +227,7 @@ def _run_sync_thread(
                     refresh_token=adapter_config.gam_refresh_token,
                 )
                 client = ad_manager.AdManagerClient(
-                    oauth2_client, "AdCP Sales Agent", network_code=adapter_config.gam_network_code
+                    oauth2_client, "Prebid Sales Agent", network_code=adapter_config.gam_network_code
                 )
 
         # Get last successful sync time for incremental mode

--- a/src/services/gcp_service_account_service.py
+++ b/src/services/gcp_service_account_service.py
@@ -188,7 +188,7 @@ class GCPServiceAccountService:
                 logger.info(f"Creating new service account with account_id='{account_id}' for tenant {tenant_id}")
                 try:
                     service_account = self._create_service_account(
-                        account_id=account_id, display_name=display_name or f"AdCP Sales Agent - {tenant_id}"
+                        account_id=account_id, display_name=display_name or f"Prebid Sales Agent - {tenant_id}"
                     )
                     service_account_email = service_account.email
                     service_account_was_created = True

--- a/src/services/slack_notifier.py
+++ b/src/services/slack_notifier.py
@@ -1,5 +1,5 @@
 """
-Slack notification system for AdCP Sales Agent.
+Slack notification system for Prebid Sales Agent.
 Sends notifications for new tasks and approvals via Slack webhooks.
 """
 


### PR DESCRIPTION
### Motivation
- Align product and documentation naming to the Prebid stewardship and clarify that this codebase is the Prebid.org reference implementation of the sales agent.
- Ensure runtime metadata and external-facing strings (agent card, notifications, GAM client display names) reflect the new Prebid branding so integrations and UI messages are consistent.

### Description
- Replaced user-facing and developer documentation references from "AdCP Sales Agent" to "Prebid Sales Agent" and added explicit Prebid.org stewardship language in top-level docs (`README.md`, `docs/index.md`, `docs/development/README.md`, `CLAUDE.md`, `AGENTS.md`).
- Updated A2A agent metadata and agent card to use the `Prebid Sales Agent` name in `src/a2a_server/adcp_a2a_server.py` and adjusted related descriptions.
- Updated service and integration strings used at runtime, including Slack notification footers/messages, GAM client display names, service account display names, and multiple module docstrings across `src/*` files to the Prebid naming.
- Tidied duplicate agent docs by collapsing `AGENTS.md` to a symlink to `CLAUDE.md` and adjusted several deployment and adapter docs to match the new naming.

### Testing
- Ran the unit test suite with `uv run pytest tests/unit/ -x` and all tests completed: `1475 passed, 31 skipped` (warnings present but no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697bb7b37bf4832ba9a255869190ffa8)