### PR TITLE
fix: add required reporting_capabilities to get-products E2E fixture

### DIFF
--- a/tests/e2e/test_schema_validation_standalone.py
+++ b/tests/e2e/test_schema_validation_standalone.py
@@ -65,6 +65,14 @@ async def test_valid_get_products_response():
                             "min_spend_per_package": 1000.0,
                         }
                     ],
+                    "reporting_capabilities": {
+                        "available_reporting_frequencies": ["daily"],
+                        "expected_delay_minutes": 240,
+                        "timezone": "UTC",
+                        "supports_webhooks": False,
+                        "available_metrics": ["impressions", "spend", "clicks"],
+                        "date_range_support": "date_range",
+                    },
                 }
             ],
         }


### PR DESCRIPTION
## Summary
- E2E `test_valid_get_products_response` has been failing on every PR because the hardcoded valid-response fixture predated the AdCP spec requiring `reporting_capabilities` on each product
- Added a minimal valid `reporting_capabilities` object with all 6 required inner fields

## Root cause
The AdCP schema at `/schemas/latest/core/product.json` now lists `reporting_capabilities` as required. The test builds a local fixture (no server involved) and validates against the live spec — the fixture was out of date.

## Test plan
- [x] `uv run pytest tests/e2e/test_schema_validation_standalone.py -v` — 7 passed
- [ ] Full E2E job on CI