### PR TITLE
fix: coerce AnyUrl to str before passing to yarl.URL() (#1106)

### DIFF
--- a/src/core/creative_agent_registry.py
+++ b/src/core/creative_agent_registry.py
@@ -173,7 +173,7 @@ class CreativeAgentRegistry:
         yarl handles: scheme/host lowercase, default port removal, percent-encoding.
         We additionally strip trailing slash so `/` and empty path are equivalent.
         """
-        return str(URL(agent_url)).rstrip("/")
+        return str(URL(str(agent_url))).rstrip("/")
 
     def _build_adcp_client(self, agents: list[CreativeAgent]) -> ADCPMultiAgentClient:
         """Build AdCP client from creative agent configs.

--- a/src/core/format_resolver.py
+++ b/src/core/format_resolver.py
@@ -44,8 +44,9 @@ def get_format(
     registry = get_creative_agent_registry()
 
     # If agent_url provided, get format directly from that agent
+    # Coerce to str: FormatId.agent_url is Pydantic AnyUrl (not a str subclass)
     if agent_url:
-        fmt = run_async_in_sync_context(registry.get_format(agent_url, format_id))
+        fmt = run_async_in_sync_context(registry.get_format(str(agent_url), format_id))
         if fmt:
             return fmt
     else:

--- a/tests/unit/test_creative_agent_registry.py
+++ b/tests/unit/test_creative_agent_registry.py
@@ -3,8 +3,48 @@
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from pydantic import AnyUrl
 
 from src.core.creative_agent_registry import CreativeAgent, CreativeAgentRegistry
+
+
+class TestCacheKeyAcceptsAnyUrl:
+    """Regression tests for #1106: _cache_key must accept Pydantic AnyUrl.
+
+    FormatId.agent_url is AnyUrl (not a str subclass in Pydantic v2).
+    When GAM line item creation resolves formats, the AnyUrl flows through
+    format_resolver → creative_agent_registry._cache_key → yarl.URL().
+    yarl.URL() rejects non-str input with TypeError.
+    """
+
+    def test_cache_key_accepts_pydantic_anyurl(self):
+        """_cache_key must not crash when given AnyUrl instead of str."""
+        registry = CreativeAgentRegistry()
+        agent_url = AnyUrl("https://creative.adcontextprotocol.org/")
+        result = registry._cache_key(agent_url)
+        assert result == "https://creative.adcontextprotocol.org"
+
+    def test_cache_key_normalizes_anyurl_same_as_str(self):
+        """AnyUrl and equivalent str must produce the same cache key."""
+        registry = CreativeAgentRegistry()
+        str_key = registry._cache_key("https://creative.adcontextprotocol.org/")
+        anyurl_key = registry._cache_key(AnyUrl("https://creative.adcontextprotocol.org/"))
+        assert str_key == anyurl_key
+
+    @pytest.mark.asyncio
+    async def test_get_format_accepts_anyurl_agent_url(self, monkeypatch):
+        """get_format must not crash when agent_url is AnyUrl (GAM line item path)."""
+        monkeypatch.delenv("ADCP_TESTING", raising=False)
+        registry = CreativeAgentRegistry()
+
+        # Patch _fetch to avoid real HTTP — we only test the cache_key path
+        async def mock_fetch(*args, **kwargs):
+            return []
+
+        monkeypatch.setattr(registry, "_fetch_formats_from_agent", mock_fetch)
+
+        result = await registry.get_format(AnyUrl("https://creative.adcontextprotocol.org/"), "display_300x250_image")
+        assert result is None  # Not found, but no TypeError
 
 
 class TestCreativeAgentRegistry:


### PR DESCRIPTION
## Summary

Fixes #1106 — GAM media buy approval fails with `Constructor parameter should be str`.

### Root Cause

`CreativeAgentRegistry._cache_key()` passes `agent_url` directly to `yarl.URL()`, which only accepts `str`. However, `FormatId.agent_url` from the adcp library is Pydantic's `AnyUrl`, which is **not** a `str` subclass in Pydantic v2. When GAM line item creation resolves creative formats, the `AnyUrl` object flows through:

1. `orders.py` — `format_id_obj.agent_url` (type: `AnyUrl`)
2. `format_resolver.py` — `get_format(agent_url=...)` passes it through
3. `creative_agent_registry.py` — `_cache_key()` → `yarl.URL(AnyUrl(...))` → **TypeError**

This was introduced in commit `6a74f62e` ("canonicalize creative agent cache keys with yarl") which assumed `agent_url` is always a plain `str`.

### Why Tests Missed It

`get_formats_for_agent()` short-circuits when `ADCP_TESTING=true` and returns mock formats **before** calling `_cache_key()`. The cache key code path was never exercised in CI.

### Fix

- `_cache_key()`: `URL(str(agent_url))` — coerce to `str` before passing to yarl
- `format_resolver.py`: `str(agent_url)` at the boundary — defense in depth

### Codebase Scan

Searched all `src/` for `yarl.URL()` usage — only one call site exists (`_cache_key`). The same `_cache_key` is called from two locations (`get_formats_for_agent` line 428, `list_all_formats` line 549), so the single fix covers all paths. Notably, `_build_adcp_client` at line 198 already uses `str(agent.agent_url)` — the pattern was known but not applied consistently.

## Test plan

- [x] 3 regression tests added to `tests/unit/test_creative_agent_registry.py::TestCacheKeyAcceptsAnyUrl`:
  - `test_cache_key_accepts_pydantic_anyurl` — direct crash reproduction
  - `test_cache_key_normalizes_anyurl_same_as_str` — AnyUrl and str produce identical cache keys
  - `test_get_format_accepts_anyurl_agent_url` — full path through `get_format()` with `AnyUrl`
- [x] All 3 tests fail before fix, pass after
- [x] `make quality`: 3820 passed (3 new vs baseline 3817)
- [x] Integration: 1210 passed (unchanged)
- [x] Integration v2: 543 passed (unchanged)
- [x] Zero regressions