### PR TITLE
fix: normalize admin ui to canonical /admin routes

### DIFF
--- a/src/admin/app.py
+++ b/src/admin/app.py
@@ -56,26 +56,14 @@ class CustomProxyFix:
     Also fixes hardcoded URLs in redirects to include the script name prefix.
     """
 
-    def __init__(self, app, script_name="/admin"):
+    def __init__(self, app):
         self.app = app
-        self.script_name = script_name
 
     def __call__(self, environ, start_response):
         # Handle X-Script-Name (standard for mounting path) or X-Forwarded-Prefix
         script_name = environ.get("HTTP_X_SCRIPT_NAME", "")
         if not script_name:
             script_name = environ.get("HTTP_X_FORWARDED_PREFIX", "")
-
-        # Use configured script_name if provided in production
-        # BUT only if this is NOT a custom domain request (via Approximated)
-        # Custom domains should have empty script_root to show landing page
-        if not script_name and os.environ.get("PRODUCTION") == "true":
-            # Check if this is a custom domain request via Approximated
-            apx_host = environ.get("HTTP_APX_INCOMING_HOST", "")
-            if not apx_host:
-                # No Approximated header - use default /admin script_name
-                script_name = self.script_name
-            # If apx_host is set, leave script_name empty for custom domains
 
         if script_name:
             # Store for use in response wrapper
@@ -318,11 +306,7 @@ def create_app(config=None):
 
         context = {}
 
-        # Inject script_name
-        if os.environ.get("PRODUCTION") == "true":
-            context["script_name"] = "/admin"
-        else:
-            context["script_name"] = ""
+        context["script_name"] = request.script_root or request.environ.get("SCRIPT_NAME", "")
 
         # Inject support email (configurable via SUPPORT_EMAIL env var)
         context["support_email"] = get_support_email()
@@ -343,26 +327,6 @@ def create_app(config=None):
                 logger.warning(f"Could not load tenant {tenant_id} for context: {e}")
 
         return context
-
-    # Add after_request handler to fix hardcoded URLs in HTML responses
-    @app.after_request
-    def fix_hardcoded_urls(response):
-        """Fix hardcoded URLs in HTML responses to include script_name prefix."""
-        if os.environ.get("PRODUCTION") == "true" and response.content_type and "text/html" in response.content_type:
-            # Only process HTML responses
-            try:
-                html = response.get_data(as_text=True)
-                # Fix common hardcoded patterns
-                html = html.replace('href="/', 'href="/admin/')
-                html = html.replace("href='/", "href='/admin/")
-                html = html.replace('action="/', 'action="/admin/')
-                html = html.replace("action='/", "action='/admin/")
-                # Fix any that were already prefixed (avoid double prefixing)
-                html = html.replace("/admin/admin/", "/admin/")
-                response.set_data(html)
-            except Exception as e:
-                logger.error(f"Error fixing URLs in response: {e}")
-        return response
 
     # Register blueprints
     app.register_blueprint(public_bp)  # Public routes (no auth required) - MUST BE FIRST

--- a/src/admin/blueprints/operations.py
+++ b/src/admin/blueprints/operations.py
@@ -76,7 +76,7 @@ def reporting(tenant_id):
                     "error.html",
                     error_title="GAM Reporting Not Available",
                     error_message=f"This tenant is currently using {tenant_obj.ad_server or 'no ad server'}. GAM Reporting is only available for tenants using Google Ad Manager.",
-                    back_url=f"/tenant/{tenant_id}",
+                    back_url=f"/admin/tenant/{tenant_id}",
                 ),
                 400,
             )

--- a/src/admin/blueprints/tenants.py
+++ b/src/admin/blueprints/tenants.py
@@ -378,8 +378,7 @@ def tenant_settings(tenant_id, section=None):
             except Exception as e:
                 logger.warning(f"Failed to load setup checklist: {e}")
 
-            # Get script_name for production URL handling
-            script_name = "/admin" if is_production else ""
+            script_name = request.script_root or request.environ.get("SCRIPT_NAME", "")
 
             # Get available currencies from Babel
             available_currencies = get_available_currencies()

--- a/src/admin/services/business_activity_service.py
+++ b/src/admin/services/business_activity_service.py
@@ -199,7 +199,7 @@ def get_business_activities(tenant_id: str, limit: int = 50) -> list[dict]:
                     links.append(
                         {
                             "text": f"View Media Buy {details['media_buy_id']}",
-                            "url": f"/tenant/{tenant_id}/media-buy/{details['media_buy_id']}",
+                            "url": f"/admin/tenant/{tenant_id}/media-buy/{details['media_buy_id']}",
                             "icon": "💰",
                         }
                     )
@@ -207,7 +207,7 @@ def get_business_activities(tenant_id: str, limit: int = 50) -> list[dict]:
                     links.append(
                         {
                             "text": f"View Creative {details['creative_id']}",
-                            "url": f"/tenant/{tenant_id}/creative/{details['creative_id']}",
+                            "url": f"/admin/tenant/{tenant_id}/creative/{details['creative_id']}",
                             "icon": "🎨",
                         }
                     )
@@ -216,7 +216,7 @@ def get_business_activities(tenant_id: str, limit: int = 50) -> list[dict]:
                 links.append(
                     {
                         "text": "View in Audit Log",
-                        "url": f"/tenant/{tenant_id}/workflows#audit-logs",
+                        "url": f"/admin/tenant/{tenant_id}/workflows#audit-logs",
                         "icon": "📋",
                     }
                 )

--- a/src/admin/tenant_management_api.py
+++ b/src/admin/tenant_management_api.py
@@ -283,7 +283,10 @@ def create_tenant():
                 "name": data["name"],
                 "subdomain": data["subdomain"],
                 "admin_token": admin_token,
-                "admin_ui_url": f"http://{data['subdomain']}.localhost:8001/tenant/{tenant_id}",
+                "admin_ui_url": (
+                    f"http://{data['subdomain']}.localhost:{os.environ.get('ADCP_SALES_PORT', '8080')}"
+                    f"/admin/tenant/{tenant_id}"
+                ),
             }
 
             if principal_token:

--- a/src/admin/tests/integration/test_admin_app.py
+++ b/src/admin/tests/integration/test_admin_app.py
@@ -79,6 +79,15 @@ class TestAdminAppIntegration:
         response = client.get("/login")
         assert response.status_code == 200
 
+    def test_context_processor_uses_request_script_root(self, app):
+        """Template prefixing should follow request context rather than env mode."""
+        with app.test_request_context("/tenant/test_tenant", environ_overrides={"SCRIPT_NAME": "/admin"}):
+            context = {}
+            for processor in app.template_context_processors[None]:
+                context.update(processor())
+
+        assert context["script_name"] == "/admin"
+
     def test_tenant_login_page(self, client):
         """Test tenant-specific login page."""
         # Need to patch in the auth blueprint where it's actually used

--- a/src/app.py
+++ b/src/app.py
@@ -266,15 +266,8 @@ from src.admin.app import create_app  # noqa: E402
 flask_admin_app = create_app()
 admin_wsgi = WSGIMiddleware(flask_admin_app)
 
-# Mount Flask admin at all paths it handles.
-# Order matters: specific routes before catch-all.
-_ADMIN_PATHS = ["/admin", "/static", "/auth", "/api", "/callback", "/logout", "/login", "/signup", "/test"]
-
-for _path in _ADMIN_PATHS:
-    app.mount(_path, admin_wsgi)  # type: ignore[arg-type]  # WSGIMiddleware is a valid ASGI app; starlette/a2wsgi typing mismatch
-
-# Tenant-specific admin: /tenant/{tenant_id}/admin/...
-app.mount("/tenant", admin_wsgi)  # type: ignore[arg-type]  # WSGIMiddleware is a valid ASGI app; starlette/a2wsgi typing mismatch
+# Mount Flask admin only at the canonical external admin prefix.
+app.mount("/admin", admin_wsgi)  # type: ignore[arg-type]  # WSGIMiddleware is a valid ASGI app; starlette/a2wsgi typing mismatch
 
 
 # ---------------------------------------------------------------------------
@@ -297,7 +290,7 @@ async def _handle_landing_page(request: Request):
     )
 
     if result.type == "admin":
-        return RedirectResponse(url="/login", status_code=302)
+        return RedirectResponse(url="/admin/login", status_code=302)
 
     if result.type in ("custom_domain", "subdomain") and result.tenant:
         try:

--- a/src/landing/landing_page.py
+++ b/src/landing/landing_page.py
@@ -97,7 +97,7 @@ def _generate_pending_configuration_page(tenant: dict, virtual_host: str | None 
     tenant_name = html.escape(tenant.get("name", "Unknown Publisher"))
     tenant_id = tenant.get("tenant_id", "default")
     base_url = _determine_base_url(virtual_host)
-    admin_url = f"{base_url}/tenant/{tenant_id}"
+    admin_url = f"{base_url}/admin/tenant/{tenant_id}"
 
     return f"""
     <!DOCTYPE html>

--- a/src/services/auth_config_service.py
+++ b/src/services/auth_config_service.py
@@ -242,7 +242,7 @@ def get_tenant_redirect_uri(tenant: Tenant) -> str:
         port = os.environ.get("ADCP_SALES_PORT", "8080")
         base = f"http://localhost:{port}"
 
-    return f"{base}/auth/oidc/callback"
+    return f"{base}/admin/auth/oidc/callback"
 
 
 def is_oidc_config_valid(tenant_id: str) -> bool:

--- a/src/services/setup_checklist_service.py
+++ b/src/services/setup_checklist_service.py
@@ -378,7 +378,7 @@ class SetupChecklistService:
                 name="⚠️ Ad Server Configuration",
                 description="BLOCKER: Configure and test ad server connection before proceeding with other setup",
                 is_complete=ad_server_fully_configured,
-                action_url=f"/tenant/{self.tenant_id}/settings#adserver",
+                action_url=f"/admin/tenant/{self.tenant_id}/settings#adserver",
                 details=config_details,
             )
         )
@@ -403,7 +403,7 @@ class SetupChecklistService:
                     name="⚠️ Single Sign-On (SSO)",
                     description="CRITICAL: Configure SSO and disable setup mode for production security",
                     is_complete=sso_enabled and setup_mode_disabled,
-                    action_url=f"/tenant/{self.tenant_id}/users",
+                    action_url=f"/admin/tenant/{self.tenant_id}/users",
                     details=sso_details,
                 )
             )
@@ -419,7 +419,7 @@ class SetupChecklistService:
                     name="Currency Configuration",
                     description="At least one currency must be configured for media buys",
                     is_complete=currency_count > 0,
-                    action_url=f"/tenant/{self.tenant_id}/settings#business-rules",
+                    action_url=f"/admin/tenant/{self.tenant_id}/settings#business-rules",
                     details=(
                         f"{currency_count} currencies configured" if currency_count > 0 else "No currencies configured"
                     ),
@@ -455,7 +455,7 @@ class SetupChecklistService:
                 name="Authorized Properties",
                 description="Configure properties with adagents.json for verification",
                 is_complete=is_complete,
-                action_url=f"/tenant/{self.tenant_id}/inventory#publishers-pane",
+                action_url=f"/admin/tenant/{self.tenant_id}/inventory#publishers-pane",
                 details=details,
             )
         )
@@ -479,7 +479,7 @@ class SetupChecklistService:
                         name="Inventory Sync",
                         description="Sync ad units and placements from ad server",
                         is_complete=inventory_synced,
-                        action_url=f"/tenant/{self.tenant_id}/settings#inventory",
+                        action_url=f"/admin/tenant/{self.tenant_id}/settings#inventory",
                         details=inventory_details,
                     )
                 )
@@ -518,7 +518,7 @@ class SetupChecklistService:
                     name="Products",
                     description="Create at least one advertising product",
                     is_complete=product_count > 0,
-                    action_url=f"/tenant/{self.tenant_id}/products",
+                    action_url=f"/admin/tenant/{self.tenant_id}/products",
                     details=f"{product_count} products created" if product_count > 0 else "No products created",
                 )
             )
@@ -532,7 +532,7 @@ class SetupChecklistService:
                 name="Advertisers (Principals)",
                 description="Create principals for advertisers who will buy inventory",
                 is_complete=principal_count > 0,
-                action_url=f"/tenant/{self.tenant_id}/settings#advertisers",
+                action_url=f"/admin/tenant/{self.tenant_id}/settings#advertisers",
                 details=(
                     f"{principal_count} advertisers configured" if principal_count > 0 else "No advertisers configured"
                 ),
@@ -555,7 +555,7 @@ class SetupChecklistService:
                 name="Account Name",
                 description="Set a display name for your sales agent",
                 is_complete=has_custom_name,
-                action_url=f"/tenant/{self.tenant_id}/settings#account",
+                action_url=f"/admin/tenant/{self.tenant_id}/settings#account",
                 details=f"Using '{tenant.name}'" if has_custom_name else "Using default name",
             )
         )
@@ -570,7 +570,7 @@ class SetupChecklistService:
                 name="Creative Approval Guidelines",
                 description="Configure auto-approval rules and manual review settings",
                 is_complete=has_approval_config,
-                action_url=f"/tenant/{self.tenant_id}/settings#business-rules",
+                action_url=f"/admin/tenant/{self.tenant_id}/settings#business-rules",
                 details=(
                     "Auto-approval formats configured"
                     if has_approval_config
@@ -588,7 +588,7 @@ class SetupChecklistService:
                 name="Naming Conventions",
                 description="Customize order and line item naming templates",
                 is_complete=has_custom_naming,
-                action_url=f"/tenant/{self.tenant_id}/settings#business-rules",
+                action_url=f"/admin/tenant/{self.tenant_id}/settings#business-rules",
                 details="Custom templates configured" if has_custom_naming else "Using default naming templates",
             )
         )
@@ -616,7 +616,7 @@ class SetupChecklistService:
                 name="Budget Controls",
                 description="Set maximum daily budget limits for safety",
                 is_complete=has_budget_limits,
-                action_url=f"/tenant/{self.tenant_id}/settings#business-rules",
+                action_url=f"/admin/tenant/{self.tenant_id}/settings#business-rules",
                 details=details,
             )
         )
@@ -645,7 +645,7 @@ class SetupChecklistService:
                 name="AXE Segment Keys",
                 description="Configure custom targeting keys for AXE audience segments (recommended for AdCP compliance)",
                 is_complete=axe_keys_configured,
-                action_url=f"/tenant/{self.tenant_id}/targeting",
+                action_url=f"/admin/tenant/{self.tenant_id}/targeting",
                 details=(
                     ", ".join(axe_details)
                     if axe_keys_configured
@@ -663,7 +663,7 @@ class SetupChecklistService:
                 name="Slack Integration",
                 description="Configure Slack webhooks for order notifications",
                 is_complete=slack_configured,
-                action_url=f"/tenant/{self.tenant_id}/settings#integrations",
+                action_url=f"/admin/tenant/{self.tenant_id}/settings#integrations",
                 details="Slack notifications enabled" if slack_configured else "No Slack integration",
             )
         )
@@ -677,7 +677,7 @@ class SetupChecklistService:
                 name="Custom Domain (CNAME)",
                 description="Configure custom domain for your sales agent",
                 is_complete=has_custom_domain,
-                action_url=f"/tenant/{self.tenant_id}/settings#account",
+                action_url=f"/admin/tenant/{self.tenant_id}/settings#account",
                 details=f"Using {virtual_host}" if has_custom_domain else "Using default subdomain",
             )
         )
@@ -708,7 +708,7 @@ class SetupChecklistService:
                     name="Single Sign-On (SSO)",
                     description="Configure tenant-specific SSO authentication",
                     is_complete=sso_enabled and setup_mode_disabled,
-                    action_url=f"/tenant/{self.tenant_id}/users",
+                    action_url=f"/admin/tenant/{self.tenant_id}/users",
                     details=sso_details,
                 )
             )
@@ -721,7 +721,7 @@ class SetupChecklistService:
                 name="Signals Discovery Agent",
                 description="Enable AXE signals for advanced targeting",
                 is_complete=signals_enabled,
-                action_url=f"/tenant/{self.tenant_id}/settings#integrations",
+                action_url=f"/admin/tenant/{self.tenant_id}/settings#integrations",
                 details="AXE signals enabled" if signals_enabled else "AXE signals not configured",
             )
         )
@@ -734,7 +734,7 @@ class SetupChecklistService:
                 name="Gemini AI Features",
                 description="Enable AI-assisted product recommendations and creative policy checks",
                 is_complete=gemini_configured,
-                action_url=f"/tenant/{self.tenant_id}/settings#integrations",
+                action_url=f"/admin/tenant/{self.tenant_id}/settings#integrations",
                 details=(
                     "AI features enabled" if gemini_configured else "Optional: Configure Gemini API key for AI features"
                 ),
@@ -751,7 +751,7 @@ class SetupChecklistService:
                 name="Multiple Currencies",
                 description="Support international advertisers with EUR, GBP, etc.",
                 is_complete=multiple_currencies,
-                action_url=f"/tenant/{self.tenant_id}/settings#business-rules",
+                action_url=f"/admin/tenant/{self.tenant_id}/settings#business-rules",
                 details=(
                     f"{currency_count} currencies supported" if multiple_currencies else "Only 1 currency configured"
                 ),
@@ -806,7 +806,7 @@ class SetupChecklistService:
                 name="⚠️ Ad Server Configuration",
                 description="BLOCKER: Configure and test ad server connection before proceeding with other setup",
                 is_complete=ad_server_fully_configured,
-                action_url=f"/tenant/{self.tenant_id}/settings#adserver",
+                action_url=f"/admin/tenant/{self.tenant_id}/settings#adserver",
                 details=config_details,
             )
         )
@@ -829,7 +829,7 @@ class SetupChecklistService:
                     name="⚠️ Single Sign-On (SSO)",
                     description="CRITICAL: Configure SSO and disable setup mode for production security",
                     is_complete=sso_enabled and setup_mode_disabled,
-                    action_url=f"/tenant/{self.tenant_id}/users",
+                    action_url=f"/admin/tenant/{self.tenant_id}/users",
                     details=sso_details,
                 )
             )
@@ -842,7 +842,7 @@ class SetupChecklistService:
                     name="Currency Configuration",
                     description="At least one currency must be configured for media buys",
                     is_complete=currency_count > 0,
-                    action_url=f"/tenant/{self.tenant_id}/settings#business-rules",
+                    action_url=f"/admin/tenant/{self.tenant_id}/settings#business-rules",
                     details=(
                         f"{currency_count} currencies configured" if currency_count > 0 else "No currencies configured"
                     ),
@@ -866,7 +866,7 @@ class SetupChecklistService:
                 name="Authorized Properties",
                 description="Configure properties with adagents.json for verification",
                 is_complete=properties_is_complete,
-                action_url=f"/tenant/{self.tenant_id}/inventory#publishers-pane",
+                action_url=f"/admin/tenant/{self.tenant_id}/inventory#publishers-pane",
                 details=properties_details,
             )
         )
@@ -881,7 +881,7 @@ class SetupChecklistService:
                         name="Inventory Sync",
                         description="Sync ad units and placements from ad server",
                         is_complete=inventory_synced,
-                        action_url=f"/tenant/{self.tenant_id}/settings#inventory",
+                        action_url=f"/admin/tenant/{self.tenant_id}/settings#inventory",
                         details=(
                             f"{gam_inventory_count:,} inventory items synced"
                             if inventory_synced
@@ -920,7 +920,7 @@ class SetupChecklistService:
                     name="Products",
                     description="Create at least one advertising product",
                     is_complete=product_count > 0,
-                    action_url=f"/tenant/{self.tenant_id}/products",
+                    action_url=f"/admin/tenant/{self.tenant_id}/products",
                     details=f"{product_count} products created" if product_count > 0 else "No products created",
                 )
             )
@@ -932,7 +932,7 @@ class SetupChecklistService:
                 name="Advertisers (Principals)",
                 description="Create principals for advertisers who will buy inventory",
                 is_complete=principal_count > 0,
-                action_url=f"/tenant/{self.tenant_id}/settings#advertisers",
+                action_url=f"/admin/tenant/{self.tenant_id}/settings#advertisers",
                 details=(
                     f"{principal_count} advertisers configured" if principal_count > 0 else "No advertisers configured"
                 ),
@@ -955,7 +955,7 @@ class SetupChecklistService:
                 name="Account Name",
                 description="Set a display name for your sales agent",
                 is_complete=has_custom_name,
-                action_url=f"/tenant/{self.tenant_id}/settings#account",
+                action_url=f"/admin/tenant/{self.tenant_id}/settings#account",
                 details=f"Using '{tenant.name}'" if has_custom_name else "Using default name",
             )
         )
@@ -970,7 +970,7 @@ class SetupChecklistService:
                 name="Creative Approval Guidelines",
                 description="Configure auto-approval rules and manual review settings",
                 is_complete=has_approval_config,
-                action_url=f"/tenant/{self.tenant_id}/settings#business-rules",
+                action_url=f"/admin/tenant/{self.tenant_id}/settings#business-rules",
                 details=(
                     "Auto-approval formats configured"
                     if has_approval_config
@@ -988,7 +988,7 @@ class SetupChecklistService:
                 name="Naming Conventions",
                 description="Customize order and line item naming templates",
                 is_complete=has_custom_naming,
-                action_url=f"/tenant/{self.tenant_id}/settings#business-rules",
+                action_url=f"/admin/tenant/{self.tenant_id}/settings#business-rules",
                 details="Custom templates configured" if has_custom_naming else "Using default naming templates",
             )
         )
@@ -1001,7 +1001,7 @@ class SetupChecklistService:
                 name="Budget Controls",
                 description="Set maximum daily budget limits for safety",
                 is_complete=has_budget_limits,
-                action_url=f"/tenant/{self.tenant_id}/settings#business-rules",
+                action_url=f"/admin/tenant/{self.tenant_id}/settings#business-rules",
                 details=(
                     f"{budget_limit_count} currency limit(s) with daily budget controls"
                     if has_budget_limits
@@ -1034,7 +1034,7 @@ class SetupChecklistService:
                 name="AXE Segment Keys",
                 description="Configure custom targeting keys for AXE audience segments (recommended for AdCP compliance)",
                 is_complete=axe_keys_configured,
-                action_url=f"/tenant/{self.tenant_id}/targeting",
+                action_url=f"/admin/tenant/{self.tenant_id}/targeting",
                 details=(
                     ", ".join(axe_details)
                     if axe_keys_configured
@@ -1051,7 +1051,7 @@ class SetupChecklistService:
                 name="Slack Integration",
                 description="Configure Slack webhooks for order notifications",
                 is_complete=slack_configured,
-                action_url=f"/tenant/{self.tenant_id}/settings#integrations",
+                action_url=f"/admin/tenant/{self.tenant_id}/settings#integrations",
                 details="Slack notifications enabled" if slack_configured else "No Slack integration",
             )
         )
@@ -1064,7 +1064,7 @@ class SetupChecklistService:
                 name="Custom Domain (CNAME)",
                 description="Configure custom domain for your sales agent",
                 is_complete=has_custom_domain,
-                action_url=f"/tenant/{self.tenant_id}/settings#account",
+                action_url=f"/admin/tenant/{self.tenant_id}/settings#account",
                 details=f"Using {tenant.virtual_host}" if has_custom_domain else "Using default subdomain",
             )
         )
@@ -1094,7 +1094,7 @@ class SetupChecklistService:
                     name="Single Sign-On (SSO)",
                     description="Configure tenant-specific SSO authentication",
                     is_complete=sso_enabled and setup_mode_disabled,
-                    action_url=f"/tenant/{self.tenant_id}/users",
+                    action_url=f"/admin/tenant/{self.tenant_id}/users",
                     details=sso_details,
                 )
             )
@@ -1107,7 +1107,7 @@ class SetupChecklistService:
                 name="Signals Discovery Agent",
                 description="Enable AXE signals for advanced targeting",
                 is_complete=signals_enabled,
-                action_url=f"/tenant/{self.tenant_id}/settings#integrations",
+                action_url=f"/admin/tenant/{self.tenant_id}/settings#integrations",
                 details="AXE signals enabled" if signals_enabled else "AXE signals not configured",
             )
         )
@@ -1120,7 +1120,7 @@ class SetupChecklistService:
                 name="Gemini AI Features",
                 description="Enable AI-assisted product recommendations and creative policy checks",
                 is_complete=gemini_configured,
-                action_url=f"/tenant/{self.tenant_id}/settings#integrations",
+                action_url=f"/admin/tenant/{self.tenant_id}/settings#integrations",
                 details=(
                     "AI features enabled" if gemini_configured else "Optional: Configure Gemini API key for AI features"
                 ),
@@ -1135,7 +1135,7 @@ class SetupChecklistService:
                 name="Multiple Currencies",
                 description="Support international advertisers with EUR, GBP, etc.",
                 is_complete=multiple_currencies,
-                action_url=f"/tenant/{self.tenant_id}/settings#business-rules",
+                action_url=f"/admin/tenant/{self.tenant_id}/settings#business-rules",
                 details=(
                     f"{currency_count} currencies supported" if multiple_currencies else "Only 1 currency configured"
                 ),

--- a/src/services/slack_notifier.py
+++ b/src/services/slack_notifier.py
@@ -163,7 +163,7 @@ class SlackNotifier:
 
         # Add action buttons with tenant-specific URL
         admin_url = os.getenv("ADMIN_UI_URL", "http://localhost:8001")
-        script_name = "/admin" if os.environ.get("PRODUCTION") == "true" else ""
+        script_name = "/admin"
         if tenant_id:
             # Tenant-specific workflows page
             operations_url = f"{admin_url}{script_name}/tenant/{tenant_id}/workflows"
@@ -303,10 +303,10 @@ class SlackNotifier:
 
         # Build correct URL to specific creative
         admin_url = os.getenv("ADMIN_UI_URL", "http://localhost:8001")
-        script_name = "/admin" if os.environ.get("PRODUCTION") == "true" else ""
+        script_name = "/admin"
         if tenant_id:
             # Link directly to the specific creative using anchor
-            # Correct URL pattern: /tenant/{tenant_id}/creatives/review#{creative_id}
+            # Correct URL pattern: /admin/tenant/{tenant_id}/creatives/review#{creative_id}
             review_url = f"{admin_url}{script_name}/tenant/{tenant_id}/creatives/review#{creative_id}"
         else:
             # Fallback to workflows page if tenant_id not provided
@@ -656,7 +656,7 @@ class SlackNotifier:
 
         # Add action button with tenant-specific URL
         admin_url = os.getenv("ADMIN_UI_URL", "http://localhost:8001")
-        script_name = "/admin" if os.environ.get("PRODUCTION") == "true" else ""
+        script_name = "/admin"
         if tenant_id and media_buy_id:
             # Link to specific media buy in tenant context
             operations_url = f"{admin_url}{script_name}/tenant/{tenant_id}/workflows#{media_buy_id}"

--- a/templates/components/inventory_picker.html
+++ b/templates/components/inventory_picker.html
@@ -158,7 +158,7 @@ Then in your template, add browse buttons:
             .then(response => {
                 // Handle authentication errors (401) by redirecting to login
                 if (response.status === 401) {
-                    const loginUrl = config.scriptRoot + '/auth/login?redirect=' + encodeURIComponent(window.location.pathname);
+                    const loginUrl = config.scriptRoot + '/login?redirect=' + encodeURIComponent(window.location.pathname);
                     window.location.href = loginUrl;
                     return Promise.reject(new Error('Session expired'));
                 }
@@ -219,7 +219,7 @@ Then in your template, add browse buttons:
             .then(response => {
                 // Handle authentication errors (401) by redirecting to login
                 if (response.status === 401) {
-                    const loginUrl = config.scriptRoot + '/auth/login?redirect=' + encodeURIComponent(window.location.pathname);
+                    const loginUrl = config.scriptRoot + '/login?redirect=' + encodeURIComponent(window.location.pathname);
                     window.location.href = loginUrl;
                     return Promise.reject(new Error('Session expired'));
                 }

--- a/templates/components/setup_checklist_widget.html
+++ b/templates/components/setup_checklist_widget.html
@@ -124,7 +124,7 @@
     </div>
 
     <!-- View Full Checklist -->
-    <a href="/tenant/{{ tenant_id }}/setup-checklist" style="display: block; margin-top: 1rem; padding: 0.75rem; background: rgba(255,255,255,0.2); border: 1px solid rgba(255,255,255,0.3); border-radius: 8px; text-align: center; color: white; text-decoration: none; font-weight: 600; font-size: 0.875rem; transition: all 0.2s; backdrop-filter: blur(10px);" onmouseover="this.style.background='rgba(255,255,255,0.3)'" onmouseout="this.style.background='rgba(255,255,255,0.2)'">
+    <a href="{{ request.script_root }}/tenant/{{ tenant_id }}/setup-checklist" style="display: block; margin-top: 1rem; padding: 0.75rem; background: rgba(255,255,255,0.2); border: 1px solid rgba(255,255,255,0.3); border-radius: 8px; text-align: center; color: white; text-decoration: none; font-weight: 600; font-size: 0.875rem; transition: all 0.2s; backdrop-filter: blur(10px);" onmouseover="this.style.background='rgba(255,255,255,0.3)'" onmouseout="this.style.background='rgba(255,255,255,0.2)'">
         View Full Setup Checklist →
     </a>
 </div>

--- a/templates/edit_product_mock.html
+++ b/templates/edit_product_mock.html
@@ -148,7 +148,7 @@
         {% if tenant_adapter == 'google_ad_manager' %}
         <div class="alert" style="background: #f3e5f5; border-color: #ce93d8; color: #6a1b9a; margin-top: 1rem;">
             <strong>Inventory Targeting:</strong> Configure which ad units this product targets.
-            <a href="/tenant/{{ tenant_id }}/product/{{ product.product_id }}/inventory" class="btn btn-sm"
+            <a href="{{ request.script_root }}/tenant/{{ tenant_id }}/product/{{ product.product_id }}/inventory" class="btn btn-sm"
                style="background: #6a1b9a; color: white; margin-left: 1rem;">Configure Inventory →</a>
         </div>
         {% endif %}

--- a/templates/gam_line_item_viewer.html
+++ b/templates/gam_line_item_viewer.html
@@ -329,7 +329,7 @@ async function loadLineItem() {
     }
 
     // Update URL
-    window.history.pushState({}, '', `/tenant/{{ tenant_id }}/gam/line-item/${lineItemId}`);
+    window.history.pushState({}, '', `{{ request.script_root }}/tenant/{{ tenant_id }}/gam/line-item/${lineItemId}`);
 
     // Show loading
     document.getElementById('loading').style.display = 'block';

--- a/templates/inventory_browser.html
+++ b/templates/inventory_browser.html
@@ -702,7 +702,7 @@ async function saveProductAssignment() {
 
         // Add new assignments
         for (const productId of toAdd) {
-            const response = await fetch(`/tenant/{{ tenant_id }}/products/${productId}/inventory`, {
+            const response = await fetch(`{{ request.script_root }}/tenant/{{ tenant_id }}/products/${productId}/inventory`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
@@ -721,7 +721,7 @@ async function saveProductAssignment() {
 
         // Remove old assignments
         for (const { productId, mappingId } of toRemove) {
-            const response = await fetch(`/tenant/{{ tenant_id }}/products/${productId}/inventory/${mappingId}`, {
+            const response = await fetch(`{{ request.script_root }}/tenant/{{ tenant_id }}/products/${productId}/inventory/${mappingId}`, {
                 method: 'DELETE',
                 headers: { 'Content-Type': 'application/json' }
             });

--- a/templates/inventory_unified.html
+++ b/templates/inventory_unified.html
@@ -591,7 +591,7 @@ function loadProfiles() {
         .then(response => {
             // Handle authentication errors (401) by redirecting to login
             if (response.status === 401) {
-                const loginUrl = scriptRoot + '/auth/login?redirect=' + encodeURIComponent(window.location.pathname);
+                const loginUrl = scriptRoot + '/login?redirect=' + encodeURIComponent(window.location.pathname);
                 window.location.href = loginUrl;
                 return Promise.reject(new Error('Session expired'));
             }
@@ -717,7 +717,7 @@ function editProfile(profileId) {
         .then(response => {
             // Handle authentication errors (401) by redirecting to login
             if (response.status === 401) {
-                const loginUrl = scriptRoot + '/auth/login?redirect=' + encodeURIComponent(window.location.pathname);
+                const loginUrl = scriptRoot + '/login?redirect=' + encodeURIComponent(window.location.pathname);
                 window.location.href = loginUrl;
                 return Promise.reject(new Error('Session expired'));
             }
@@ -749,7 +749,7 @@ function deleteProfile(profileId, profileName) {
         .then(response => {
             // Handle authentication errors (401) by redirecting to login
             if (response.status === 401) {
-                const loginUrl = scriptRoot + '/auth/login?redirect=' + encodeURIComponent(window.location.pathname);
+                const loginUrl = scriptRoot + '/login?redirect=' + encodeURIComponent(window.location.pathname);
                 window.location.href = loginUrl;
                 return Promise.reject(new Error('Session expired'));
             }
@@ -787,7 +787,7 @@ function loadInventoryStatus() {
         .then(response => {
             // Handle authentication errors (401) by redirecting to login
             if (response.status === 401) {
-                const loginUrl = scriptRoot + '/auth/login?redirect=' + encodeURIComponent(window.location.pathname);
+                const loginUrl = scriptRoot + '/login?redirect=' + encodeURIComponent(window.location.pathname);
                 window.location.href = loginUrl;
                 return Promise.reject(new Error('Session expired'));
             }
@@ -864,7 +864,7 @@ function syncInventory() {
         .then(response => {
             // Handle authentication errors (401) by redirecting to login
             if (response.status === 401) {
-                const loginUrl = scriptRoot + '/auth/login?redirect=' + encodeURIComponent(window.location.pathname);
+                const loginUrl = scriptRoot + '/login?redirect=' + encodeURIComponent(window.location.pathname);
                 window.location.href = loginUrl;
                 return Promise.reject(new Error('Session expired'));
             }
@@ -903,7 +903,7 @@ function pollInventorySyncStatus(syncId, btn) {
             .then(response => {
                 // Handle authentication errors (401) by redirecting to login
                 if (response.status === 401) {
-                    const loginUrl = scriptRoot + '/auth/login?redirect=' + encodeURIComponent(window.location.pathname);
+                    const loginUrl = scriptRoot + '/login?redirect=' + encodeURIComponent(window.location.pathname);
                     window.location.href = loginUrl;
                     return Promise.reject(new Error('Session expired'));
                 }
@@ -969,7 +969,7 @@ function performSelectiveSync() {
         .then(response => {
             // Handle authentication errors (401) by redirecting to login
             if (response.status === 401) {
-                const loginUrl = scriptRoot + '/auth/login?redirect=' + encodeURIComponent(window.location.pathname);
+                const loginUrl = scriptRoot + '/login?redirect=' + encodeURIComponent(window.location.pathname);
                 window.location.href = loginUrl;
                 return Promise.reject(new Error('Session expired'));
             }
@@ -1164,7 +1164,7 @@ function searchInventory() {
         .then(response => {
             // Handle authentication errors (401) by redirecting to login
             if (response.status === 401) {
-                const loginUrl = scriptRoot + '/auth/login?redirect=' + encodeURIComponent(window.location.pathname);
+                const loginUrl = scriptRoot + '/login?redirect=' + encodeURIComponent(window.location.pathname);
                 window.location.href = loginUrl;
                 return Promise.reject(new Error('Session expired'));
             }

--- a/templates/media_buy_approval.html
+++ b/templates/media_buy_approval.html
@@ -148,7 +148,7 @@
     <div class="card" style="background: #f0f8ff;">
         <h3>Approval Actions</h3>
         <div style="display: flex; gap: 1rem;">
-            <form method="POST" action="/tenant/{{ tenant_id }}/media-buy/{{ media_buy.media_buy_id }}/approve" style="display: inline;">
+            <form method="POST" action="{{ request.script_root }}/tenant/{{ tenant_id }}/media-buy/{{ media_buy.media_buy_id }}/approve" style="display: inline;">
                 <input type="hidden" name="action" value="approve">
                 {% if human_task %}
                 <input type="hidden" name="task_id" value="{{ human_task.task_id }}">
@@ -158,7 +158,7 @@
                 </button>
             </form>
 
-            <form method="POST" action="/tenant/{{ tenant_id }}/media-buy/{{ media_buy.media_buy_id }}/approve" style="display: inline;">
+            <form method="POST" action="{{ request.script_root }}/tenant/{{ tenant_id }}/media-buy/{{ media_buy.media_buy_id }}/approve" style="display: inline;">
                 <input type="hidden" name="action" value="reject">
                 {% if human_task %}
                 <input type="hidden" name="task_id" value="{{ human_task.task_id }}">
@@ -168,7 +168,7 @@
                 </button>
             </form>
 
-            <a href="/tenant/{{ tenant_id }}/operations" class="btn btn-secondary">
+            <a href="{{ request.script_root }}/tenant/{{ tenant_id }}/operations" class="btn btn-secondary">
                 Cancel
             </a>
         </div>
@@ -176,7 +176,7 @@
     {% else %}
     <div class="card">
         <p>This media buy has already been processed. Status: <strong>{{ media_buy.status }}</strong></p>
-        <a href="/tenant/{{ tenant_id }}/operations" class="btn btn-secondary">
+        <a href="{{ request.script_root }}/tenant/{{ tenant_id }}/operations" class="btn btn-secondary">
             Back to Operations
         </a>
     </div>

--- a/templates/orders_browser.html
+++ b/templates/orders_browser.html
@@ -156,7 +156,7 @@ function searchLineItem() {
     }
 
     // Open the line item viewer in a new tab
-    window.open(`/tenant/${tenantId}/gam/line-item/${lineItemId}`, '_blank');
+    window.open(`{{ request.script_root }}/tenant/${tenantId}/gam/line-item/${lineItemId}`, '_blank');
 }
 
 function loadOrders() {
@@ -165,7 +165,7 @@ function loadOrders() {
     const advertiserId = document.getElementById('advertiserFilter').value;
     const hasLineItems = document.getElementById('lineItemsFilter').value;
 
-    let url = `/api/tenant/${tenantId}/orders?`;
+    let url = `{{ request.script_root }}/api/tenant/${tenantId}/orders?`;
     if (searchTerm) url += `search=${encodeURIComponent(searchTerm)}&`;
     if (status) url += `status=${encodeURIComponent(status)}&`;
     if (advertiserId) url += `advertiser_id=${encodeURIComponent(advertiserId)}&`;
@@ -435,7 +435,7 @@ function displayOrderDetails(order) {
                                     <td>${liDeliveryPercentage.toFixed(1)}%</td>
                                     <td>${li.cost_per_unit ? '$' + li.cost_per_unit.toFixed(2) : '-'}</td>
                                     <td>
-                                        <a href="/tenant/${tenantId}/gam/line-item/${li.line_item_id}"
+                                        <a href="{{ request.script_root }}/tenant/${tenantId}/gam/line-item/${li.line_item_id}"
                                            class="btn btn-sm btn-outline-info"
                                            target="_blank"
                                            title="View full line item details including targeting, creatives, and JSON representation">

--- a/templates/policy_review.html
+++ b/templates/policy_review.html
@@ -9,8 +9,8 @@
             <h1>Policy Review Task</h1>
             <nav aria-label="breadcrumb">
                 <ol class="breadcrumb">
-                    <li class="breadcrumb-item"><a href="/tenant/{{ tenant_id }}">Dashboard</a></li>
-                    <li class="breadcrumb-item"><a href="/tenant/{{ tenant_id }}/policy">Policy Settings</a></li>
+                    <li class="breadcrumb-item"><a href="{{ request.script_root }}/tenant/{{ tenant_id }}">Dashboard</a></li>
+                    <li class="breadcrumb-item"><a href="{{ request.script_root }}/tenant/{{ tenant_id }}/policy">Policy Settings</a></li>
                     <li class="breadcrumb-item active">Review Task</li>
                 </ol>
             </nav>
@@ -79,7 +79,7 @@
                     <h5 class="mb-0">Review Action</h5>
                 </div>
                 <div class="card-body">
-                    <form action="/tenant/{{ tenant_id }}/policy/review/{{ task_id }}" method="POST">
+                    <form action="{{ request.script_root }}/tenant/{{ tenant_id }}/policy/review/{{ task_id }}" method="POST">
                         <div class="form-group">
                             <label for="review_notes">Review Notes</label>
                             <textarea class="form-control" id="review_notes" name="review_notes"
@@ -95,7 +95,7 @@
                             </button>
                         </div>
 
-                        <a href="/tenant/{{ tenant_id }}/policy" class="btn btn-secondary btn-block">
+                        <a href="{{ request.script_root }}/tenant/{{ tenant_id }}/policy" class="btn btn-secondary btn-block">
                             Cancel
                         </a>
                     </form>

--- a/templates/policy_rules.html
+++ b/templates/policy_rules.html
@@ -9,8 +9,8 @@
             <h1>Custom Policy Rules - {{ tenant_name }}</h1>
             <nav aria-label="breadcrumb">
                 <ol class="breadcrumb">
-                    <li class="breadcrumb-item"><a href="/tenant/{{ tenant_id }}">Dashboard</a></li>
-                    <li class="breadcrumb-item"><a href="/tenant/{{ tenant_id }}/policy">Policy Settings</a></li>
+                    <li class="breadcrumb-item"><a href="{{ request.script_root }}/tenant/{{ tenant_id }}">Dashboard</a></li>
+                    <li class="breadcrumb-item"><a href="{{ request.script_root }}/tenant/{{ tenant_id }}/policy">Policy Settings</a></li>
                     <li class="breadcrumb-item active">Custom Rules</li>
                 </ol>
             </nav>
@@ -19,7 +19,7 @@
 
     <div class="row mt-4">
         <div class="col-md-12">
-            <form action="/tenant/{{ tenant_id }}/policy/rules" method="POST">
+            <form action="{{ request.script_root }}/tenant/{{ tenant_id }}/policy/rules" method="POST">
                 <div class="row">
                     <!-- Prohibited Advertisers -->
                     <div class="col-md-4">
@@ -91,7 +91,7 @@ deceptive advertising">{{ '\n'.join(custom_rules.prohibited_tactics) }}</textare
                 <div class="row mt-3">
                     <div class="col-md-12">
                         <button type="submit" class="btn btn-primary">Save Rules</button>
-                        <a href="/tenant/{{ tenant_id }}/policy" class="btn btn-secondary">Back to Policy Settings</a>
+                        <a href="{{ request.script_root }}/tenant/{{ tenant_id }}/policy" class="btn btn-secondary">Back to Policy Settings</a>
                     </div>
                 </div>
             </form>

--- a/templates/policy_settings.html
+++ b/templates/policy_settings.html
@@ -9,7 +9,7 @@
             <h1>Policy Settings - {{ tenant_name }}</h1>
             <nav aria-label="breadcrumb">
                 <ol class="breadcrumb">
-                    <li class="breadcrumb-item"><a href="/tenant/{{ tenant_id }}">Dashboard</a></li>
+                    <li class="breadcrumb-item"><a href="{{ request.script_root }}/tenant/{{ tenant_id }}">Dashboard</a></li>
                     <li class="breadcrumb-item active">Policy Settings</li>
                 </ol>
             </nav>
@@ -24,7 +24,7 @@
                     <h5 class="mb-0">Policy Configuration</h5>
                 </div>
                 <div class="card-body">
-                    <form action="/tenant/{{ tenant_id }}/policy/update" method="POST">
+                    <form action="{{ request.script_root }}/tenant/{{ tenant_id }}/policy/update" method="POST">
                         <div class="form-check mb-3">
                             <input class="form-check-input" type="checkbox" id="enabled" name="enabled"
                                    {% if policy_settings.enabled %}checked{% endif %}>
@@ -48,7 +48,7 @@
                         </div>
 
                         <button type="submit" class="btn btn-primary">Save Settings</button>
-                        <a href="/tenant/{{ tenant_id }}/policy/rules" class="btn btn-secondary">
+                        <a href="{{ request.script_root }}/tenant/{{ tenant_id }}/policy/rules" class="btn btn-secondary">
                             Manage Custom Rules
                         </a>
                     </form>
@@ -66,7 +66,7 @@
                     {% if pending_reviews %}
                         <div class="list-group">
                             {% for review in pending_reviews %}
-                            <a href="/tenant/{{ tenant_id }}/policy/review/{{ review.task_id }}"
+                            <a href="{{ request.script_root }}/tenant/{{ tenant_id }}/policy/review/{{ review.task_id }}"
                                class="list-group-item list-group-item-action">
                                 <div class="d-flex w-100 justify-content-between">
                                     <h6 class="mb-1">{{ review.brief[:50] }}...</h6>

--- a/templates/policy_settings_comprehensive.html
+++ b/templates/policy_settings_comprehensive.html
@@ -61,7 +61,7 @@
                 <h1>Policy Settings - {{ tenant_name }}</h1>
                 <nav aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="/tenant/{{ tenant_id }}">Dashboard</a></li>
+                        <li class="breadcrumb-item"><a href="{{ request.script_root }}/tenant/{{ tenant_id }}">Dashboard</a></li>
                         <li class="breadcrumb-item active">Policy Settings</li>
                     </ol>
                 </nav>
@@ -75,7 +75,7 @@
     </div>
 
     <div id="policy-container" class="view-mode">
-        <form action="/tenant/{{ tenant_id }}/policy/update" method="POST" id="policy-form">
+        <form action="{{ request.script_root }}/tenant/{{ tenant_id }}/policy/update" method="POST" id="policy-form">
         <div class="row mt-4">
             <!-- General Settings -->
             <div class="col-md-4">
@@ -117,7 +117,7 @@
                         {% if pending_reviews %}
                             <div class="list-group">
                                 {% for review in pending_reviews[:5] %}
-                                <a href="/tenant/{{ tenant_id }}/policy/review/{{ review.task_id }}"
+                                <a href="{{ request.script_root }}/tenant/{{ tenant_id }}/policy/review/{{ review.task_id }}"
                                    class="list-group-item list-group-item-action">
                                     <div class="d-flex w-100 justify-content-between">
                                         <h6 class="mb-1">{{ review.brief[:50] }}...</h6>

--- a/templates/product_inventory_config.html
+++ b/templates/product_inventory_config.html
@@ -8,9 +8,9 @@
         <div class="col-12">
             <nav aria-label="breadcrumb">
                 <ol class="breadcrumb">
-                    <li class="breadcrumb-item"><a href="/tenant/{{ tenant_id }}">{{ tenant_name }}</a></li>
-                    <li class="breadcrumb-item"><a href="/tenant/{{ tenant_id }}/products">Products</a></li>
-                    <li class="breadcrumb-item"><a href="/tenant/{{ tenant_id }}/products/{{ product.product_id }}/edit">{{ product.name }}</a></li>
+                    <li class="breadcrumb-item"><a href="{{ request.script_root }}/tenant/{{ tenant_id }}">{{ tenant_name }}</a></li>
+                    <li class="breadcrumb-item"><a href="{{ request.script_root }}/tenant/{{ tenant_id }}/products">Products</a></li>
+                    <li class="breadcrumb-item"><a href="{{ request.script_root }}/tenant/{{ tenant_id }}/products/{{ product.product_id }}/edit">{{ product.name }}</a></li>
                     <li class="breadcrumb-item active">Configure Inventory</li>
                 </ol>
             </nav>
@@ -102,7 +102,7 @@
                         <button class="btn btn-primary" onclick="saveConfiguration()">
                             Save Configuration
                         </button>
-                        <a href="/tenant/{{ tenant_id }}/products/{{ product.product_id }}/edit"
+                        <a href="{{ request.script_root }}/tenant/{{ tenant_id }}/products/{{ product.product_id }}/edit"
                            class="btn btn-secondary">Cancel</a>
                     </div>
                 </div>
@@ -326,7 +326,7 @@ function findUnitById(units, unitId) {
 
 function refreshInventory() {
     // Redirect to Inventory Browser for syncing
-    window.location.href = `/tenant/${tenantId}/inventory`;
+    window.location.href = `{{ request.script_root }}/tenant/${tenantId}/inventory`;
 }
 
 function getSuggestions() {
@@ -408,7 +408,7 @@ function saveConfiguration() {
     .then(result => {
         if (result.status === 'success') {
             alert('Configuration saved successfully!');
-            window.location.href = `/tenant/${tenantId}/products/${productId}/edit`;
+            window.location.href = `{{ request.script_root }}/tenant/${tenantId}/products/${productId}/edit`;
         } else {
             alert('Error saving configuration: ' + (result.error || 'Unknown error'));
         }

--- a/templates/setup_checklist.html
+++ b/templates/setup_checklist.html
@@ -216,7 +216,7 @@
 <div class="checklist-container">
     <!-- Back Button -->
     <div style="margin-bottom: 1rem;">
-        <a href="/tenant/{{ tenant_id }}" style="color: #6b7280; text-decoration: none; font-size: 0.875rem;">
+        <a href="{{ request.script_root }}/tenant/{{ tenant_id }}" style="color: #6b7280; text-decoration: none; font-size: 0.875rem;">
             ← Back to Dashboard
         </a>
     </div>

--- a/templates/signup_complete.html
+++ b/templates/signup_complete.html
@@ -43,7 +43,7 @@
                             https://{{ tenant.subdomain }}.{{ sales_agent_domain }}/admin/
                         </a>
                     {% else %}
-                        <a href="/tenant/{{ tenant.tenant_id }}" style="color: #4285F4; text-decoration: none; font-weight: 500;">
+                        <a href="{{ request.script_root }}/tenant/{{ tenant.tenant_id }}" style="color: #4285F4; text-decoration: none; font-weight: 500;">
                             View Your Dashboard
                         </a>
                     {% endif %}

--- a/templates/tenant_dashboard.html
+++ b/templates/tenant_dashboard.html
@@ -1302,7 +1302,7 @@ function handleTask(activityId, taskId) {
         return;
     }
     // Navigate to task approval page
-    window.location.href = `/tenant/{{ tenant.tenant_id }}/tasks/${taskId}/approve`;
+    window.location.href = `{{ request.script_root }}/tenant/{{ tenant.tenant_id }}/tasks/${taskId}/approve`;
 }
 
 // View task details

--- a/templates/tenant_settings.html
+++ b/templates/tenant_settings.html
@@ -436,7 +436,7 @@
             Configure {{ tenant.name }}
         </p>
     </div>
-    <a href="/tenant/{{ tenant.tenant_id }}" class="btn btn-secondary">
+    <a href="{{ request.script_root }}/tenant/{{ tenant.tenant_id }}" class="btn btn-secondary">
         ← Back to Dashboard
     </a>
 </div>
@@ -519,7 +519,7 @@
                 <p>Organization identity, virtual host configuration, and access control</p>
             </div>
 
-            <form id="account-settings-form" method="POST" action="/tenant/{{ tenant.tenant_id }}/settings/general">
+            <form id="account-settings-form" method="POST" action="{{ request.script_root }}/tenant/{{ tenant.tenant_id }}/settings/general">
                 <div class="form-section">
                     <h3>Organization Information</h3>
                     <div class="form-grid">
@@ -2035,7 +2035,7 @@ Exclude any products that don't match the brand's tone.</pre>
                             Create your first advertising product to start offering inventory to buyers.
                         </p>
                     </div>
-                    <a href="/tenant/{{ tenant.tenant_id }}/products/add" class="btn btn-success">
+                    <a href="{{ request.script_root }}/tenant/{{ tenant.tenant_id }}/products/add" class="btn btn-success">
                         <i class="fas fa-plus"></i> Create Product
                     </a>
                 </div>
@@ -2051,8 +2051,8 @@ Exclude any products that don't match the brand's tone.</pre>
                         </p>
                     </div>
                     <div style="display: flex; gap: 0.5rem;">
-                        <a href="/tenant/{{ tenant.tenant_id }}/products" class="btn btn-small">Manage</a>
-                        <a href="/tenant/{{ tenant.tenant_id }}/products/add" class="btn btn-primary btn-small">Add New</a>
+                        <a href="{{ request.script_root }}/tenant/{{ tenant.tenant_id }}/products" class="btn btn-small">Manage</a>
+                        <a href="{{ request.script_root }}/tenant/{{ tenant.tenant_id }}/products/add" class="btn btn-primary btn-small">Add New</a>
                     </div>
                 </div>
             </div>
@@ -2077,7 +2077,7 @@ Exclude any products that don't match the brand's tone.</pre>
                             {{ active_advertisers }} active this month
                         </p>
                     </div>
-                    <a href="/tenant/{{ tenant.tenant_id }}/principals/create" class="btn btn-primary btn-small">
+                    <a href="{{ request.script_root }}/tenant/{{ tenant.tenant_id }}/principals/create" class="btn btn-primary btn-small">
                         Add Advertiser
                     </a>
                 </div>
@@ -2185,7 +2185,7 @@ Exclude any products that don't match the brand's tone.</pre>
             <div class="card" style="margin-top: 1rem;">
                 <div class="card-body text-center text-muted">
                     <p>No advertisers registered yet.</p>
-                    <a href="/tenant/{{ tenant.tenant_id }}/principals/create" class="btn btn-primary">
+                    <a href="{{ request.script_root }}/tenant/{{ tenant.tenant_id }}/principals/create" class="btn btn-primary">
                         Create First Advertiser
                     </a>
                 </div>
@@ -2227,7 +2227,7 @@ Exclude any products that don't match the brand's tone.</pre>
                     </div>
                 </details>
 
-                <form method="POST" action="/tenant/{{ tenant.tenant_id }}/settings/slack">
+                <form method="POST" action="{{ request.script_root }}/tenant/{{ tenant.tenant_id }}/settings/slack">
                     <div class="form-group">
                         <label for="slack_webhook_url">Task Notifications Webhook URL</label>
                         <input type="url" id="slack_webhook_url" name="slack_webhook_url"
@@ -2285,7 +2285,7 @@ Exclude any products that don't match the brand's tone.</pre>
                 </div>
                 {% endif %}
 
-                <form method="POST" action="/tenant/{{ tenant.tenant_id }}/settings/ai">
+                <form method="POST" action="{{ request.script_root }}/tenant/{{ tenant.tenant_id }}/settings/ai">
                     <div class="form-group">
                         <label for="ai_provider">AI Provider</label>
                         <select id="ai_provider" name="ai_provider" onchange="updateModelOptions()">
@@ -2676,7 +2676,7 @@ result = await client.tools.get_products(brief="video ads")</pre>
 
             <div class="form-section">
                 <h3>Raw Configuration (JSON)</h3>
-                <form method="POST" action="/tenant/{{ tenant.tenant_id }}/settings/raw">
+                <form method="POST" action="{{ request.script_root }}/tenant/{{ tenant.tenant_id }}/settings/raw">
                     <div class="form-group">
                         <textarea id="raw_config" name="config" rows="20"
                                   style="font-family: monospace;">{{ tenant.config_json }}</textarea>
@@ -2717,7 +2717,7 @@ result = await client.tools.get_products(brief="video ads")</pre>
                     <li><strong>Preserve all data</strong> - you can reactivate later by contacting support</li>
                 </ul>
 
-                <form id="deactivate-form" method="POST" action="/tenant/{{ tenant.tenant_id }}/deactivate" onsubmit="return confirmDeactivation()">
+                <form id="deactivate-form" method="POST" action="{{ request.script_root }}/tenant/{{ tenant.tenant_id }}/deactivate" onsubmit="return confirmDeactivation()">
                     <div class="form-group">
                         <label for="confirm-name" style="color: #991b1b;">
                             Type <strong>{{ tenant.name }}</strong> to confirm:

--- a/templates/workflows.html
+++ b/templates/workflows.html
@@ -98,7 +98,7 @@
                         <td>{{ buy.created_at.strftime('%Y-%m-%d %H:%M') if buy.created_at else 'N/A' }}</td>
                         <td>
                             {% if buy.status == 'pending_approval' %}
-                            <a href="/tenant/{{ tenant.tenant_id }}/media-buy/{{ buy.media_buy_id }}/approve" class="btn btn-sm btn-primary" title="Review and Approve">
+                            <a href="{{ request.script_root }}/tenant/{{ tenant.tenant_id }}/media-buy/{{ buy.media_buy_id }}/approve" class="btn btn-sm btn-primary" title="Review and Approve">
                                 Review & Approve
                             </a>
                             {% elif buy.status == 'active' %}

--- a/tests/e2e/test_landing_pages.py
+++ b/tests/e2e/test_landing_pages.py
@@ -47,7 +47,7 @@ class TestLandingPages:
             # Admin domain should redirect to login
             assert response.status_code == 302, f"Admin domain should return 302 redirect, got {response.status_code}"
             location = response.headers.get("Location", "")
-            assert "/login" in location, f"Admin domain should redirect to /login, got {location}"
+            assert "/admin/login" in location, f"Admin domain should redirect to /admin/login, got {location}"
 
         except (requests.ConnectionError, requests.Timeout):
             pytest.skip(f"Server not running at {base_url}")
@@ -166,7 +166,7 @@ class TestLandingPages:
             )
 
             location = response.headers.get("Location", "")
-            assert "/login" in location, f"Proxied admin domain should redirect to /login, got {location}"
+            assert "/admin/login" in location, f"Proxied admin domain should redirect to /admin/login, got {location}"
 
         except (requests.ConnectionError, requests.Timeout):
             pytest.skip(f"Server not running at {base_url}")
@@ -421,7 +421,7 @@ class TestProductionLandingPages:
             assert response.status_code == 302, f"Admin UI should redirect to login (302), got {response.status_code}"
 
             location = response.headers.get("Location", "")
-            assert "/login" in location, f"Admin UI should redirect to /login, got {location}"
+            assert "/admin/login" in location, f"Admin UI should redirect to /admin/login, got {location}"
 
         except requests.RequestException as e:
             pytest.skip(f"Could not reach production URL: {e}")

--- a/tests/integration/test_notification_urls_exist.py
+++ b/tests/integration/test_notification_urls_exist.py
@@ -37,8 +37,8 @@ class TestNotificationUrlsExist:
 
         content = slack_notifier_path.read_text()
 
-        # Extract URL patterns like: f"{admin_url}/tenant/{tenant_id}/workflows"
-        # Pattern matches: /tenant/{var}/something or /something
+        # Extract URL patterns like: f"{admin_url}/admin/tenant/{tenant_id}/workflows"
+        # Pattern matches: /admin/tenant/{var}/something or /something
         url_pattern = r'["\'](/[a-z_\-{}/<>]+)["\']'
         urls = re.findall(url_pattern, content)
 
@@ -49,7 +49,7 @@ class TestNotificationUrlsExist:
             if content[content.find(url) - 10 : content.find(url)].find("http") != -1:
                 continue
             # Skip static files and external paths
-            if url.startswith("/static") or url.startswith("/admin/admin"):
+            if url.startswith("/static"):
                 continue
             route_patterns.append(url)
 
@@ -80,8 +80,8 @@ class TestNotificationUrlsExist:
         missing_routes = []
 
         for notification_url in slack_notifier_urls:
-            # Convert our format {tenant_id} to Flask format <tenant_id>
-            flask_route = notification_url.replace("{", "<").replace("}", ">")
+            # Convert public /admin-prefixed URLs to internal Flask route shape.
+            flask_route = notification_url.removeprefix("/admin").replace("{", "<").replace("}", ">")
 
             # Check if route exists (exact match or as a prefix)
             route_exists = any(
@@ -118,8 +118,8 @@ class TestNotificationUrlsExist:
         """
         # Known notification URLs that should exist
         required_routes = [
-            "/tenant/<tenant_id>/workflows",  # Fixed in this PR (was /operations)
-            "/tenant/<tenant_id>/creatives/review",  # Creative review page
+            "/tenant/<tenant_id>/workflows",  # Public URL is /admin/tenant/<tenant_id>/workflows
+            "/tenant/<tenant_id>/creatives/review",  # Public URL is /admin/tenant/<tenant_id>/creatives/review
         ]
 
         missing = []
@@ -150,6 +150,7 @@ class TestNotificationUrlsExist:
         deprecated_patterns = [
             "/operations",  # Global operations (doesn't exist)
             "/tenant/{tenant_id}/operations",  # Tenant operations (doesn't exist)
+            "/admin/tenant/{tenant_id}/operations",  # Canonical public tenant operations (doesn't exist)
         ]
 
         found_deprecated = [pattern for pattern in deprecated_patterns if pattern in slack_notifier_urls]

--- a/tests/integration/test_setup_checklist_service.py
+++ b/tests/integration/test_setup_checklist_service.py
@@ -344,7 +344,7 @@ class TestSetupChecklistService:
             for task in status["critical"]:
                 if not task["is_complete"] and task["key"] != "gemini_api_key":
                     assert task["action_url"] is not None
-                    assert f"/tenant/{test_tenant_id}" in task["action_url"]
+                    assert f"/admin/tenant/{test_tenant_id}" in task["action_url"]
 
     def test_get_next_steps(self, integration_db, setup_minimal_tenant, test_tenant_id):
         """Test get_next_steps returns prioritized actions."""

--- a/tests/integration/test_tenant_settings_comprehensive.py
+++ b/tests/integration/test_tenant_settings_comprehensive.py
@@ -144,7 +144,7 @@ def test_settings_page():
     # Test authentication
     print("\n1. Testing authentication...")
     auth_data = {"email": TEST_EMAIL, "password": TEST_PASSWORD}
-    response = session.post(f"{BASE_URL}/test/auth", data=auth_data, allow_redirects=False)
+    response = session.post(f"{BASE_URL}/admin/test/auth", data=auth_data, allow_redirects=False)
     print(f"   Auth response: {response.status_code}")
 
     if response.status_code == 302:
@@ -155,7 +155,7 @@ def test_settings_page():
 
     # Test settings page
     print("\n2. Testing settings page...")
-    response = session.get(f"{BASE_URL}/tenant/default/settings")
+    response = session.get(f"{BASE_URL}/admin/tenant/default/settings")
     print(f"   Settings page response: {response.status_code}")
 
     if response.status_code == 200:
@@ -196,7 +196,7 @@ def test_settings_page():
 
     # Test dashboard page
     print("\n3. Testing dashboard page...")
-    response = session.get(f"{BASE_URL}/tenant/default")
+    response = session.get(f"{BASE_URL}/admin/tenant/default")
     print(f"   Dashboard response: {response.status_code}")
 
     if response.status_code == 200:

--- a/tests/ui/test_comprehensive_pages.py
+++ b/tests/ui/test_comprehensive_pages.py
@@ -115,7 +115,7 @@ def test_all_admin_pages():
     }
 
     try:
-        response = session.post(f"{base_url}/test/auth", json=auth_data)
+        response = session.post(f"{base_url}/admin/test/auth", json=auth_data)
     except (requests.ConnectionError, requests.Timeout):
         pytest.skip(f"Server not running at {base_url}")
 
@@ -129,18 +129,18 @@ def test_all_admin_pages():
     print("-" * 40)
 
     main_pages = [
-        (f"/tenant/{TENANT_ID}", "Dashboard"),
-        (f"/tenant/{TENANT_ID}/settings", "Settings Main"),
-        (f"/tenant/{TENANT_ID}/operations", "Operations"),
-        (f"/tenant/{TENANT_ID}/products", "Products List"),
-        (f"/tenant/{TENANT_ID}/products/new", "New Product"),
-        (f"/tenant/{TENANT_ID}/advertisers", "Advertisers List"),
-        (f"/tenant/{TENANT_ID}/advertisers/new", "New Advertiser"),
-        (f"/tenant/{TENANT_ID}/formats", "Creative Formats"),
-        (f"/tenant/{TENANT_ID}/integrations", "Integrations"),
-        (f"/tenant/{TENANT_ID}/api-tokens", "API Tokens"),
-        (f"/tenant/{TENANT_ID}/users", "Users"),
-        (f"/tenant/{TENANT_ID}/activity", "Activity Log"),
+        (f"/admin/tenant/{TENANT_ID}", "Dashboard"),
+        (f"/admin/tenant/{TENANT_ID}/settings", "Settings Main"),
+        (f"/admin/tenant/{TENANT_ID}/operations", "Operations"),
+        (f"/admin/tenant/{TENANT_ID}/products", "Products List"),
+        (f"/admin/tenant/{TENANT_ID}/products/new", "New Product"),
+        (f"/admin/tenant/{TENANT_ID}/advertisers", "Advertisers List"),
+        (f"/admin/tenant/{TENANT_ID}/advertisers/new", "New Advertiser"),
+        (f"/admin/tenant/{TENANT_ID}/formats", "Creative Formats"),
+        (f"/admin/tenant/{TENANT_ID}/integrations", "Integrations"),
+        (f"/admin/tenant/{TENANT_ID}/api-tokens", "API Tokens"),
+        (f"/admin/tenant/{TENANT_ID}/users", "Users"),
+        (f"/admin/tenant/{TENANT_ID}/activity", "Activity Log"),
     ]
 
     for path, description in main_pages:
@@ -165,7 +165,7 @@ def test_all_admin_pages():
     ]
 
     for section in settings_sections:
-        path = f"/tenant/{TENANT_ID}/settings/{section}"
+        path = f"/admin/tenant/{TENANT_ID}/settings/{section}"
         _check_page(session, path, f"Settings: {section.title()}", base_url=base_url)
 
     print()
@@ -175,14 +175,14 @@ def test_all_admin_pages():
     print("-" * 40)
 
     api_endpoints = [
-        (f"/api/tenant/{TENANT_ID}/products", "API: Products List"),
-        (f"/api/tenant/{TENANT_ID}/advertisers", "API: Advertisers List"),
-        (f"/api/tenant/{TENANT_ID}/formats", "API: Formats List"),
-        (f"/api/tenant/{TENANT_ID}/metrics", "API: Metrics"),
-        (f"/api/tenant/{TENANT_ID}/activity", "API: Activity"),
-        (f"/api/tenant/{TENANT_ID}/config", "API: Config"),
-        (f"/api/tenant/{TENANT_ID}/products/suggestions", "API: Product Suggestions"),
-        (f"/api/tenant/{TENANT_ID}/products/templates", "API: Product Templates"),
+        (f"/admin/api/tenant/{TENANT_ID}/products", "API: Products List"),
+        (f"/admin/api/tenant/{TENANT_ID}/advertisers", "API: Advertisers List"),
+        (f"/admin/api/tenant/{TENANT_ID}/formats", "API: Formats List"),
+        (f"/admin/api/tenant/{TENANT_ID}/metrics", "API: Metrics"),
+        (f"/admin/api/tenant/{TENANT_ID}/activity", "API: Activity"),
+        (f"/admin/api/tenant/{TENANT_ID}/config", "API: Config"),
+        (f"/admin/api/tenant/{TENANT_ID}/products/suggestions", "API: Product Suggestions"),
+        (f"/admin/api/tenant/{TENANT_ID}/products/templates", "API: Product Templates"),
     ]
 
     for path, description in api_endpoints:
@@ -197,10 +197,10 @@ def test_all_admin_pages():
     special_routes = [
         ("/", "Root"),
         ("/health", "Health Check"),
-        ("/login", "Login Page"),
-        (f"/tenant/{TENANT_ID}/login", "Tenant Login"),
-        ("/tenants", "Tenants List (Super Admin)"),
-        ("/test/login", "Test Login Page"),
+        ("/admin/login", "Login Page"),
+        (f"/admin/tenant/{TENANT_ID}/login", "Tenant Login"),
+        ("/admin/tenants", "Tenants List (Super Admin)"),
+        ("/admin/test/login", "Test Login Page"),
     ]
 
     for path, description in special_routes:

--- a/tests/unit/test_fastapi_app_regression.py
+++ b/tests/unit/test_fastapi_app_regression.py
@@ -323,3 +323,60 @@ class TestFormatResolverNoEventLoopCreation:
             result = get_format("test_format", agent_url="http://example.com/agent")
 
         assert result == mock_format
+
+
+class TestAdminCanonicalMount:
+    """Admin UI should only be exposed through the canonical /admin mount."""
+
+    def test_fastapi_mounts_admin_only_at_admin_prefix(self):
+        from starlette.routing import Mount
+
+        from src.app import app
+
+        admin_mounts = [
+            route.path for route in app.routes if isinstance(route, Mount) and route.app.__class__.__name__ == "WSGIMiddleware"
+        ]
+
+        assert "/admin" in admin_mounts
+        assert "/tenant" not in admin_mounts
+        assert "/auth" not in admin_mounts
+        assert "/login" not in admin_mounts
+        assert "/logout" not in admin_mounts
+        assert "/signup" not in admin_mounts
+        assert "/test" not in admin_mounts
+
+    def test_root_login_path_is_not_exposed_by_unified_app(self):
+        from starlette.testclient import TestClient
+
+        from src.app import app
+
+        client = TestClient(app)
+
+        response = client.get("/login", follow_redirects=False)
+        assert response.status_code == 404
+
+    def test_admin_login_path_remains_available(self):
+        from starlette.testclient import TestClient
+
+        from src.app import app
+
+        client = TestClient(app)
+
+        response = client.get("/admin/login", follow_redirects=False)
+        assert response.status_code != 404
+
+
+class TestCanonicalOidcCallback:
+    """OIDC config should use the canonical /admin callback path."""
+
+    def test_get_tenant_redirect_uri_uses_admin_prefix(self):
+        from src.services.auth_config_service import get_tenant_redirect_uri
+
+        tenant = MagicMock()
+        tenant.virtual_host = None
+        tenant.subdomain = None
+
+        with patch.dict(os.environ, {"ADCP_SALES_PORT": "8080"}, clear=False):
+            redirect_uri = get_tenant_redirect_uri(tenant)
+
+        assert redirect_uri.endswith("/admin/auth/oidc/callback")

--- a/tests/unit/test_slack_notification_urls.py
+++ b/tests/unit/test_slack_notification_urls.py
@@ -49,7 +49,7 @@ class TestSlackNotificationUrls:
         assert actions_block is not None, "Should have actions block"
 
         url = actions_block["elements"][0]["url"]
-        assert url == "https://sales-agent.example.com/tenant/tenant_abc/workflows"
+        assert url == "https://sales-agent.example.com/admin/tenant/tenant_abc/workflows"
         assert "localhost" not in url, "Should not contain localhost"
 
     def test_notify_new_task_without_tenant_id(self, slack_notifier, mock_webhook_delivery):
@@ -97,7 +97,7 @@ class TestSlackNotificationUrls:
             actions_block = next((b for b in payload["attachments"][0]["blocks"] if b["type"] == "actions"), None)
 
         url = actions_block["elements"][0]["url"]
-        assert url == "https://sales-agent.example.com/tenant/tenant_abc/workflows#mb_123"
+        assert url == "https://sales-agent.example.com/admin/tenant/tenant_abc/workflows#mb_123"
         assert "localhost" not in url
 
     def test_notify_media_buy_event_with_tenant_only(self, slack_notifier, mock_webhook_delivery):
@@ -121,7 +121,7 @@ class TestSlackNotificationUrls:
         actions_block = next((b for b in payload["attachments"][0]["blocks"] if b["type"] == "actions"), None)
         url = actions_block["elements"][0]["url"]
 
-        assert url == "https://sales-agent.example.com/tenant/tenant_abc/workflows"
+        assert url == "https://sales-agent.example.com/admin/tenant/tenant_abc/workflows"
         assert "localhost" not in url
 
     def test_notify_media_buy_event_without_tenant_id(self, slack_notifier, mock_webhook_delivery):
@@ -164,7 +164,7 @@ class TestSlackNotificationUrls:
         actions_block = next((b for b in payload["blocks"] if b["type"] == "actions"), None)
         url = actions_block["elements"][0]["url"]
 
-        assert url == "https://sales-agent.example.com/tenant/tenant_abc/creatives/review#creative_123"
+        assert url == "https://sales-agent.example.com/admin/tenant/tenant_abc/creatives/review#creative_123"
         assert "localhost" not in url
 
     def test_localhost_fallback_when_env_not_set(self, slack_notifier, mock_webhook_delivery):
@@ -186,7 +186,7 @@ class TestSlackNotificationUrls:
         url = actions_block["elements"][0]["url"]
 
         # Should use localhost fallback in dev mode
-        assert url == "http://localhost:8001/tenant/tenant_abc/workflows"
+        assert url == "http://localhost:8001/admin/tenant/tenant_abc/workflows"
 
     def test_all_event_types_use_tenant_urls(self, slack_notifier, mock_webhook_delivery):
         """Test that all event types properly handle tenant-specific URLs."""


### PR DESCRIPTION
## Summary

Normalize the unified admin UI to a single canonical external path model.

This change makes `/admin/...` the only supported public admin URL space in the unified FastAPI deployment. It removes env-based prefix guessing, removes HTML response rewriting, updates admin link generation to use request-aware prefixes, and updates OIDC callback generation to `/admin/auth/oidc/callback`.

This PR does not add compatibility redirects. Legacy root-style admin entry URLs such as `/tenant/...`, `/login`, `/test/...`, and `/auth/...` are intentionally no longer treated as supported public admin paths in the unified app.

## What changed

### Routing
- mount the Flask admin app only at `/admin` in `src/app.py`
- remove duplicate-prefix admin mounts for `/tenant`, `/auth`, `/login`, `/logout`, `/signup`, `/test`, and related root aliases
- update admin landing redirect to `/admin/login`

### Prefix handling
- stop deriving `script_name` from `PRODUCTION`
- derive template prefixing from `request.script_root` / `SCRIPT_NAME` in `src/admin/app.py`
- remove the after-request HTML rewriting hook that tried to inject `/admin`

### Canonical callback generation
- change OIDC redirect URI generation to `/admin/auth/oidc/callback` in `src/services/auth_config_service.py`

### Admin URL generation cleanup
Updated audited templates and backend URL producers so they emit canonical admin-aware URLs instead of unsupported root-style admin paths.

Key areas updated:
- dashboard and settings pages
- setup checklist pages
- policy pages
- product inventory and order/browser pages
- workflow/media-buy pages
- setup checklist service URLs
- business activity service URLs
- Slack notification URLs
- tenant bootstrap `admin_ui_url`
- tenant landing/admin entry URL generation

## Files of interest

### Core routing / app behavior
- `src/app.py`
- `src/admin/app.py`
- `src/admin/blueprints/tenants.py`
- `src/services/auth_config_service.py`

### Backend URL generators
- `src/services/setup_checklist_service.py`
- `src/admin/services/business_activity_service.py`
- `src/services/slack_notifier.py`
- `src/landing/landing_page.py`
- `src/admin/tenant_management_api.py`

### Templates updated
- `templates/tenant_dashboard.html`
- `templates/tenant_settings.html`
- `templates/policy_settings.html`
- `templates/policy_settings_comprehensive.html`
- `templates/policy_rules.html`
- `templates/policy_review.html`
- `templates/setup_checklist.html`
- `templates/components/setup_checklist_widget.html`
- `templates/product_inventory_config.html`
- `templates/media_buy_approval.html`
- `templates/workflows.html`
- `templates/orders_browser.html`
- `templates/inventory_browser.html`
- `templates/inventory_unified.html`
- `templates/gam_line_item_viewer.html`
- `templates/components/inventory_picker.html`
- `templates/edit_product_mock.html`
- `templates/signup_complete.html`

## Tests updated

### Unified-app / canonical path coverage
- `tests/unit/test_fastapi_app_regression.py`
- `tests/ui/test_comprehensive_pages.py`
- `tests/integration/test_tenant_settings_comprehensive.py`
- `tests/e2e/test_landing_pages.py`

### Direct Flask app coverage
- `src/admin/tests/integration/test_admin_app.py`

### URL producer / notification coverage
- `tests/integration/test_notification_urls_exist.py`
- `tests/integration/test_setup_checklist_service.py`
- `tests/unit/test_slack_notification_urls.py`

## Verification

Completed:
- `python3 -m py_compile` on all touched Python files

Not completed in this environment:
- `make quality`
- `pytest`
- `tox -e integration`

I could not run the full suites here because the environment does not have the required runtime/test dependencies installed.

## Breaking change

This PR intentionally changes the public admin URL contract for the unified deployment.

Supported public admin URLs:
- `/admin/...`

No longer supported as canonical public admin URLs:
- `/tenant/...`
- `/auth/...`
- `/login`
- `/logout`
- `/signup`
- `/test/...`

Existing bookmarks and IdP callback configurations using root-style admin URLs will need to be updated.

## Issues

Closes #1105