### PR TITLE
fix: add missing AdCP spec fields and correct stale e2e assertions

### DIFF
--- a/src/core/schemas/_base.py
+++ b/src/core/schemas/_base.py
@@ -1616,6 +1616,12 @@ class UpdateMediaBuyRequest(LibraryUpdateMediaBuyRequest1):
     - packages: use our AdCPPackageUpdate (adds creative_ids)
     - budget: campaign-level budget (not in library — convenience field)
     - today: internal testing field
+
+    Spec fields missing from library codegen (accepted here for forward compatibility):
+    - revision: optimistic concurrency control
+    - canceled: irreversible cancellation flag
+    - cancellation_reason: reason for cancellation
+    - new_packages: mid-flight package additions
     """
 
     model_config = ConfigDict(extra=get_pydantic_extra_mode())
@@ -1630,6 +1636,11 @@ class UpdateMediaBuyRequest(LibraryUpdateMediaBuyRequest1):
     # Bare float is accepted so transport wrappers can preserve existing DB currency
     # when the caller updates only the amount.
     budget: Budget | float | None = None
+    # Spec fields missing from library codegen — accept for forward compatibility
+    revision: int | None = Field(None, description="Expected current revision for optimistic concurrency")
+    canceled: bool | None = Field(None, description="Cancel the media buy (irreversible)")
+    cancellation_reason: str | None = Field(None, description="Reason for cancellation", max_length=500)
+    new_packages: list[PackageRequest] | None = Field(None, description="New packages to add mid-flight")
     # Internal testing field
     today: date | None = Field(None, exclude=True, description="For testing/simulation only - not part of AdCP spec")
 

--- a/tests/e2e/test_a2a_protocol_compliance.py
+++ b/tests/e2e/test_a2a_protocol_compliance.py
@@ -44,8 +44,9 @@ class TestA2AProtocolCompliance:
             assert "packages" in schema["properties"], "AdCP schema should define 'packages' field"
             assert "updates" not in schema["properties"], "AdCP schema should NOT have legacy 'updates' field"
 
-            # Verify other required structure
-            assert "oneOf" in schema, "Schema should have oneOf constraint for media_buy_id/buyer_ref"
+            # Verify media_buy_id is required (spec uses required array, not oneOf)
+            assert "media_buy_id" in schema.get("properties", {}), "Schema should define media_buy_id"
+            assert "media_buy_id" in schema.get("required", []), "media_buy_id should be required"
 
     @pytest.mark.asyncio
     async def test_update_media_buy_schema_validates_correctly(self):
@@ -134,7 +135,7 @@ class TestA2AProtocolCompliance:
 
             # Verify expected fields from AdCP spec
             assert "media_buy_ids" in schema["properties"], "Should accept media_buy_ids (plural) per AdCP spec"
-            assert "buyer_refs" in schema["properties"], "Should accept buyer_refs for querying by buyer reference"
+            assert "status_filter" in schema["properties"], "Should accept status_filter for filtering by status"
 
             # Validate a minimal valid request
             valid_request = {"media_buy_ids": ["mb_1", "mb_2"]}


### PR DESCRIPTION
## Summary

- **Add 4 missing AdCP spec fields** to `UpdateMediaBuyRequest`: `revision`, `canceled`, `cancellation_reason`, `new_packages`. These are spec fields that the adcp library codegen hasn't caught up with yet — without them, clients sending spec-compliant requests get validation errors.
- **Fix 2 incorrect e2e test assertions** in `test_a2a_protocol_compliance.py`:
  - `test_update_media_buy_request_schema_structure` asserted `oneOf` exists in the schema — the actual spec uses a `required` array with `media_buy_id`, not `oneOf`
  - `test_get_media_buy_delivery_request_schema` asserted `buyer_refs` exists — this field is not in the AdCP spec

## Test plan

- [x] `make quality` — 4071 unit tests pass (0 failures)
- [x] `./run_all_tests.sh` — all 6,752 tests pass across 5 suites (unit, integration, e2e, admin, bdd)
- [x] Verified new fields work: `UpdateMediaBuyRequest(media_buy_id='x', revision=5, canceled=True, cancellation_reason='...', new_packages=[...])`
- [x] Verified assertions match live AdCP spec at adcontextprotocol.org