### PR TITLE
fix: resolve template literal syntax error in add_product.html

### DIFF
--- a/templates/add_product.html
+++ b/templates/add_product.html
@@ -406,11 +406,11 @@ function addPricingOption() {
     container.insertAdjacentHTML('beforeend', optionHtml);
 
     // Create the update function for this specific option
-    window[\`updatePricingFields\${index}\`] = function() {
-        const pricingModel = document.querySelector(\`select[name="pricing_model_\${index}"]\`).value;
-        const rateGroup = document.getElementById(\`rate-group-\${index}\`);
-        const floorGroup = document.getElementById(\`floor-group-\${index}\`);
-        const priceGuidance = document.getElementById(\`price-guidance-\${index}\`);
+    window[`updatePricingFields${index}`] = function() {
+        const pricingModel = document.querySelector(`select[name="pricing_model_${index}"]`).value;
+        const rateGroup = document.getElementById(`rate-group-${index}`);
+        const floorGroup = document.getElementById(`floor-group-${index}`);
+        const priceGuidance = document.getElementById(`price-guidance-${index}`);
 
         // Determine if fixed or auction from pricing model selection
         const isAuction = pricingModel.includes('_auction') || pricingModel === 'vcpm' || pricingModel === 'cpc';
@@ -420,20 +420,20 @@ function addPricingOption() {
             rateGroup.style.display = 'none';
             floorGroup.style.display = 'block';
             priceGuidance.style.display = 'block';
-            document.querySelector(\`input[name="rate_\${index}"]\`).required = false;
-            document.querySelector(\`input[name="floor_\${index}"]\`).required = true;
+            document.querySelector(`input[name="rate_${index}"]`).required = false;
+            document.querySelector(`input[name="floor_${index}"]`).required = true;
         } else {
             // Fixed rate mode
             rateGroup.style.display = 'block';
             floorGroup.style.display = 'none';
             priceGuidance.style.display = 'none';
-            document.querySelector(\`input[name="rate_\${index}"]\`).required = true;
-            document.querySelector(\`input[name="floor_\${index}"]\`).required = false;
+            document.querySelector(`input[name="rate_${index}"]`).required = true;
+            document.querySelector(`input[name="floor_${index}"]`).required = false;
         }
 
         // Show model-specific parameters based on selected model
-        const parametersDiv = document.getElementById(\`parameters-\${index}\`);
-        const paramsContent = document.getElementById(\`params-content-\${index}\`);
+        const parametersDiv = document.getElementById(`parameters-${index}`);
+        const paramsContent = document.getElementById(`params-content-${index}`);
 
         // Extract base model - strip _fixed/_auction suffix
         let baseModel = pricingModel;
@@ -443,38 +443,38 @@ function addPricingOption() {
 
         if (baseModel === 'cpp') {
             parametersDiv.style.display = 'block';
-            paramsContent.innerHTML = \`
+            paramsContent.innerHTML = `
                 <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0.5rem;">
                     <div>
                         <label>Demographic</label>
-                        <input type="text" name="demographic_\${index}" placeholder="e.g., A18-49">
+                        <input type="text" name="demographic_${index}" placeholder="e.g., A18-49">
                     </div>
                     <div>
                         <label>Min Points (GRPs)</label>
-                        <input type="number" name="min_points_\${index}" step="0.1">
+                        <input type="number" name="min_points_${index}" step="0.1">
                     </div>
                 </div>
-            \`;
+            `;
         } else if (baseModel === 'cpv') {
             parametersDiv.style.display = 'block';
-            paramsContent.innerHTML = \`
+            paramsContent.innerHTML = `
                 <div>
                     <label>View Threshold</label>
-                    <input type="number" name="view_threshold_\${index}" step="0.01" min="0" max="1" placeholder="0.5 = 50% viewed">
+                    <input type="number" name="view_threshold_${index}" step="0.01" min="0" max="1" placeholder="0.5 = 50% viewed">
                     <small style="color: #666;">Percentage of video that must be viewed (0.0 to 1.0)</small>
                 </div>
-            \`;
+            `;
         } else {
             parametersDiv.style.display = 'none';
         }
     };
 
     // Initialize fields
-    window[\`updatePricingFields\${index}\`]();
+    window[`updatePricingFields${index}`]();
 }
 
 function removePricingOption(index) {
-    const option = document.getElementById(\`pricing-option-\${index}\`);
+    const option = document.getElementById(`pricing-option-${index}`);
     if (option) {
         option.remove();
     }


### PR DESCRIPTION
## Summary

Fixes a JavaScript `Invalid or unexpected token` error on the Add Product page caused by incorrect double-backslash escaping of template literals inside a Jinja2 `<script>` block.

## Problem

In `templates/add_product.html`, JavaScript template literals in `addPricingOption()` and `removePricingOption()` were written with escaped backticks and `\${index}` interpolations. Since Jinja2 does not process content inside `<script>` tags (only `{{ }}` / `{% %}` delimiters are parsed), the backslashes were rendered literally into the JavaScript output, causing a syntax error at runtime.

## Fix

Removed the incorrect backslash escaping so plain ES6 template literals are used:

**Before:**
```javascript
window[`updatePricingFields\${index}`] = function() {
    const pricingModel = document.querySelector(`select[name="pricing_model_\${index}"]`).value;
```

**After:**
```javascript
window[`updatePricingFields${index}`] = function() {
    const pricingModel = document.querySelector(`select[name="pricing_model_${index}"]`).value;
```

## Files Changed
- `templates/add_product.html` — 20 lines (backslash escaping removed from template literals)
