### PR TITLE
fix: add missing ext parameter to all MCP/A2A tool wrappers

### DIFF
--- a/src/core/schema_helpers.py
+++ b/src/core/schema_helpers.py
@@ -102,6 +102,7 @@ def create_get_products_request(
     filters: dict[str, Any] | ProductFilters | None = None,
     property_list: dict[str, Any] | PropertyListReference | None = None,
     context: dict[str, Any] | ContextObject | None = None,
+    ext: Any | None = None,
 ) -> GetProductsRequest:
     """Create GetProductsRequest aligned with adcp v3.6.0 spec.
 
@@ -136,6 +137,7 @@ def create_get_products_request(
         filters=filters_obj,
         property_list=to_property_list_reference(property_list),
         context=to_context_object(context),
+        ext=ext,
     )
 
 

--- a/src/core/schemas/_base.py
+++ b/src/core/schemas/_base.py
@@ -1141,6 +1141,7 @@ class UpdatePerformanceIndexRequest(SalesAgentBaseModel):
     context: ContextObject | None = Field(
         None, description="Application-level context provided by the client (echoed in responses)"
     )
+    ext: dict[str, Any] | None = Field(default=None, description="Extension object for custom fields")
 
 
 class UpdatePerformanceIndexResponse(SalesAgentBaseModel):
@@ -2099,6 +2100,7 @@ class ActivateSignalResponse(SalesAgentBaseModel):
     activation_details: dict[str, Any] | None = Field(None, description="Platform-specific activation details")
     errors: list[Error] | None = Field(None, description="Optional error reporting")
     context: ContextObject | None = Field(None, description="Application-level context echoed from the request")
+    ext: dict[str, Any] | None = Field(default=None, description="Extension object for custom fields")
 
     def __str__(self) -> str:
         """Return human-readable summary message for protocol envelope."""
@@ -2370,6 +2372,7 @@ class GetMediaBuysRequest(SalesAgentBaseModel):
     account_id: str | None = Field(default=None, description="Account to filter to (legacy, prefer account)")
     account: LibraryAccountReference | None = Field(default=None, description="Account reference (AdCP 3.x)")
     context: ContextObject | None = Field(default=None, description="Application-level context")
+    ext: dict[str, Any] | None = Field(default=None, description="Extension object for custom fields")
 
 
 class GetMediaBuysResponse(NestedModelSerializerMixin, SalesAgentBaseModel):

--- a/src/core/tools/accounts.py
+++ b/src/core/tools/accounts.py
@@ -180,6 +180,7 @@ async def list_accounts(
     pagination: PaginationRequest | None = None,
     sandbox: bool | None = None,
     context: ContextObject | None = None,
+    ext: Any | None = None,  # AdCP ExtensionObject for custom fields
     ctx: Context | ToolContext | None = None,
 ) -> Any:
     """List accounts accessible to the authenticated agent (MCP tool).
@@ -202,6 +203,7 @@ async def list_accounts(
         pagination=pagination,
         sandbox=sandbox,
         context=context,
+        ext=ext,
     )
 
     identity = (await ctx.get_state("identity")) if isinstance(ctx, Context) else None
@@ -653,6 +655,7 @@ async def sync_accounts(
     delete_missing: bool | None = None,
     dry_run: bool | None = None,
     context: ContextObject | None = None,
+    ext: Any | None = None,  # AdCP ExtensionObject for custom fields
     ctx: Context | ToolContext | None = None,
 ) -> Any:
     """Sync accounts by natural key (MCP tool).
@@ -675,6 +678,7 @@ async def sync_accounts(
         delete_missing=delete_missing,
         dry_run=dry_run,
         context=context,
+        ext=ext,
     )
     identity = (await ctx.get_state("identity")) if isinstance(ctx, Context) else None
     response = await _sync_accounts_impl(req, identity)

--- a/src/core/tools/capabilities.py
+++ b/src/core/tools/capabilities.py
@@ -8,6 +8,7 @@ This module follows the MCP/A2A shared implementation pattern from CLAUDE.md.
 
 import logging
 from datetime import UTC, datetime
+from typing import Any
 
 from adcp.types import GetAdcpCapabilitiesRequest, GetAdcpCapabilitiesResponse
 from adcp.types.generated_poc.core.media_buy_features import MediaBuyFeatures
@@ -243,6 +244,7 @@ def _get_adcp_capabilities_impl(
 
 async def get_adcp_capabilities(
     protocols: list[str] | None = None,
+    ext: Any | None = None,  # AdCP ExtensionObject for custom fields
     ctx: Context | None = None,
 ) -> ToolResult:
     """Get the capabilities of this AdCP sales agent.
@@ -259,7 +261,7 @@ async def get_adcp_capabilities(
     identity = (await ctx.get_state("identity")) if isinstance(ctx, Context) else None
 
     # Build request object (currently minimal)
-    req = GetAdcpCapabilitiesRequest()
+    req = GetAdcpCapabilitiesRequest(ext=ext)
 
     # Call shared implementation
     response = _get_adcp_capabilities_impl(req, identity)
@@ -287,6 +289,7 @@ async def get_adcp_capabilities(
 
 async def get_adcp_capabilities_raw(
     protocols: list[str] | None = None,
+    ext: Any | None = None,  # AdCP ExtensionObject for custom fields
     ctx: Context | ToolContext | None = None,
     identity: ResolvedIdentity | None = None,
 ) -> GetAdcpCapabilitiesResponse:
@@ -306,5 +309,5 @@ async def get_adcp_capabilities_raw(
         from src.core.transport_helpers import resolve_identity_from_context
 
         identity = resolve_identity_from_context(ctx, require_valid_token=False)
-    req = GetAdcpCapabilitiesRequest()
+    req = GetAdcpCapabilitiesRequest(ext=ext)
     return _get_adcp_capabilities_impl(req, identity)

--- a/src/core/tools/creative_formats.py
+++ b/src/core/tools/creative_formats.py
@@ -6,7 +6,7 @@ implementation pattern from CLAUDE.md.
 
 import logging
 import time
-from typing import TypeVar
+from typing import Any, TypeVar
 
 from adcp import FormatId
 from adcp.types import Format as AdcpFormat
@@ -452,6 +452,7 @@ async def list_creative_formats(
     min_height: int | None = None,
     max_height: int | None = None,
     context: ContextObject | None = None,  # Application level context per adcp spec
+    ext: Any | None = None,  # AdCP ExtensionObject for custom fields
     ctx: Context | ToolContext | None = None,
 ):
     """List all available creative formats (AdCP spec endpoint).
@@ -493,6 +494,7 @@ async def list_creative_formats(
             min_height=min_height,
             max_height=max_height,
             context=context,
+            ext=ext,
         )
     except ValidationError as e:
         raise AdCPValidationError(format_validation_error(e, context="list_creative_formats request")) from e

--- a/src/core/tools/creatives/_sync.py
+++ b/src/core/tools/creatives/_sync.py
@@ -35,6 +35,7 @@ def _sync_creatives_impl(
     validation_mode: str = "strict",
     push_notification_config: PushNotificationConfig | dict | None = None,
     context: ContextObject | dict | None = None,
+    ext: Any | None = None,  # AdCP ExtensionObject for custom fields
     identity: ResolvedIdentity | None = None,
 ) -> SyncCreativesResponse:
     """Sync creative assets to centralized library (AdCP v2.5 spec compliant endpoint).

--- a/src/core/tools/creatives/listing.py
+++ b/src/core/tools/creatives/listing.py
@@ -55,6 +55,7 @@ def _list_creatives_impl(
     sort_by: str = "created_date",
     sort_order: str = "desc",
     context: ContextObject | None = None,  # Application level context per adcp spec
+    ext: Any | None = None,  # AdCP ExtensionObject for custom fields
     identity: ResolvedIdentity | None = None,
 ) -> ListCreativesResponse:
     """List and search creative library (AdCP v2.5 spec endpoint).
@@ -410,6 +411,7 @@ async def list_creatives(
     sort_order: str = "desc",
     webhook_url: str | None = None,
     context: ContextObject | None = None,  # Application level context per adcp spec
+    ext: Any | None = None,  # AdCP ExtensionObject for custom fields
     ctx: Context | ToolContext | None = None,
 ):
     """List and filter creative assets from the centralized library (AdCP v2.5).
@@ -454,6 +456,7 @@ async def list_creatives(
         sort_by=sort_by,
         sort_order=sort_order,
         context=context,
+        ext=ext,
         identity=identity,
     )
     return ToolResult(content=str(response), structured_content=response)
@@ -480,6 +483,7 @@ def list_creatives_raw(
     sort_by: str = "created_date",
     sort_order: str = "desc",
     context: dict | None = None,  # Application level context per adcp spec
+    ext: Any | None = None,  # AdCP ExtensionObject for custom fields
     ctx: Context | ToolContext | None = None,
     identity: ResolvedIdentity | None = None,
 ):
@@ -540,5 +544,6 @@ def list_creatives_raw(
         sort_by=sort_by,
         sort_order=sort_order,
         context=to_context_object(context),
+        ext=ext,
         identity=identity,
     )

--- a/src/core/tools/creatives/sync_wrappers.py
+++ b/src/core/tools/creatives/sync_wrappers.py
@@ -1,5 +1,7 @@
 """MCP and A2A wrapper functions for sync_creatives."""
 
+from typing import Any
+
 from adcp import PushNotificationConfig
 from adcp.types import AccountReference as LibraryAccountReference
 from adcp.types.generated_poc.core.context import ContextObject
@@ -23,6 +25,7 @@ async def sync_creatives(
     validation_mode: ValidationMode | None = None,
     push_notification_config: PushNotificationConfig | None = None,
     context: ContextObject | None = None,  # Application level context per adcp spec
+    ext: Any | None = None,  # AdCP ExtensionObject for custom fields
     account: LibraryAccountReference | None = None,
     ctx: Context | ToolContext | None = None,
 ):
@@ -64,6 +67,7 @@ async def sync_creatives(
         validation_mode=validation_mode_str,
         push_notification_config=push_notification_config,
         context=context,
+        ext=ext,
         identity=identity,
     )
     return ToolResult(content=str(response), structured_content=response)
@@ -78,6 +82,7 @@ def sync_creatives_raw(
     validation_mode: str = "strict",
     push_notification_config: PushNotificationConfig | None = None,
     context: ContextObject | None = None,
+    ext: Any | None = None,  # AdCP ExtensionObject for custom fields
     account: LibraryAccountReference | None = None,
     ctx: Context | ToolContext | None = None,
     identity: ResolvedIdentity | None = None,
@@ -120,5 +125,6 @@ def sync_creatives_raw(
         validation_mode=validation_mode,
         push_notification_config=push_notification_config,
         context=context,
+        ext=ext,
         identity=identity,
     )

--- a/src/core/tools/media_buy_delivery.py
+++ b/src/core/tools/media_buy_delivery.py
@@ -595,6 +595,7 @@ async def get_media_buy_delivery(
     include_package_daily_breakdown: bool | None = None,
     account: dict[str, Any] | None = None,
     context: ContextObject | None = None,
+    ext: Any | None = None,  # AdCP ExtensionObject for custom fields
     ctx: Context | ToolContext | None = None,
 ):
     """Get delivery data for media buys.
@@ -640,6 +641,7 @@ async def get_media_buy_delivery(
             attribution_window=attribution_window,
             include_package_daily_breakdown=include_package_daily_breakdown,
             context=cast(ContextObject | None, context),
+            ext=ext,
         )
 
         response = _get_media_buy_delivery_impl(req, identity)
@@ -660,6 +662,7 @@ def get_media_buy_delivery_raw(
     include_package_daily_breakdown: bool | None = None,
     account: dict[str, Any] | None = None,
     context: ContextObject | None = None,
+    ext: Any | None = None,  # AdCP ExtensionObject for custom fields
     ctx: Context | ToolContext | None = None,
     identity: ResolvedIdentity | None = None,
 ):
@@ -707,6 +710,7 @@ def get_media_buy_delivery_raw(
         attribution_window=attribution_window,
         include_package_daily_breakdown=include_package_daily_breakdown,
         context=cast(ContextObject | None, context),
+        ext=ext,
     )
 
     # Call the implementation

--- a/src/core/tools/media_buy_list.py
+++ b/src/core/tools/media_buy_list.py
@@ -223,6 +223,7 @@ async def get_media_buys(
     include_snapshot: bool = False,
     account: dict | None = None,
     context: ContextObject | None = None,
+    ext: Any | None = None,  # AdCP ExtensionObject for custom fields
     ctx: Context | ToolContext | None = None,
 ):
     """Get media buys with status, creative approval state, and optional delivery snapshots.
@@ -248,6 +249,7 @@ async def get_media_buys(
             status_filter=cast(MediaBuyStatus | list[MediaBuyStatus] | None, status_filter),
             account=account,
             context=cast(ContextObject | None, context),
+            ext=ext,
         )
         # Read identity pre-resolved by MCPAuthMiddleware
         identity = (await ctx.get_state("identity")) if isinstance(ctx, Context) else None
@@ -264,6 +266,7 @@ def get_media_buys_raw(
     include_snapshot: bool = False,
     account: dict | None = None,
     context: ContextObject | None = None,
+    ext: Any | None = None,  # AdCP ExtensionObject for custom fields
     ctx: Context | ToolContext | None = None,
     identity: ResolvedIdentity | None = None,
 ):
@@ -293,6 +296,7 @@ def get_media_buys_raw(
         status_filter=cast(MediaBuyStatus | list[MediaBuyStatus] | None, status_filter),
         account=account,
         context=cast(ContextObject | None, context),
+        ext=ext,
     )
     return _get_media_buys_impl(req, identity=identity, include_snapshot=include_snapshot)
 

--- a/src/core/tools/performance.py
+++ b/src/core/tools/performance.py
@@ -31,6 +31,7 @@ def _update_performance_index_impl(
     media_buy_id: str,
     performance_data: list[dict[str, Any]],
     context: ContextObject | None = None,
+    ext: Any | None = None,  # AdCP ExtensionObject for custom fields
     identity: ResolvedIdentity | None = None,
 ) -> UpdatePerformanceIndexResponse:
     """Shared implementation for update_performance_index (used by both MCP and A2A).
@@ -51,7 +52,7 @@ def _update_performance_index_impl(
     try:
         performance_objects = [ProductPerformance(**perf) for perf in performance_data]
         req = UpdatePerformanceIndexRequest(
-            media_buy_id=media_buy_id, performance_data=performance_objects, context=context
+            media_buy_id=media_buy_id, performance_data=performance_objects, context=context, ext=ext
         )
     except ValidationError as e:
         raise AdCPValidationError(format_validation_error(e, context="update_performance_index request")) from e
@@ -132,6 +133,7 @@ async def update_performance_index(
     performance_data: list[dict[str, Any]],
     webhook_url: str | None = None,
     context: ContextObject | None = None,
+    ext: Any | None = None,  # AdCP ExtensionObject for custom fields
     ctx: Context | ToolContext | None = None,
 ):
     """Update performance index data for a media buy.
@@ -149,7 +151,7 @@ async def update_performance_index(
         ToolResult with UpdatePerformanceIndexResponse data
     """
     identity = (await ctx.get_state("identity")) if isinstance(ctx, Context) else None
-    response = _update_performance_index_impl(media_buy_id, performance_data, context, identity)
+    response = _update_performance_index_impl(media_buy_id, performance_data, context, ext, identity)
     return ToolResult(content=str(response), structured_content=response)
 
 
@@ -157,6 +159,7 @@ def update_performance_index_raw(
     media_buy_id: str,
     performance_data: list[dict[str, Any]],
     context: ContextObject | None = None,
+    ext: Any | None = None,  # AdCP ExtensionObject for custom fields
     ctx: Context | ToolContext | None = None,
     identity: ResolvedIdentity | None = None,
 ):
@@ -177,7 +180,7 @@ def update_performance_index_raw(
         from src.core.transport_helpers import resolve_identity_from_context
 
         identity = resolve_identity_from_context(ctx, require_valid_token=True)
-    return _update_performance_index_impl(media_buy_id, performance_data, context, identity)
+    return _update_performance_index_impl(media_buy_id, performance_data, context, ext, identity)
 
 
 # --- Human-in-the-Loop Task Queue Tools ---

--- a/src/core/tools/products.py
+++ b/src/core/tools/products.py
@@ -814,6 +814,7 @@ async def get_products(
     property_list: dict | None = None,
     push_notification_config: PushNotificationConfig | None = None,
     context: ContextObject | None = None,  # payload-level context
+    ext: Any | None = None,  # AdCP ExtensionObject for custom fields
     ctx: Context | ToolContext | None = None,
 ):
     """Get available products matching the brief.
@@ -841,6 +842,7 @@ async def get_products(
             filters=filters,
             property_list=property_list,
             context=context,
+            ext=ext,
         )
 
     except ValidationError as e:
@@ -873,6 +875,7 @@ async def get_products_raw(
     property_list: dict | None = None,
     strategy_id: str | None = None,
     context: dict | None = None,  # Application level context per adcp spec
+    ext: Any | None = None,  # AdCP ExtensionObject for custom fields
     ctx: Context | ToolContext | None = None,
     identity: ResolvedIdentity | None = None,
 ) -> GetProductsResponse:
@@ -910,6 +913,7 @@ async def get_products_raw(
         filters=filters,
         property_list=property_list,
         context=context,
+        ext=ext,
     )
 
     # Call shared implementation

--- a/src/core/tools/properties.py
+++ b/src/core/tools/properties.py
@@ -202,6 +202,7 @@ async def list_authorized_properties(
     property_tags: list[str] | None = None,
     webhook_url: str | None = None,
     context: ContextObject | None = None,
+    ext: Any | None = None,  # AdCP ExtensionObject for custom fields
     ctx: Context | ToolContext | None = None,
 ):
     """List all properties this agent is authorized to represent (AdCP spec endpoint).
@@ -223,6 +224,7 @@ async def list_authorized_properties(
         publisher_domains=publisher_domains,
         property_tags=property_tags,
         context=context,
+        ext=ext,
     )
     identity = (await ctx.get_state("identity")) if isinstance(ctx, Context) else None
     response = _list_authorized_properties_impl(req, identity)

--- a/src/core/tools/signals.py
+++ b/src/core/tools/signals.py
@@ -7,6 +7,7 @@ implementation pattern from CLAUDE.md.
 import logging
 import time
 import uuid
+from typing import Any
 
 from fastmcp.server.context import Context
 from fastmcp.tools.tool import ToolResult
@@ -195,6 +196,7 @@ async def _activate_signal_impl(
     campaign_id: str = None,
     media_buy_id: str = None,
     context: dict | None = None,  # payload-level context
+    ext: Any | None = None,  # AdCP ExtensionObject for custom fields
     identity: ResolvedIdentity | None = None,
 ) -> ActivateSignalResponse:
     """Shared implementation for activate_signal (used by both MCP and A2A).
@@ -297,6 +299,7 @@ async def activate_signal(
     campaign_id: str = None,
     media_buy_id: str = None,
     context: dict | None = None,  # payload-level context
+    ext: Any | None = None,  # AdCP ExtensionObject for custom fields
     ctx: Context | ToolContext | None = None,
 ):
     """Activate a signal for use in campaigns.
@@ -316,7 +319,7 @@ async def activate_signal(
     from src.core.transport_helpers import resolve_identity_from_context
 
     identity = resolve_identity_from_context(ctx)
-    response = await _activate_signal_impl(signal_agent_segment_id, campaign_id, media_buy_id, context, identity)
+    response = await _activate_signal_impl(signal_agent_segment_id, campaign_id, media_buy_id, context, ext, identity)
     return ToolResult(content=str(response), structured_content=response)
 
 
@@ -349,6 +352,7 @@ async def activate_signal_raw(
     campaign_id: str = None,
     media_buy_id: str = None,
     context: dict | None = None,  # payload-level context
+    ext: Any | None = None,  # AdCP ExtensionObject for custom fields
     ctx: Context | ToolContext | None = None,
     identity: ResolvedIdentity | None = None,
 ) -> ActivateSignalResponse:
@@ -371,4 +375,4 @@ async def activate_signal_raw(
         from src.core.transport_helpers import resolve_identity_from_context
 
         identity = resolve_identity_from_context(ctx)
-    return await _activate_signal_impl(signal_agent_segment_id, campaign_id, media_buy_id, context, identity)
+    return await _activate_signal_impl(signal_agent_segment_id, campaign_id, media_buy_id, context, ext, identity)

--- a/tests/unit/test_architecture_no_model_dump_in_impl.py
+++ b/tests/unit/test_architecture_no_model_dump_in_impl.py
@@ -53,7 +53,7 @@ KNOWN_VIOLATIONS = {
     # _get_products_impl: 1 violation (logging)
     ("products.py", 637),
     # _list_creatives_impl: 1 violation (filter dict conversion)
-    ("creatives/listing.py", 153),  # filters.model_dump(exclude_none=True)
+    ("creatives/listing.py", 154),  # filters.model_dump(exclude_none=True)
 }
 
 

--- a/tests/unit/test_raw_function_parameter_validation.py
+++ b/tests/unit/test_raw_function_parameter_validation.py
@@ -127,7 +127,7 @@ class TestRawFunctionParameterValidation:
 
         # adcp 3.6.0: brand_manifest removed, only brand (BrandReference) remains.
         # Note: promoted_offering removed per adcp v1.2.1 migration
-        expected_params = ["brief", "brand", "filters", "property_list", "context"]
+        expected_params = ["brief", "brand", "filters", "property_list", "context", "ext"]
 
         assert params == expected_params, (
             f"create_get_products_request signature changed!\n"
@@ -196,7 +196,7 @@ class TestHelperFunctionDocumentation:
         # Verify create_get_products_request (the one that caused the bug)
         assert "create_get_products_request" in signatures
         # adcp 3.6.0: brand_manifest removed, only brand (BrandReference) remains.
-        expected = ["brief", "brand", "filters", "property_list", "context"]
+        expected = ["brief", "brand", "filters", "property_list", "context", "ext"]
         actual = signatures["create_get_products_request"]
         assert actual == expected, (
             f"create_get_products_request signature changed!\n"


### PR DESCRIPTION
## Summary
- Add `ext: Any | None = None` parameter to all MCP tool wrappers and A2A raw functions that were missing it — the AdCP spec defines `ext` (ExtensionObject) on all request/response types, but only `create_media_buy` and `update_media_buy` exposed it
- Add `ext` field to 3 local schemas that didn't inherit it from the library (`GetMediaBuysRequest`, `UpdatePerformanceIndexRequest`, `ActivateSignalResponse`)
- Add `ext` to `create_get_products_request` helper in `schema_helpers.py`
- Update test expectations for new parameter signatures

## Problem
Callers passing `ext` to any tool other than `create_media_buy`/`update_media_buy` received:
```
1 validation error for call[get_products]
ext
  Unexpected keyword argument [type=unexpected_keyword_argument, ...]
```

## Spec reference
- https://adcontextprotocol.org/schemas/v3/media-buy/get-products-request.json

## Test plan
- [x] `make quality` passes (4228 unit tests, ruff format, ruff lint, mypy)
- [x] All architecture guards pass (boundary completeness, type alignment, model_dump restrictions)
- [x] MCP/A2A parameter alignment test passes
- [ ] Integration tests with `ext` payloads on affected endpoints

Closes #1193