### PR TITLE
fix: add missing script_name prefix to hardcoded URLs in templates

### DIFF
--- a/templates/edit_product_mock.html
+++ b/templates/edit_product_mock.html
@@ -148,7 +148,7 @@
         {% if tenant_adapter == 'google_ad_manager' %}
         <div class="alert" style="background: #f3e5f5; border-color: #ce93d8; color: #6a1b9a; margin-top: 1rem;">
             <strong>Inventory Targeting:</strong> Configure which ad units this product targets.
-            <a href="/tenant/{{ tenant_id }}/product/{{ product.product_id }}/inventory" class="btn btn-sm"
+            <a href="{{ script_name }}/tenant/{{ tenant_id }}/product/{{ product.product_id }}/inventory" class="btn btn-sm"
                style="background: #6a1b9a; color: white; margin-left: 1rem;">Configure Inventory →</a>
         </div>
         {% endif %}

--- a/templates/inventory_browser.html
+++ b/templates/inventory_browser.html
@@ -702,7 +702,7 @@ async function saveProductAssignment() {
 
         // Add new assignments
         for (const productId of toAdd) {
-            const response = await fetch(`/tenant/{{ tenant_id }}/products/${productId}/inventory`, {
+            const response = await fetch(`{{ script_name }}/tenant/{{ tenant_id }}/products/${productId}/inventory`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
@@ -721,7 +721,7 @@ async function saveProductAssignment() {
 
         // Remove old assignments
         for (const { productId, mappingId } of toRemove) {
-            const response = await fetch(`/tenant/{{ tenant_id }}/products/${productId}/inventory/${mappingId}`, {
+            const response = await fetch(`{{ script_name }}/tenant/{{ tenant_id }}/products/${productId}/inventory/${mappingId}`, {
                 method: 'DELETE',
                 headers: { 'Content-Type': 'application/json' }
             });

--- a/templates/media_buy_approval.html
+++ b/templates/media_buy_approval.html
@@ -148,7 +148,7 @@
     <div class="card" style="background: #f0f8ff;">
         <h3>Approval Actions</h3>
         <div style="display: flex; gap: 1rem;">
-            <form method="POST" action="/tenant/{{ tenant_id }}/media-buy/{{ media_buy.media_buy_id }}/approve" style="display: inline;">
+            <form method="POST" action="{{ script_name }}/tenant/{{ tenant_id }}/media-buy/{{ media_buy.media_buy_id }}/approve" style="display: inline;">
                 <input type="hidden" name="action" value="approve">
                 {% if human_task %}
                 <input type="hidden" name="task_id" value="{{ human_task.task_id }}">
@@ -158,7 +158,7 @@
                 </button>
             </form>
 
-            <form method="POST" action="/tenant/{{ tenant_id }}/media-buy/{{ media_buy.media_buy_id }}/approve" style="display: inline;">
+            <form method="POST" action="{{ script_name }}/tenant/{{ tenant_id }}/media-buy/{{ media_buy.media_buy_id }}/approve" style="display: inline;">
                 <input type="hidden" name="action" value="reject">
                 {% if human_task %}
                 <input type="hidden" name="task_id" value="{{ human_task.task_id }}">
@@ -168,7 +168,7 @@
                 </button>
             </form>
 
-            <a href="/tenant/{{ tenant_id }}/operations" class="btn btn-secondary">
+            <a href="{{ script_name }}/tenant/{{ tenant_id }}/operations" class="btn btn-secondary">
                 Cancel
             </a>
         </div>
@@ -176,7 +176,7 @@
     {% else %}
     <div class="card">
         <p>This media buy has already been processed. Status: <strong>{{ media_buy.status }}</strong></p>
-        <a href="/tenant/{{ tenant_id }}/operations" class="btn btn-secondary">
+        <a href="{{ script_name }}/tenant/{{ tenant_id }}/operations" class="btn btn-secondary">
             Back to Operations
         </a>
     </div>

--- a/templates/orders_browser.html
+++ b/templates/orders_browser.html
@@ -137,6 +137,7 @@
 <script>
 let currentOrders = [];
 const tenantId = '{{ tenant_id }}';
+const scriptName = '{{ script_name }}';
 
 // Load orders on page load
 document.addEventListener('DOMContentLoaded', function() {
@@ -435,7 +436,7 @@ function displayOrderDetails(order) {
                                     <td>${liDeliveryPercentage.toFixed(1)}%</td>
                                     <td>${li.cost_per_unit ? '$' + li.cost_per_unit.toFixed(2) : '-'}</td>
                                     <td>
-                                        <a href="/tenant/${tenantId}/gam/line-item/${li.line_item_id}"
+                                        <a href="${scriptName}/tenant/${tenantId}/gam/line-item/${li.line_item_id}"
                                            class="btn btn-sm btn-outline-info"
                                            target="_blank"
                                            title="View full line item details including targeting, creatives, and JSON representation">

--- a/templates/policy_review.html
+++ b/templates/policy_review.html
@@ -9,8 +9,8 @@
             <h1>Policy Review Task</h1>
             <nav aria-label="breadcrumb">
                 <ol class="breadcrumb">
-                    <li class="breadcrumb-item"><a href="/tenant/{{ tenant_id }}">Dashboard</a></li>
-                    <li class="breadcrumb-item"><a href="/tenant/{{ tenant_id }}/policy">Policy Settings</a></li>
+                    <li class="breadcrumb-item"><a href="{{ script_name }}/tenant/{{ tenant_id }}">Dashboard</a></li>
+                    <li class="breadcrumb-item"><a href="{{ script_name }}/tenant/{{ tenant_id }}/policy">Policy Settings</a></li>
                     <li class="breadcrumb-item active">Review Task</li>
                 </ol>
             </nav>
@@ -79,7 +79,7 @@
                     <h5 class="mb-0">Review Action</h5>
                 </div>
                 <div class="card-body">
-                    <form action="/tenant/{{ tenant_id }}/policy/review/{{ task_id }}" method="POST">
+                    <form action="{{ script_name }}/tenant/{{ tenant_id }}/policy/review/{{ task_id }}" method="POST">
                         <div class="form-group">
                             <label for="review_notes">Review Notes</label>
                             <textarea class="form-control" id="review_notes" name="review_notes"
@@ -95,7 +95,7 @@
                             </button>
                         </div>
 
-                        <a href="/tenant/{{ tenant_id }}/policy" class="btn btn-secondary btn-block">
+                        <a href="{{ script_name }}/tenant/{{ tenant_id }}/policy" class="btn btn-secondary btn-block">
                             Cancel
                         </a>
                     </form>

--- a/templates/policy_rules.html
+++ b/templates/policy_rules.html
@@ -9,8 +9,8 @@
             <h1>Custom Policy Rules - {{ tenant_name }}</h1>
             <nav aria-label="breadcrumb">
                 <ol class="breadcrumb">
-                    <li class="breadcrumb-item"><a href="/tenant/{{ tenant_id }}">Dashboard</a></li>
-                    <li class="breadcrumb-item"><a href="/tenant/{{ tenant_id }}/policy">Policy Settings</a></li>
+                    <li class="breadcrumb-item"><a href="{{ script_name }}/tenant/{{ tenant_id }}">Dashboard</a></li>
+                    <li class="breadcrumb-item"><a href="{{ script_name }}/tenant/{{ tenant_id }}/policy">Policy Settings</a></li>
                     <li class="breadcrumb-item active">Custom Rules</li>
                 </ol>
             </nav>
@@ -19,7 +19,7 @@
 
     <div class="row mt-4">
         <div class="col-md-12">
-            <form action="/tenant/{{ tenant_id }}/policy/rules" method="POST">
+            <form action="{{ script_name }}/tenant/{{ tenant_id }}/policy/rules" method="POST">
                 <div class="row">
                     <!-- Prohibited Advertisers -->
                     <div class="col-md-4">
@@ -91,7 +91,7 @@ deceptive advertising">{{ '\n'.join(custom_rules.prohibited_tactics) }}</textare
                 <div class="row mt-3">
                     <div class="col-md-12">
                         <button type="submit" class="btn btn-primary">Save Rules</button>
-                        <a href="/tenant/{{ tenant_id }}/policy" class="btn btn-secondary">Back to Policy Settings</a>
+                        <a href="{{ script_name }}/tenant/{{ tenant_id }}/policy" class="btn btn-secondary">Back to Policy Settings</a>
                     </div>
                 </div>
             </form>

--- a/templates/policy_settings.html
+++ b/templates/policy_settings.html
@@ -9,7 +9,7 @@
             <h1>Policy Settings - {{ tenant_name }}</h1>
             <nav aria-label="breadcrumb">
                 <ol class="breadcrumb">
-                    <li class="breadcrumb-item"><a href="/tenant/{{ tenant_id }}">Dashboard</a></li>
+                    <li class="breadcrumb-item"><a href="{{ script_name }}/tenant/{{ tenant_id }}">Dashboard</a></li>
                     <li class="breadcrumb-item active">Policy Settings</li>
                 </ol>
             </nav>
@@ -24,7 +24,7 @@
                     <h5 class="mb-0">Policy Configuration</h5>
                 </div>
                 <div class="card-body">
-                    <form action="/tenant/{{ tenant_id }}/policy/update" method="POST">
+                    <form action="{{ script_name }}/tenant/{{ tenant_id }}/policy/update" method="POST">
                         <div class="form-check mb-3">
                             <input class="form-check-input" type="checkbox" id="enabled" name="enabled"
                                    {% if policy_settings.enabled %}checked{% endif %}>
@@ -48,7 +48,7 @@
                         </div>
 
                         <button type="submit" class="btn btn-primary">Save Settings</button>
-                        <a href="/tenant/{{ tenant_id }}/policy/rules" class="btn btn-secondary">
+                        <a href="{{ script_name }}/tenant/{{ tenant_id }}/policy/rules" class="btn btn-secondary">
                             Manage Custom Rules
                         </a>
                     </form>
@@ -66,7 +66,7 @@
                     {% if pending_reviews %}
                         <div class="list-group">
                             {% for review in pending_reviews %}
-                            <a href="/tenant/{{ tenant_id }}/policy/review/{{ review.task_id }}"
+                            <a href="{{ script_name }}/tenant/{{ tenant_id }}/policy/review/{{ review.task_id }}"
                                class="list-group-item list-group-item-action">
                                 <div class="d-flex w-100 justify-content-between">
                                     <h6 class="mb-1">{{ review.brief[:50] }}...</h6>

--- a/templates/policy_settings_comprehensive.html
+++ b/templates/policy_settings_comprehensive.html
@@ -61,7 +61,7 @@
                 <h1>Policy Settings - {{ tenant_name }}</h1>
                 <nav aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="/tenant/{{ tenant_id }}">Dashboard</a></li>
+                        <li class="breadcrumb-item"><a href="{{ script_name }}/tenant/{{ tenant_id }}">Dashboard</a></li>
                         <li class="breadcrumb-item active">Policy Settings</li>
                     </ol>
                 </nav>
@@ -75,7 +75,7 @@
     </div>
 
     <div id="policy-container" class="view-mode">
-        <form action="/tenant/{{ tenant_id }}/policy/update" method="POST" id="policy-form">
+        <form action="{{ script_name }}/tenant/{{ tenant_id }}/policy/update" method="POST" id="policy-form">
         <div class="row mt-4">
             <!-- General Settings -->
             <div class="col-md-4">
@@ -117,7 +117,7 @@
                         {% if pending_reviews %}
                             <div class="list-group">
                                 {% for review in pending_reviews[:5] %}
-                                <a href="/tenant/{{ tenant_id }}/policy/review/{{ review.task_id }}"
+                                <a href="{{ script_name }}/tenant/{{ tenant_id }}/policy/review/{{ review.task_id }}"
                                    class="list-group-item list-group-item-action">
                                     <div class="d-flex w-100 justify-content-between">
                                         <h6 class="mb-1">{{ review.brief[:50] }}...</h6>

--- a/templates/product_inventory_config.html
+++ b/templates/product_inventory_config.html
@@ -8,9 +8,9 @@
         <div class="col-12">
             <nav aria-label="breadcrumb">
                 <ol class="breadcrumb">
-                    <li class="breadcrumb-item"><a href="/tenant/{{ tenant_id }}">{{ tenant_name }}</a></li>
-                    <li class="breadcrumb-item"><a href="/tenant/{{ tenant_id }}/products">Products</a></li>
-                    <li class="breadcrumb-item"><a href="/tenant/{{ tenant_id }}/products/{{ product.product_id }}/edit">{{ product.name }}</a></li>
+                    <li class="breadcrumb-item"><a href="{{ script_name }}/tenant/{{ tenant_id }}">{{ tenant_name }}</a></li>
+                    <li class="breadcrumb-item"><a href="{{ script_name }}/tenant/{{ tenant_id }}/products">Products</a></li>
+                    <li class="breadcrumb-item"><a href="{{ script_name }}/tenant/{{ tenant_id }}/products/{{ product.product_id }}/edit">{{ product.name }}</a></li>
                     <li class="breadcrumb-item active">Configure Inventory</li>
                 </ol>
             </nav>
@@ -102,7 +102,7 @@
                         <button class="btn btn-primary" onclick="saveConfiguration()">
                             Save Configuration
                         </button>
-                        <a href="/tenant/{{ tenant_id }}/products/{{ product.product_id }}/edit"
+                        <a href="{{ script_name }}/tenant/{{ tenant_id }}/products/{{ product.product_id }}/edit"
                            class="btn btn-secondary">Cancel</a>
                     </div>
                 </div>
@@ -326,7 +326,7 @@ function findUnitById(units, unitId) {
 
 function refreshInventory() {
     // Redirect to Inventory Browser for syncing
-    window.location.href = `/tenant/${tenantId}/inventory`;
+    window.location.href = `{{ script_name }}/tenant/${tenantId}/inventory`;
 }
 
 function getSuggestions() {
@@ -408,7 +408,7 @@ function saveConfiguration() {
     .then(result => {
         if (result.status === 'success') {
             alert('Configuration saved successfully!');
-            window.location.href = `/tenant/${tenantId}/products/${productId}/edit`;
+            window.location.href = `{{ script_name }}/tenant/${tenantId}/products/${productId}/edit`;
         } else {
             alert('Error saving configuration: ' + (result.error || 'Unknown error'));
         }

--- a/templates/signup_complete.html
+++ b/templates/signup_complete.html
@@ -43,7 +43,7 @@
                             https://{{ tenant.subdomain }}.{{ sales_agent_domain }}/admin/
                         </a>
                     {% else %}
-                        <a href="/tenant/{{ tenant.tenant_id }}" style="color: #4285F4; text-decoration: none; font-weight: 500;">
+                        <a href="{{ script_name }}/tenant/{{ tenant.tenant_id }}" style="color: #4285F4; text-decoration: none; font-weight: 500;">
                             View Your Dashboard
                         </a>
                     {% endif %}

--- a/templates/tenant_dashboard.html
+++ b/templates/tenant_dashboard.html
@@ -1302,7 +1302,7 @@ function handleTask(activityId, taskId) {
         return;
     }
     // Navigate to task approval page
-    window.location.href = `/tenant/{{ tenant.tenant_id }}/tasks/${taskId}/approve`;
+    window.location.href = `{{ script_name }}/tenant/{{ tenant.tenant_id }}/tasks/${taskId}/approve`;
 }
 
 // View task details

--- a/templates/tenant_settings.html
+++ b/templates/tenant_settings.html
@@ -519,7 +519,7 @@
                 <p>Organization identity, virtual host configuration, and access control</p>
             </div>
 
-            <form id="account-settings-form" method="POST" action="/tenant/{{ tenant.tenant_id }}/settings/general">
+            <form id="account-settings-form" method="POST" action="{{ script_name }}/tenant/{{ tenant.tenant_id }}/settings/general">
                 <div class="form-section">
                     <h3>Organization Information</h3>
                     <div class="form-grid">
@@ -2035,7 +2035,7 @@ Exclude any products that don't match the brand's tone.</pre>
                             Create your first advertising product to start offering inventory to buyers.
                         </p>
                     </div>
-                    <a href="/tenant/{{ tenant.tenant_id }}/products/add" class="btn btn-success">
+                    <a href="{{ script_name }}/tenant/{{ tenant.tenant_id }}/products/add" class="btn btn-success">
                         <i class="fas fa-plus"></i> Create Product
                     </a>
                 </div>
@@ -2051,8 +2051,8 @@ Exclude any products that don't match the brand's tone.</pre>
                         </p>
                     </div>
                     <div style="display: flex; gap: 0.5rem;">
-                        <a href="/tenant/{{ tenant.tenant_id }}/products" class="btn btn-small">Manage</a>
-                        <a href="/tenant/{{ tenant.tenant_id }}/products/add" class="btn btn-primary btn-small">Add New</a>
+                        <a href="{{ script_name }}/tenant/{{ tenant.tenant_id }}/products" class="btn btn-small">Manage</a>
+                        <a href="{{ script_name }}/tenant/{{ tenant.tenant_id }}/products/add" class="btn btn-primary btn-small">Add New</a>
                     </div>
                 </div>
             </div>
@@ -2077,7 +2077,7 @@ Exclude any products that don't match the brand's tone.</pre>
                             {{ active_advertisers }} active this month
                         </p>
                     </div>
-                    <a href="/tenant/{{ tenant.tenant_id }}/principals/create" class="btn btn-primary btn-small">
+                    <a href="{{ script_name }}/tenant/{{ tenant.tenant_id }}/principals/create" class="btn btn-primary btn-small">
                         Add Advertiser
                     </a>
                 </div>
@@ -2185,7 +2185,7 @@ Exclude any products that don't match the brand's tone.</pre>
             <div class="card" style="margin-top: 1rem;">
                 <div class="card-body text-center text-muted">
                     <p>No advertisers registered yet.</p>
-                    <a href="/tenant/{{ tenant.tenant_id }}/principals/create" class="btn btn-primary">
+                    <a href="{{ script_name }}/tenant/{{ tenant.tenant_id }}/principals/create" class="btn btn-primary">
                         Create First Advertiser
                     </a>
                 </div>
@@ -2227,7 +2227,7 @@ Exclude any products that don't match the brand's tone.</pre>
                     </div>
                 </details>
 
-                <form method="POST" action="/tenant/{{ tenant.tenant_id }}/settings/slack">
+                <form method="POST" action="{{ script_name }}/tenant/{{ tenant.tenant_id }}/settings/slack">
                     <div class="form-group">
                         <label for="slack_webhook_url">Task Notifications Webhook URL</label>
                         <input type="url" id="slack_webhook_url" name="slack_webhook_url"
@@ -2285,7 +2285,7 @@ Exclude any products that don't match the brand's tone.</pre>
                 </div>
                 {% endif %}
 
-                <form method="POST" action="/tenant/{{ tenant.tenant_id }}/settings/ai">
+                <form method="POST" action="{{ script_name }}/tenant/{{ tenant.tenant_id }}/settings/ai">
                     <div class="form-group">
                         <label for="ai_provider">AI Provider</label>
                         <select id="ai_provider" name="ai_provider" onchange="updateModelOptions()">
@@ -2676,7 +2676,7 @@ result = await client.tools.get_products(brief="video ads")</pre>
 
             <div class="form-section">
                 <h3>Raw Configuration (JSON)</h3>
-                <form method="POST" action="/tenant/{{ tenant.tenant_id }}/settings/raw">
+                <form method="POST" action="{{ script_name }}/tenant/{{ tenant.tenant_id }}/settings/raw">
                     <div class="form-group">
                         <textarea id="raw_config" name="config" rows="20"
                                   style="font-family: monospace;">{{ tenant.config_json }}</textarea>
@@ -2717,7 +2717,7 @@ result = await client.tools.get_products(brief="video ads")</pre>
                     <li><strong>Preserve all data</strong> - you can reactivate later by contacting support</li>
                 </ul>
 
-                <form id="deactivate-form" method="POST" action="/tenant/{{ tenant.tenant_id }}/deactivate" onsubmit="return confirmDeactivation()">
+                <form id="deactivate-form" method="POST" action="{{ script_name }}/tenant/{{ tenant.tenant_id }}/deactivate" onsubmit="return confirmDeactivation()">
                     <div class="form-group">
                         <label for="confirm-name" style="color: #991b1b;">
                             Type <strong>{{ tenant.name }}</strong> to confirm:

--- a/templates/workflows.html
+++ b/templates/workflows.html
@@ -98,7 +98,7 @@
                         <td>{{ buy.created_at.strftime('%Y-%m-%d %H:%M') if buy.created_at else 'N/A' }}</td>
                         <td>
                             {% if buy.status == 'pending_approval' %}
-                            <a href="/tenant/{{ tenant.tenant_id }}/media-buy/{{ buy.media_buy_id }}/approve" class="btn btn-sm btn-primary" title="Review and Approve">
+                            <a href="{{ script_name }}/tenant/{{ tenant.tenant_id }}/media-buy/{{ buy.media_buy_id }}/approve" class="btn btn-sm btn-primary" title="Review and Approve">
                                 Review & Approve
                             </a>
                             {% elif buy.status == 'active' %}


### PR DESCRIPTION
## Summary
Fix AGENTS.md pattern #6 violations across 13 templates where /tenant/... URLs were hardcoded without the {{ script_name }} prefix, causing 404s in path-prefix proxy deployments (nginx at /admin).

## Problem
When the sales agent is deployed behind a reverse proxy at a sub-path (e.g., nginx serving the app at `/admin`), all hardcoded `/tenant/...` URLs in templates were missing the `{{ script_name }}` prefix. This caused 404 errors for form actions, anchor hrefs, JavaScript `window.location` assignments, and `fetch()` calls — any navigation or API call that used a literal path instead of the template variable.

## Fix
Replaced all hardcoded `/tenant/...` paths with `{{ script_name }}/tenant/...` equivalents. For JavaScript contexts where the Jinja variable isn't directly available, a `scriptName` JS variable was introduced (e.g., in `orders_browser.html`) and used in template literals.

Before:
```html
<form action="/tenant/settings">
<a href="/tenant/products">
window.location = '/tenant/dashboard';
fetch('/tenant/inventory')
```

After:
```html
<form action="{{ script_name }}/tenant/settings">
<a href="{{ script_name }}/tenant/products">
window.location = '{{ script_name }}/tenant/dashboard';
const scriptName = '{{ script_name }}'; fetch(`${scriptName}/tenant/inventory`)
```

## Files Changed
- [`templates/tenant_settings.html`](templates/tenant_settings.html) — 10 form actions and links prefixed
- [`templates/product_inventory_config.html`](templates/product_inventory_config.html) — 3 hrefs + 2 JS `window.location` calls prefixed
- [`templates/media_buy_approval.html`](templates/media_buy_approval.html) — 4 form actions and links prefixed
- [`templates/policy_review.html`](templates/policy_review.html) — breadcrumbs, forms, links prefixed
- [`templates/policy_rules.html`](templates/policy_rules.html) — breadcrumbs, forms, links prefixed
- [`templates/policy_settings.html`](templates/policy_settings.html) — breadcrumbs, forms, links prefixed
- [`templates/policy_settings_comprehensive.html`](templates/policy_settings_comprehensive.html) — breadcrumbs, forms, links prefixed
- [`templates/inventory_browser.html`](templates/inventory_browser.html) — 2 JS fetch URLs prefixed
- [`templates/orders_browser.html`](templates/orders_browser.html) — added `scriptName` JS var + 1 template literal prefixed
- [`templates/tenant_dashboard.html`](templates/tenant_dashboard.html) — 1 JS `window.location` prefixed
- [`templates/edit_product_mock.html`](templates/edit_product_mock.html) — URL prefixed
- [`templates/workflows.html`](templates/workflows.html) — URL prefixed
- [`templates/signup_complete.html`](templates/signup_complete.html) — URL prefixed
