### PR TITLE
feat: Display version in tenant landing page footer

### DIFF
--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -100,41 +100,8 @@ from src.core.tools import (
 from src.core.tools import (
     update_performance_index_raw as core_update_performance_index_tool,
 )
+from src.core.version import get_version
 from src.services.protocol_webhook_service import get_protocol_webhook_service
-
-
-def _get_sales_agent_version() -> str:
-    """Get the sales agent version from package metadata or pyproject.toml.
-
-    Returns:
-        Version string (e.g., "0.4.1")
-    """
-    # Try importlib.metadata first (works when package is installed)
-    try:
-        from importlib.metadata import version
-
-        return version("adcp-sales-agent")
-    except Exception:
-        pass
-
-    # Fall back to reading pyproject.toml directly (works in development)
-    try:
-        import tomllib
-        from pathlib import Path
-
-        # Look for pyproject.toml relative to this file
-        project_root = Path(__file__).parent.parent.parent
-        pyproject_path = project_root / "pyproject.toml"
-
-        if pyproject_path.exists():
-            with open(pyproject_path, "rb") as f:
-                data = tomllib.load(f)
-                return data.get("project", {}).get("version", "0.0.0")
-    except Exception:
-        pass
-
-    return "0.0.0"
-
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
@@ -2328,7 +2295,7 @@ def create_agent_card() -> AgentCard:
     from adcp import get_adcp_version
 
     # Get sales agent version from package metadata or pyproject.toml
-    sales_agent_version = _get_sales_agent_version()
+    sales_agent_version = get_version()
 
     # Create AdCP extension (AdCP 2.5 spec)
     # As of adcp 2.12.1, get_adcp_version() returns the protocol version (e.g., "2.5.0")

--- a/src/core/version.py
+++ b/src/core/version.py
@@ -1,0 +1,39 @@
+"""Version utilities for the AdCP Sales Agent."""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def get_version() -> str:
+    """Get the sales agent version from package metadata or pyproject.toml.
+
+    Returns:
+        Version string (e.g., "1.2.0")
+    """
+    # Try importlib.metadata first (works when package is installed)
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        return version("adcp-sales-agent")
+    except PackageNotFoundError:
+        # Package not installed, fall through to pyproject.toml
+        pass
+
+    # Fall back to reading pyproject.toml directly (works in development)
+    try:
+        import tomllib
+        from pathlib import Path
+
+        # Look for pyproject.toml relative to this file
+        project_root = Path(__file__).parent.parent.parent
+        pyproject_path = project_root / "pyproject.toml"
+
+        if pyproject_path.exists():
+            with open(pyproject_path, "rb") as f:
+                data = tomllib.load(f)
+                return data.get("project", {}).get("version", "0.0.0")
+    except (FileNotFoundError, tomllib.TOMLDecodeError, KeyError) as e:
+        logger.debug("Failed to read version from pyproject.toml: %s", e)
+
+    return "0.0.0"

--- a/src/landing/landing_page.py
+++ b/src/landing/landing_page.py
@@ -3,6 +3,7 @@
 import html
 import os
 
+from adcp import get_adcp_version
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from src.core.domain_config import (
@@ -11,6 +12,7 @@ from src.core.domain_config import (
     get_tenant_url,
     is_sales_agent_domain,
 )
+from src.core.version import get_version
 
 
 def _get_jinja_env() -> Environment:
@@ -280,6 +282,8 @@ def generate_tenant_landing_page(tenant: dict, virtual_host: str | None = None) 
         "is_production": os.getenv("PRODUCTION") == "true",
         # Additional context
         "page_title": f"{tenant.get('name', 'Publisher')} Sales Agent",
+        "version": get_version(),
+        "adcp_version": get_adcp_version(),
     }
 
     # Load and render template

--- a/src/landing/templates/tenant_landing.html
+++ b/src/landing/templates/tenant_landing.html
@@ -308,6 +308,7 @@
             | Account: {{ tenant_subdomain }}
             {% endif %}
             | <a href="{{ admin_url }}" style="color: #6c757d; font-size: 0.85em; text-decoration: none;">Internal Admin</a>
+            | <span style="color: #6c757d; font-size: 0.85em;">Prebid Sales Agent v{{ version }} (AdCP {{ adcp_version }})</span>
         </div>
     </div>
 </body>

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,0 +1,26 @@
+"""Tests for the version module."""
+
+import re
+
+from src.core.version import get_version
+
+
+def test_get_version_returns_valid_semver():
+    """get_version should return a valid semantic version string."""
+    version = get_version()
+
+    # Should be a string
+    assert isinstance(version, str)
+
+    # Should match semver pattern (e.g., "1.2.0" or "0.0.0")
+    assert re.match(r"^\d+\.\d+\.\d+", version), f"Version '{version}' doesn't match semver pattern"
+
+
+def test_get_version_not_default():
+    """get_version should return the actual version, not the fallback."""
+    version = get_version()
+
+    # Verifies that at least one retrieval method works (importlib.metadata or pyproject.toml).
+    # The fallback "0.0.0" is only returned if both methods fail, which would indicate
+    # a broken environment rather than an actual version of 0.0.0.
+    assert version != "0.0.0", "Version should not be the fallback value"

--- a/tests/unit/test_virtual_host_landing_page.py
+++ b/tests/unit/test_virtual_host_landing_page.py
@@ -148,6 +148,9 @@ class TestVirtualHostLandingPage:
         assert "Test Publisher" in html_content
         assert "AdCP" in html_content
         assert "testpub" in html_content
+        # Check version is displayed in footer (both sales agent and AdCP versions)
+        assert "Prebid Sales Agent v" in html_content
+        assert "(AdCP " in html_content
 
     def test_landing_page_admin_dashboard_link(self):
         """Test that landing page includes admin dashboard link."""


### PR DESCRIPTION
## Summary

- Extract `get_version()` to a shared module (`src/core/version.py`) for reuse across the codebase
- Display Sales Agent version and AdCP protocol version in the tenant landing page footer
- Use specific exceptions (`PackageNotFoundError`, `FileNotFoundError`, `TOMLDecodeError`) instead of broad `Exception` catches for better debugging

## Test plan

- [x] Unit tests for version module (`tests/unit/test_version.py`)
- [x] Updated landing page tests to verify version display
- [x] All pre-commit hooks pass
- [x] Unit and integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)