### PR TITLE
fix: error-handling cleanup — data loss bugs, silent catches, structural guard (#1078)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "flask>=3.1.3",
     "flask-caching>=2.3.0", # Response caching for improved performance
     "psycopg2-binary>=2.9.9",
-    "authlib>=1.6.7",
+    "authlib>=1.6.11",
     "requests-oauthlib>=1.3.1",
     "fastapi>=0.100.0",
     "uvicorn>=0.23.0",
@@ -109,6 +109,7 @@ dev = [
     "pytest-bdd>=7.0.0",
     # Security patches for transitive dev dependencies
     "black>=26.3.1",  # GHSA-3936-cmfr-pm3m
+    "types-python-dateutil>=2.9.0.20260408",
 ]
 
 [tool.black]

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -607,7 +607,7 @@ class AdCPRequestHandler(RequestHandler):
                             if response_obj and hasattr(response_obj, "__str__"):
                                 text_message = str(response_obj)
                         except Exception:
-                            pass  # If reconstruction fails, skip text part
+                            logger.debug("Response reconstruction failed, skipping text part", exc_info=True)
 
                     # Build parts list per A2A spec: optional TextPart + required DataPart
                     parts = []

--- a/src/adapters/gam_orders_discovery.py
+++ b/src/adapters/gam_orders_discovery.py
@@ -541,12 +541,11 @@ class GAMOrdersDiscovery:
                         self.orders[order.order_id] = order
                         discovered_orders.append(order)
                     except Exception as e:
-                        order_id = "unknown"
-                        try:
-                            order_id = str(getattr(gam_order, "id", "unknown"))
-                        except Exception:
-                            pass
-                        logger.error(f"Error processing order {order_id}: {e}")
+                        order_id = str(getattr(gam_order, "id", "unknown"))
+                        logger.error(
+                            f"Error processing order {order_id}: {e}",
+                            exc_info=True,
+                        )
                         continue
 
                 statement_builder.offset += len(response["results"])
@@ -597,12 +596,11 @@ class GAMOrdersDiscovery:
                         self.line_items[line_item.line_item_id] = line_item
                         discovered_line_items.append(line_item)
                     except Exception as e:
-                        li_id = "unknown"
-                        try:
-                            li_id = str(getattr(gam_line_item, "id", "unknown"))
-                        except Exception:
-                            pass
-                        logger.error(f"Error processing line item {li_id}: {e}")
+                        li_id = str(getattr(gam_line_item, "id", "unknown"))
+                        logger.error(
+                            f"Error processing line item {li_id}: {e}",
+                            exc_info=True,
+                        )
                         continue
 
                 statement_builder.offset += len(response["results"])

--- a/src/adapters/gam_reporting_service.py
+++ b/src/adapters/gam_reporting_service.py
@@ -442,9 +442,13 @@ class GAMReportingService:
                     # Use as-is
                     normalized_row[key] = value
 
-            # Skip rows with zero impressions to reduce data volume
+            # Skip rows where ALL metrics are zero to reduce data volume.
+            # Do NOT skip zero-impression rows that have clicks or revenue —
+            # FLAT_RATE/SPONSORSHIP line items accrue spend without impressions.
             impressions = int(normalized_row.get("AD_SERVER_IMPRESSIONS", 0) or 0)
-            if impressions == 0:
+            clicks = int(normalized_row.get("AD_SERVER_CLICKS", 0) or 0)
+            revenue = float(normalized_row.get("AD_SERVER_CPM_AND_CPC_REVENUE", 0) or 0)
+            if impressions == 0 and clicks == 0 and revenue == 0:
                 continue
 
             # Build aggregation key from dimensions

--- a/src/adapters/google_ad_manager.py
+++ b/src/adapters/google_ad_manager.py
@@ -1150,7 +1150,7 @@ class GoogleAdManager(AdServerAdapter):
                     elif len(date_str) == 10 and date_str[4] == "-" and date_str[7] == "-":
                         pass  # Already in correct format
                 except Exception:
-                    # If parsing fails, skip this row
+                    logger.warning("Failed to parse date '%s', skipping row", date_str, exc_info=True)
                     continue
 
                 if date_str not in daily_metrics:

--- a/src/adapters/google_ad_manager.py
+++ b/src/adapters/google_ad_manager.py
@@ -1136,21 +1136,15 @@ class GoogleAdManager(AdServerAdapter):
             # Extract date from the row (reporting service uses DATE dimension)
             date_str = row.get("date", row.get("DATE", ""))
             if date_str:
-                # Ensure date format is YYYY-MM-DD
+                # Normalize to YYYY-MM-DD using dateutil (handles any format)
                 if not isinstance(date_str, str):
                     date_str = str(date_str)
-
-                # Parse and reformat if needed (handle various date formats)
                 try:
-                    # Try parsing ISO format first
-                    if "T" in date_str:
-                        date_obj = datetime.fromisoformat(date_str.split("T")[0])
-                        date_str = date_obj.strftime("%Y-%m-%d")
-                    # Handle YYYY-MM-DD format (already correct)
-                    elif len(date_str) == 10 and date_str[4] == "-" and date_str[7] == "-":
-                        pass  # Already in correct format
-                except Exception:
-                    logger.warning("Failed to parse date '%s', skipping row", date_str, exc_info=True)
+                    from dateutil import parser as dateutil_parser  # type: ignore[import-untyped]
+
+                    date_str = dateutil_parser.parse(date_str).strftime("%Y-%m-%d")
+                except (ValueError, OverflowError) as e:
+                    logger.warning("Unparseable date '%s' in reporting row, skipping: %s", date_str, e)
                     continue
 
                 if date_str not in daily_metrics:

--- a/src/adapters/google_ad_manager.py
+++ b/src/adapters/google_ad_manager.py
@@ -1140,7 +1140,7 @@ class GoogleAdManager(AdServerAdapter):
                 if not isinstance(date_str, str):
                     date_str = str(date_str)
                 try:
-                    from dateutil import parser as dateutil_parser  # type: ignore[import-untyped]
+                    from dateutil import parser as dateutil_parser
 
                     date_str = dateutil_parser.parse(date_str).strftime("%Y-%m-%d")
                 except (ValueError, OverflowError) as e:

--- a/src/adapters/mock_ad_server.py
+++ b/src/adapters/mock_ad_server.py
@@ -1400,7 +1400,7 @@ class MockAdServer(AdServerAdapter):
                         # Handle format selection
                         formats = request.form.getlist("formats")
                         if formats:
-                            product_obj.formats = formats
+                            product_obj.format_ids = formats
 
                         # Validate the configuration
                         validation_errors = self.validate_product_config(new_config)
@@ -1416,7 +1416,7 @@ class MockAdServer(AdServerAdapter):
                                 product=product,
                                 config=config,
                                 formats=available_formats,
-                                selected_formats=product_obj.formats or [],
+                                selected_formats=product_obj.format_ids or [],
                                 error=validation_errors[0],
                             )
 
@@ -1435,7 +1435,7 @@ class MockAdServer(AdServerAdapter):
                             product=product,
                             config=new_config,
                             formats=available_formats,
-                            selected_formats=product_obj.formats or [],
+                            selected_formats=product_obj.format_ids or [],
                             success=True,
                         )
 
@@ -1450,7 +1450,7 @@ class MockAdServer(AdServerAdapter):
                         product=product,
                         config=config,
                         formats=available_formats,
-                        selected_formats=product_obj.formats or [],
+                        selected_formats=product_obj.format_ids or [],
                     )
 
             return wrapped_view()

--- a/src/adapters/mock_ad_server.py
+++ b/src/adapters/mock_ad_server.py
@@ -1,6 +1,9 @@
+import logging
 import random
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from src.core.schemas import Snapshot
@@ -684,7 +687,7 @@ class MockAdServer(AdServerAdapter):
                         tenant_gemini_key = tenant_obj.gemini_api_key
         except Exception:
             # Database not available (e.g., in unit tests) - use default template
-            pass
+            logger.debug("Could not load tenant config from DB, using defaults", exc_info=True)
 
         # Build context and apply template
         context = build_order_name_context(request, packages, start_time, end_time, tenant_gemini_key=tenant_gemini_key)

--- a/src/adapters/xandr.py
+++ b/src/adapters/xandr.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import requests
+from dateutil import parser as dateutil_parser  # type: ignore[import-untyped]
 
 from src.adapters.base import AdServerAdapter
 from src.core.retry_utils import api_retry
@@ -664,8 +665,8 @@ class XandrAdapter(AdServerAdapter):
                 package_statuses=package_statuses,
                 total_budget=total_budget,
                 total_spent=spent,
-                start_date=datetime.fromisoformat(io["start_date"]),
-                end_date=datetime.fromisoformat(io["end_date"]),
+                start_date=dateutil_parser.parse(io["start_date"]),
+                end_date=dateutil_parser.parse(io["end_date"]),
                 approval_status="approved" if io["state"] == "active" else "pending",
             )
 
@@ -808,7 +809,7 @@ class XandrAdapter(AdServerAdapter):
                 if "budget" in package_update:
                     li["lifetime_budget"] = float(package_update["budget"])
                     # Recalculate daily budget
-                    days = (datetime.fromisoformat(li["end_date"]) - datetime.fromisoformat(li["start_date"])).days
+                    days = (dateutil_parser.parse(li["end_date"]) - dateutil_parser.parse(li["start_date"])).days
                     li["daily_budget"] = float(package_update["budget"]) / days if days > 0 else 0
 
                 if "impressions" in package_update:

--- a/src/adapters/xandr.py
+++ b/src/adapters/xandr.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import requests
-from dateutil import parser as dateutil_parser  # type: ignore[import-untyped]
+from dateutil import parser as dateutil_parser
 
 from src.adapters.base import AdServerAdapter
 from src.core.retry_utils import api_retry

--- a/src/admin/blueprints/policy.py
+++ b/src/admin/blueprints/policy.py
@@ -125,7 +125,7 @@ def index(tenant_id):
                 )
         except Exception:
             # WorkflowStep table might not exist in fresh databases
-            pass
+            logger.debug("Could not load workflow steps (table may not exist)", exc_info=True)
 
     return render_template(
         "policy_settings_comprehensive.html",

--- a/src/admin/blueprints/products.py
+++ b/src/admin/blueprints/products.py
@@ -1235,7 +1235,8 @@ def add_product(tenant_id):
                         try:
                             product_kwargs["variant_ttl_days"] = int(variant_ttl_days)
                         except ValueError:
-                            pass  # Leave as None if invalid
+                            flash(f"Invalid variant TTL days: '{variant_ttl_days}' is not a number", "error")
+                            return _render_add_product_form(tenant_id, form_data=form_data)
 
                 # Create product with correct fields matching the Product model
                 product = Product(**product_kwargs)

--- a/src/admin/blueprints/products.py
+++ b/src/admin/blueprints/products.py
@@ -2184,7 +2184,7 @@ def delete_product(tenant_id, product_id):
         try:
             db_session.rollback()
         except Exception:
-            pass
+            logger.debug("Rollback failed during error handling", exc_info=True)
 
         # More specific error handling
         error_message = str(e)

--- a/src/admin/blueprints/tenants.py
+++ b/src/admin/blueprints/tenants.py
@@ -49,7 +49,7 @@ def get_available_currencies():
             if name:  # Skip if no English name available
                 currencies.append({"code": code, "name": name})
         except Exception:
-            # Skip currencies that can't be resolved
+            logger.debug("Could not resolve currency %s", code, exc_info=True)
             continue
 
     return currencies

--- a/src/admin/sync_api.py
+++ b/src/admin/sync_api.py
@@ -184,7 +184,7 @@ def trigger_sync(tenant_id: str) -> tuple[Response, int]:
                 sync_job.error_message = str(e)
                 db_session.commit()
             except Exception:
-                pass  # Ignore secondary errors in error handling
+                logger.warning("Failed to update sync_job error record", exc_info=True)
 
             return jsonify({"sync_id": sync_id, "status": "failed", "error": str(e)}), 500
 

--- a/src/core/audit_logger.py
+++ b/src/core/audit_logger.py
@@ -241,7 +241,7 @@ class AuditLogger:
                 )
         except Exception:
             # Don't let Slack failures affect core functionality
-            pass
+            audit_logger.warning("Slack audit notification failed", exc_info=True)
 
     def log_security_violation(
         self, operation: str, principal_id: str, resource_id: str, reason: str, tenant_id: str | None = None
@@ -314,7 +314,7 @@ class AuditLogger:
             )
         except Exception:
             # Don't let Slack failures affect core functionality
-            pass
+            audit_logger.warning("Slack security violation notification failed", exc_info=True)
 
     def log_success(self, message: str):
         """Log a success message with checkmark."""

--- a/src/core/audit_logger.py
+++ b/src/core/audit_logger.py
@@ -146,7 +146,7 @@ class AuditLogger:
                         if tenant:
                             tenant_name = tenant.name
                 except Exception:
-                    pass
+                    audit_logger.debug("Could not load tenant name for Slack context", exc_info=True)
 
             # Send notification based on criteria
             should_notify = False
@@ -226,7 +226,7 @@ class AuditLogger:
                             if tenant:
                                 tenant_config = serialize_tenant_to_dict(tenant)
                     except Exception:
-                        pass
+                        audit_logger.debug("Could not load tenant config for Slack context", exc_info=True)
 
                 slack_notifier = get_slack_notifier(tenant_config=tenant_config)
                 slack_notifier.notify_audit_log(
@@ -299,7 +299,7 @@ class AuditLogger:
                             tenant_name = tenant.name
                             tenant_config = serialize_tenant_to_dict(tenant)
                 except Exception:
-                    pass
+                    audit_logger.debug("Could not load tenant for security violation Slack context", exc_info=True)
 
             slack_notifier = get_slack_notifier(tenant_config=tenant_config)
             slack_notifier.notify_audit_log(

--- a/src/core/auth.py
+++ b/src/core/auth.py
@@ -99,7 +99,7 @@ def get_principal_from_context(
     try:
         headers = get_http_headers(include_all=True)
     except Exception:
-        pass  # Will try fallback below
+        logger.debug("get_http_headers() unavailable, trying fallback", exc_info=True)
 
     # If get_http_headers() returned empty dict or None, try context.meta fallback
     # This is necessary for sync tools where get_http_headers() may not work

--- a/src/core/database/models.py
+++ b/src/core/database/models.py
@@ -174,9 +174,10 @@ class Tenant(Base, JSONValidatorMixin):
 
         try:
             return decrypt_api_key(self._gemini_api_key)
-        except ValueError:
-            logger.warning(f"Failed to decrypt Gemini API key for tenant {self.tenant_id}")
-            return None
+        except ValueError as exc:
+            from src.core.exceptions import AdCPConfigurationError
+
+            raise AdCPConfigurationError(f"Failed to decrypt Gemini API key for tenant {self.tenant_id}") from exc
 
     @gemini_api_key.setter
     def gemini_api_key(self, value: str | None) -> None:
@@ -638,7 +639,12 @@ class TenantAuthConfig(Base):
             return None
         from src.core.utils.encryption import decrypt_api_key
 
-        return decrypt_api_key(self.oidc_client_secret_encrypted)
+        try:
+            return decrypt_api_key(self.oidc_client_secret_encrypted)
+        except ValueError as exc:
+            from src.core.exceptions import AdCPConfigurationError
+
+            raise AdCPConfigurationError(f"Failed to decrypt OIDC client secret for tenant {self.tenant_id}") from exc
 
     @oidc_client_secret.setter
     def oidc_client_secret(self, value: str | None) -> None:
@@ -1187,9 +1193,12 @@ class AdapterConfig(Base):
 
         try:
             return decrypt_api_key(self._gam_service_account_json)
-        except ValueError:
-            logger.warning(f"Failed to decrypt GAM service account JSON for tenant {self.tenant_id}")
-            return None
+        except ValueError as exc:
+            from src.core.exceptions import AdCPConfigurationError
+
+            raise AdCPConfigurationError(
+                f"Failed to decrypt GAM service account JSON for tenant {self.tenant_id}"
+            ) from exc
 
     @gam_service_account_json.setter
     def gam_service_account_json(self, value: str | None) -> None:

--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -159,6 +159,19 @@ class AdCPAdapterError(AdCPError):
     recovery: RecoveryHint = "transient"
 
 
+class AdCPConfigurationError(AdCPError):
+    """Server-side configuration is broken (500).
+
+    Raised when encrypted secrets cannot be decrypted (key rotation,
+    corruption, missing ENCRYPTION_KEY). Callers should NOT silently
+    fall back — the configuration needs admin intervention.
+    """
+
+    status_code = 500
+    error_code = "CONFIGURATION_ERROR"
+    recovery: RecoveryHint = "correctable"
+
+
 class AdCPServiceUnavailableError(AdCPError):
     """Service or product temporarily unavailable (503)."""
 

--- a/src/core/json_validators.py
+++ b/src/core/json_validators.py
@@ -44,67 +44,6 @@ class PlatformMappingModel(BaseModel):
         return self
 
 
-class CreativeFormatModel(BaseModel):
-    """Model for product.format_ids array items."""
-
-    format_id: str = Field(..., min_length=1)
-    name: str = Field(..., min_length=1)
-    type: str = Field(..., min_length=1)
-    description: str | None = Field(None, min_length=1)
-    width: int | None = Field(None, gt=0)
-    height: int | None = Field(None, gt=0)
-    duration: int | None = Field(None, gt=0)
-    assets: list[dict[str, Any]] = Field(default_factory=list)
-    delivery_options: dict[str, Any] = Field(default_factory=dict)
-
-    @field_validator("type")
-    @classmethod
-    def validate_type(cls, v: str) -> str:
-        """Validate format type with flexible handling for legacy values."""
-        if not v or not v.strip():
-            raise ValueError("Format type cannot be empty")
-
-        v = v.strip().lower()
-
-        # Standard AdCP format types
-        standard_types = {"display", "video", "audio", "native"}
-
-        # Legacy/alternative format types that should be mapped to standard types
-        type_mapping = {
-            "banner": "display",
-            "image": "display",
-            "static": "display",
-            "advertisement": "display",
-            "rich_media": "display",
-            "expandable": "display",
-            "interstitial": "display",
-            "popup": "display",
-            "overlay": "display",
-            "streaming": "video",
-            "preroll": "video",
-            "midroll": "video",
-            "postroll": "video",
-            "podcast": "audio",
-            "radio": "audio",
-            "sponsored": "native",
-            "content": "native",
-            "article": "native",
-            "feed": "native",
-        }
-
-        # If it's already a standard type, return as-is
-        if v in standard_types:
-            return v
-
-        # If it's a mappable legacy type, map it to standard type
-        if v in type_mapping:
-            return type_mapping[v]
-
-        # If it's not recognized, default to 'display' but allow it
-        # This prevents deletion failures for products with non-standard format types
-        return "display"
-
-
 class TargetingTemplateModel(BaseModel):
     """Model for product.targeting_template."""
 
@@ -208,71 +147,6 @@ class JSONValidatorMixin:
         # Validate using Pydantic
         validated = PlatformMappingModel(**value)
         return validated.model_dump(mode="json", exclude_none=True)
-
-    @validates("formats")
-    def validate_formats(self, key, value):
-        """Validate formats field is a list of format IDs (strings)."""
-        if value is None:
-            return []
-
-        if isinstance(value, str):
-            try:
-                value = json.loads(value)
-            except json.JSONDecodeError:
-                # For deletion operations, don't fail on invalid JSON - just return as-is
-                # SQLAlchemy may trigger validators even during deletion
-                import logging
-
-                logger = logging.getLogger(__name__)
-                logger.warning(f"Invalid JSON in formats field during validation: {value[:100]}")
-                return []
-
-        if not isinstance(value, list):
-            # During deletion, be lenient with validation
-            import logging
-
-            logger = logging.getLogger(__name__)
-            logger.warning(f"Expected list for formats field, got {type(value).__name__}")
-            return []
-
-        validated_formats = []
-        for fmt in value:
-            try:
-                if isinstance(fmt, dict):
-                    # AdCP spec uses "id" field, but we store full format objects
-                    # Accept both "id" (AdCP spec) and "format_id" (legacy)
-                    format_id = fmt.get("id") or fmt.get("format_id")
-                    if not format_id:
-                        # Skip invalid format objects instead of failing
-                        import logging
-
-                        logger = logging.getLogger(__name__)
-                        logger.warning(f"Skipping format object without id or format_id: {fmt}")
-                        continue
-                    # Store the full format object (with agent_url and id)
-                    validated_formats.append(fmt)
-                elif isinstance(fmt, str):
-                    # Current approach: Store format IDs as strings
-                    if not fmt.strip():
-                        # Skip empty format IDs instead of failing
-                        continue
-                    validated_formats.append(fmt.strip())
-                else:
-                    # Skip unrecognized format types instead of failing
-                    import logging
-
-                    logger = logging.getLogger(__name__)
-                    logger.warning(f"Skipping unrecognized format type: {type(fmt).__name__}")
-                    continue
-            except Exception as e:
-                # Be extra defensive - don't let validation errors block deletion
-                import logging
-
-                logger = logging.getLogger(__name__)
-                logger.warning(f"Error validating individual format: {e}")
-                continue
-
-        return validated_formats
 
     @validates("targeting_template")
     def validate_targeting_template(self, key, value):

--- a/src/core/mcp_auth_middleware.py
+++ b/src/core/mcp_auth_middleware.py
@@ -59,6 +59,6 @@ class MCPAuthMiddleware(Middleware):
                 if ctx_id:
                     await context.fastmcp_context.set_state("context_id", ctx_id, serializable=False)
             except Exception:
-                pass
+                logger.debug("Could not set context_id state", exc_info=True)
 
         return await call_next(context)

--- a/src/core/request_compat.py
+++ b/src/core/request_compat.py
@@ -53,7 +53,7 @@ def _translate_brand_manifest(value: Any) -> dict[str, str] | None:
         if hostname:
             return {"domain": hostname}
     except Exception:  # noqa: BLE001
-        pass
+        logger.debug("Could not parse domain from agent_url", exc_info=True)
     return None
 
 
@@ -250,6 +250,7 @@ def _strip_node(value: Any, schema: dict[str, Any], defs: dict[str, Any]) -> Any
                         best_score = score
                         best_result = candidate
                 except Exception:
+                    logger.debug("Schema candidate matching failed", exc_info=True)
                     continue
             return best_result
 

--- a/src/core/testing_hooks.py
+++ b/src/core/testing_hooks.py
@@ -13,6 +13,7 @@ This module handles all testing headers and provides isolated test execution:
 - X-Simulated-Spend: Track simulated spending without real money
 """
 
+import logging
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from enum import Enum
@@ -21,6 +22,8 @@ from typing import TYPE_CHECKING, Any
 from fastmcp.server.context import Context
 from fastmcp.server.dependencies import get_http_headers
 from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from src.core.tool_context import ToolContext
@@ -165,7 +168,7 @@ class AdCPTestContext(BaseModel):
         try:
             headers = get_http_headers()
         except Exception:
-            pass  # Will try fallback below
+            logger.debug("get_http_headers() unavailable in testing hooks", exc_info=True)
 
         # If get_http_headers() returned empty dict or None, try context.meta fallback
         # This is necessary for sync tools where get_http_headers() may not work

--- a/src/core/tool_error_logging.py
+++ b/src/core/tool_error_logging.py
@@ -52,7 +52,7 @@ def _extract_tenant_and_principal(context: Any) -> tuple[str | None, str | None]
                 if identity.principal_id:
                     principal_id = identity.principal_id
         except Exception:
-            pass
+            logger.debug("Could not extract identity for error logging", exc_info=True)
 
     return tenant_id, principal_id
 

--- a/src/core/transport_helpers.py
+++ b/src/core/transport_helpers.py
@@ -70,7 +70,7 @@ def resolve_identity_from_context(
     try:
         headers = get_http_headers(include_all=True)
     except Exception:
-        pass
+        logger.debug("get_http_headers() unavailable, trying fallback", exc_info=True)
 
     # Fallback to context.meta if available
     if not headers and ctx is not None:
@@ -93,7 +93,7 @@ def resolve_identity_from_context(
         if ctx is not None:
             testing_context = TestContext.from_context(ctx)
     except Exception:
-        pass
+        logger.debug("Could not extract testing context", exc_info=True)
 
     return resolve_identity(
         headers=headers,

--- a/src/services/activity_feed.py
+++ b/src/services/activity_feed.py
@@ -35,7 +35,7 @@ class ActivityFeed:
             try:
                 asyncio.create_task(websocket.send(json.dumps(activity)))
             except Exception:
-                pass
+                logger.debug("WebSocket send failed for activity replay", exc_info=True)
 
     def remove_connection(self, tenant_id: str, websocket):
         """Remove a WebSocket connection."""
@@ -201,6 +201,7 @@ class ActivityFeed:
             else:
                 return "Just now"
         except Exception:
+            logger.debug("Failed to format time_ago", exc_info=True)
             return "Unknown"
 
 

--- a/src/services/background_sync_service.py
+++ b/src/services/background_sync_service.py
@@ -223,7 +223,7 @@ def _run_sync_thread(
                     try:
                         os.unlink(temp_keyfile)
                     except Exception:
-                        pass
+                        logger.debug("Could not delete temp keyfile %s", temp_keyfile, exc_info=True)
             else:  # OAuth
                 oauth2_client = oauth2.GoogleRefreshTokenClient(
                     client_id=os.environ.get("GAM_OAUTH_CLIENT_ID"),

--- a/src/services/background_sync_service.py
+++ b/src/services/background_sync_service.py
@@ -160,7 +160,6 @@ def _run_sync_thread(
 
         # Import here to avoid circular dependencies
         import os
-        import tempfile
 
         import google.oauth2.service_account
         from googleads import ad_manager, oauth2
@@ -207,23 +206,16 @@ def _run_sync_thread(
                     _mark_sync_failed(sync_id, "Service account JSON not found")
                     return
 
-                with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
-                    f.write(service_account_json_str)
-                    temp_keyfile = f.name
+                import json as json_mod
 
-                try:
-                    credentials = google.oauth2.service_account.Credentials.from_service_account_file(
-                        temp_keyfile, scopes=["https://www.googleapis.com/auth/dfp"]
-                    )
-                    oauth2_client = oauth2.GoogleCredentialsClient(credentials)
-                    client = ad_manager.AdManagerClient(
-                        oauth2_client, "Prebid Sales Agent", network_code=adapter_config.gam_network_code
-                    )
-                finally:
-                    try:
-                        os.unlink(temp_keyfile)
-                    except Exception:
-                        logger.debug("Could not delete temp keyfile %s", temp_keyfile, exc_info=True)
+                service_account_info = json_mod.loads(service_account_json_str)
+                credentials = google.oauth2.service_account.Credentials.from_service_account_info(
+                    service_account_info, scopes=["https://www.googleapis.com/auth/dfp"]
+                )
+                oauth2_client = oauth2.GoogleCredentialsClient(credentials)
+                client = ad_manager.AdManagerClient(
+                    oauth2_client, "Prebid Sales Agent", network_code=adapter_config.gam_network_code
+                )
             else:  # OAuth
                 oauth2_client = oauth2.GoogleRefreshTokenClient(
                     client_id=os.environ.get("GAM_OAUTH_CLIENT_ID"),

--- a/src/services/protocol_webhook_service.py
+++ b/src/services/protocol_webhook_service.py
@@ -49,8 +49,7 @@ def _normalize_localhost_for_docker(url: str) -> str:
             new_netloc = f"{userinfo}host.docker.internal{port}"
             return urlunparse(parsed._replace(netloc=new_netloc))
     except Exception:
-        # If anything goes wrong, fall back to the original URL
-        pass
+        logger.debug("Docker URL rewrite failed, using original URL", exc_info=True)
     return url
 
 

--- a/src/services/slack_notifier.py
+++ b/src/services/slack_notifier.py
@@ -646,7 +646,7 @@ class SlackNotifier:
                 detail_parts.append(f"*Duration:* {duration} days")
                 detail_parts.append(f"*Flight:* {start.strftime('%Y-%m-%d')} to {end.strftime('%Y-%m-%d')}")
             except Exception:
-                pass  # Skip if date parsing fails
+                logger.debug("Could not parse flight dates for Slack notification", exc_info=True)
 
         if details.get("approval_reason"):
             detail_parts.append(f"*Approval Required:* {details['approval_reason']}")

--- a/tests/integration/test_decryption_failure_raises.py
+++ b/tests/integration/test_decryption_failure_raises.py
@@ -1,0 +1,71 @@
+"""Regression test for H1: decryption failure must raise, not return None.
+
+Three encrypted property getters (gemini_api_key, gam_service_account_json,
+oidc_client_secret) previously caught ValueError and returned None. Callers
+interpreted None as "not configured" when it meant "configuration is broken."
+
+GH #1078 H1.
+"""
+
+import pytest
+
+from src.core.database.models import AdapterConfig, TenantAuthConfig
+from src.core.exceptions import AdCPConfigurationError
+from tests.factories import TenantFactory
+from tests.harness._base import IntegrationEnv
+
+pytestmark = [pytest.mark.requires_db, pytest.mark.integration]
+
+
+class _BareEnv(IntegrationEnv):
+    """Minimal integration env — just session + factory binding."""
+
+    EXTERNAL_PATCHES = {}
+
+
+class TestDecryptionFailureRaises:
+    """Encrypted property getters must raise AdCPConfigurationError on failure."""
+
+    def test_tenant_gemini_key_raises_on_corrupt_data(self, integration_db):
+        """Tenant.gemini_api_key raises AdCPConfigurationError for corrupt ciphertext."""
+        with _BareEnv() as env:
+            tenant = TenantFactory(tenant_id="t-decrypt")
+
+            # Write corrupt encrypted data directly
+            tenant._gemini_api_key = "not-valid-fernet-token"
+            env._session.commit()
+
+            with pytest.raises(AdCPConfigurationError, match="decrypt"):
+                _ = tenant.gemini_api_key
+
+    def test_adapter_config_gam_json_raises_on_corrupt_data(self, integration_db):
+        """AdapterConfig.gam_service_account_json raises on corrupt ciphertext."""
+        with _BareEnv() as env:
+            tenant = TenantFactory(tenant_id="t-decrypt2")
+            config = AdapterConfig(
+                tenant_id=tenant.tenant_id,
+                adapter_type="google_ad_manager",
+                _gam_service_account_json="not-valid-fernet-token",
+            )
+            env._session.add(config)
+            env._session.commit()
+
+            with pytest.raises(AdCPConfigurationError, match="decrypt"):
+                _ = config.gam_service_account_json
+
+    def test_oidc_secret_raises_on_corrupt_data(self, integration_db):
+        """TenantAuthConfig.oidc_client_secret raises on corrupt ciphertext."""
+        with _BareEnv() as env:
+            tenant = TenantFactory(tenant_id="t-decrypt3")
+            auth_config = TenantAuthConfig(
+                tenant_id=tenant.tenant_id,
+                oidc_enabled=True,
+                oidc_provider="google",
+                oidc_client_id="test-client-id",
+                oidc_client_secret_encrypted="not-valid-fernet-token",
+            )
+            env._session.add(auth_config)
+            env._session.commit()
+
+            with pytest.raises(AdCPConfigurationError, match="decrypt"):
+                _ = auth_config.oidc_client_secret

--- a/tests/integration/test_mock_adapter_format_persistence.py
+++ b/tests/integration/test_mock_adapter_format_persistence.py
@@ -1,0 +1,75 @@
+"""Regression test for H2: mock adapter writes .formats instead of .format_ids.
+
+The mock adapter admin form handler sets `product_obj.formats = formats` (line 1403
+of mock_ad_server.py), but the ORM column is `format_ids`. SQLAlchemy silently sets
+`.formats` as a transient Python attribute that is never persisted.
+
+This test verifies via ProductRepository that:
+1. `update_fields(format_ids=...)` persists correctly (correct path)
+2. `update_fields(formats=...)` raises ValueError (what the adapter SHOULD hit if it used the repo)
+
+GH #1078 H2.
+"""
+
+import pytest
+
+from src.core.database.repositories.product import ProductRepository
+from tests.factories import TenantFactory
+from tests.factories.product import ProductFactory
+from tests.harness._base import IntegrationEnv
+
+pytestmark = [pytest.mark.requires_db, pytest.mark.integration]
+
+
+class _BareEnv(IntegrationEnv):
+    """Minimal integration env — just session + factory binding, no patches."""
+
+    EXTERNAL_PATCHES = {}
+
+
+class TestProductFormatFieldPersistence:
+    """ProductRepository rejects the wrong attribute name and accepts the right one."""
+
+    def test_update_format_ids_persists_via_repository(self, integration_db):
+        """Updating format_ids through the repository persists to DB."""
+        with _BareEnv() as env:
+            tenant = TenantFactory(tenant_id="t-fmt")
+            product = ProductFactory(
+                tenant=tenant,
+                format_ids=[{"agent_url": "https://creative.adcontextprotocol.org", "id": "display_300x250"}],
+            )
+
+            repo = ProductRepository(env._session, tenant_id="t-fmt")
+            new_formats = [
+                {"agent_url": "https://creative.adcontextprotocol.org", "id": "video_16x9"},
+                {"agent_url": "https://creative.adcontextprotocol.org", "id": "display_728x90"},
+            ]
+            updated = repo.update_fields(product.product_id, format_ids=new_formats)
+            assert updated is not None
+            env._session.commit()
+
+            # Re-read to confirm persistence
+            reloaded = repo.get_by_id(product.product_id)
+            assert reloaded is not None
+            assert len(reloaded.format_ids) == 2
+            assert reloaded.format_ids[0]["id"] == "video_16x9"
+            assert reloaded.format_ids[1]["id"] == "display_728x90"
+
+    def test_update_formats_raises_via_repository(self, integration_db):
+        """Using 'formats' (wrong column name) through the repository raises ValueError.
+
+        This is the bug: the mock adapter writes to .formats directly on the ORM
+        object, bypassing the repository. If it used the repository, this would
+        fail immediately instead of silently losing data.
+        """
+        with _BareEnv() as env:
+            tenant = TenantFactory(tenant_id="t-fmt2")
+            product = ProductFactory(
+                tenant=tenant,
+                format_ids=[{"agent_url": "https://creative.adcontextprotocol.org", "id": "display_300x250"}],
+            )
+
+            repo = ProductRepository(env._session, tenant_id="t-fmt2")
+
+            with pytest.raises(ValueError, match="Product has no attribute 'formats'"):
+                repo.update_fields(product.product_id, formats=["video_16x9"])

--- a/tests/integration/test_session_json_validation.py
+++ b/tests/integration/test_session_json_validation.py
@@ -10,7 +10,6 @@ from src.core.database.database_session import DatabaseManager, get_db_session, 
 from src.core.database.models import Context, Principal, Product, Tenant, WorkflowStep
 from src.core.json_validators import (
     CommentModel,
-    CreativeFormatModel,
     PlatformMappingModel,
     ensure_json_array,
     ensure_json_object,
@@ -170,45 +169,6 @@ class TestJSONValidation:
         # Invalid - no platforms
         with pytest.raises(ValueError, match="At least one platform mapping"):
             PlatformMappingModel()
-
-    def test_creative_format_validation(self):
-        """Test creative format validation."""
-        # Valid format
-        fmt = CreativeFormatModel(
-            format_id="display_300x250",
-            name="Display Banner",
-            type="display",
-            description="Standard banner",
-            width=300,
-            height=250,
-        )
-        assert fmt.width == 300
-        assert fmt.type == "display"
-
-        # Legacy format type - should be mapped to standard type
-        legacy_fmt = CreativeFormatModel(
-            format_id="banner_728x90",
-            name="Banner",
-            type="banner",  # Legacy type, should be mapped to "display"
-            description="Legacy banner format",
-            width=728,
-            height=90,
-        )
-        assert legacy_fmt.type == "display"  # Should be mapped from "banner" to "display"
-
-        # Unknown format type - should default to "display"
-        unknown_fmt = CreativeFormatModel(
-            format_id="unknown_format",
-            name="Unknown Format",
-            type="some_unknown_type",  # Unknown type, should default to "display"
-        )
-        assert unknown_fmt.type == "display"  # Should default to "display"
-
-        # Empty type should raise error
-        from pydantic import ValidationError
-
-        with pytest.raises(ValidationError, match="String should have at least 1 character"):
-            CreativeFormatModel(format_id="test", name="Test", type="", description="Test")  # Empty type
 
     def test_ensure_json_helpers(self):
         """Test JSON helper functions."""

--- a/tests/unit/test_architecture_no_silent_except.py
+++ b/tests/unit/test_architecture_no_silent_except.py
@@ -1,0 +1,187 @@
+"""Guard: except blocks must not silently swallow exceptions.
+
+Two patterns are banned in ``src/``:
+
+1. ``except Exception: pass`` — catches everything, does nothing
+2. ``except Exception: continue`` — catches everything, silently drops loop iteration
+
+Both patterns hide bugs and data loss. If an exception should be caught, it must
+be logged (at minimum ``logger.debug(..., exc_info=True)``).
+
+Legitimate patterns that are NOT violations:
+- ``except ImportError: pass`` — optional dependency guards (specific exception type)
+- ``except IntegrityError:`` — race-condition upsert patterns (specific exception type)
+- ``except Exception as e: logger.error(...)`` — logged exception handling
+- ``except Exception as e: return {"error": str(e)}, 500`` — Flask error returns
+
+beads: salesagent-q28c (H2), salesagent-gyn1 (H1)
+GH #1078
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_SRC_DIR = Path(__file__).resolve().parents[2] / "src"
+
+# Exception types that are acceptable to catch with pass/continue
+# (they indicate expected, specific failure modes, not catch-all swallowing)
+_ACCEPTABLE_EXCEPTION_TYPES = frozenset(
+    {
+        "ImportError",
+        "ModuleNotFoundError",
+        "IntegrityError",
+        "KeyboardInterrupt",
+        "SystemExit",
+        "StopIteration",
+        "StopAsyncIteration",
+        "GeneratorExit",
+    }
+)
+
+# Known violations — allowlist must only shrink, never grow.
+# Format: (relative_path_from_src, line_number)
+# Each entry must have a FIXME(#1078) comment at the source location.
+_KNOWN_VIOLATIONS: set[tuple[str, int]] = {
+    # FIXME(#1078): a2a protocol error formatting — needs structured error response
+    ("a2a_server/adcp_a2a_server.py", 609),
+    # FIXME(#1078): GAM date parsing — silent row drop (H5 location 1, partial fix)
+    ("adapters/google_ad_manager.py", 1152),
+    # FIXME(#1078): mock adapter template rendering fallback
+    ("adapters/mock_ad_server.py", 685),
+    # FIXME(#1078): admin product form — silent field parse error
+    ("admin/blueprints/products.py", 2186),
+    # FIXME(#1078): tenant list — silent iteration skip
+    ("admin/blueprints/tenants.py", 51),
+    # FIXME(#1078): audit logger — tenant name lookup for Slack context (3 locations)
+    ("core/audit_logger.py", 148),
+    ("core/audit_logger.py", 228),
+    ("core/audit_logger.py", 301),
+    # FIXME(#1078): auth header fallback — transport boundary (reviewed as by-design M8)
+    ("core/auth.py", 101),
+    # FIXME(#1078): MCP auth middleware — header extraction fallback
+    ("core/mcp_auth_middleware.py", 61),
+    # FIXME(#1078): request compat — best-effort schema matching
+    ("core/request_compat.py", 55),
+    ("core/request_compat.py", 252),
+    # FIXME(#1078): testing hooks — cleanup during test teardown
+    ("core/testing_hooks.py", 167),
+    # FIXME(#1078): tool error logging — serialization fallback
+    ("core/tool_error_logging.py", 54),
+    # FIXME(#1078): transport helpers — header extraction fallback (2 locations)
+    ("core/transport_helpers.py", 72),
+    ("core/transport_helpers.py", 95),
+    # FIXME(#1078): background sync — periodic task error isolation
+    ("services/background_sync_service.py", 225),
+    # FIXME(#1078): protocol webhook — delivery failure isolation
+    ("services/protocol_webhook_service.py", 51),
+    # FIXME(#1078): slack notifier — notification delivery isolation
+    ("services/slack_notifier.py", 648),
+}
+
+
+def _is_broad_exception_handler(handler: ast.ExceptHandler) -> bool:
+    """Check if this is a broad exception catch (Exception or bare except)."""
+    if handler.type is None:
+        # bare except:
+        return True
+    if isinstance(handler.type, ast.Name) and handler.type.id == "Exception":
+        return True
+    if isinstance(handler.type, ast.Attribute):
+        # e.g., builtins.Exception — unlikely but possible
+        attr = handler.type.attr
+        if attr == "Exception":
+            return True
+    return False
+
+
+def _handler_body_is_silent(handler: ast.ExceptHandler) -> tuple[bool, str]:
+    """Check if except body is just pass or continue (silent swallow).
+
+    Returns (is_silent, pattern_name).
+    """
+    # Filter out docstrings — body may start with a string constant
+    stmts = [
+        s
+        for s in handler.body
+        if not (isinstance(s, ast.Expr) and isinstance(s.value, ast.Constant) and isinstance(s.value.value, str))
+    ]
+
+    if len(stmts) == 0:
+        return True, "empty body"
+
+    if len(stmts) == 1:
+        stmt = stmts[0]
+        if isinstance(stmt, ast.Pass):
+            return True, "pass"
+        if isinstance(stmt, ast.Continue):
+            return True, "continue"
+
+    return False, ""
+
+
+def _scan_file(filepath: Path) -> list[tuple[str, int, str]]:
+    """Scan a Python file for silent broad exception handlers.
+
+    Returns list of (relative_path, line, pattern).
+    """
+    violations = []
+    try:
+        source = filepath.read_text()
+        tree = ast.parse(source, filename=str(filepath))
+    except SyntaxError:
+        return violations
+
+    rel_path = str(filepath.relative_to(_SRC_DIR))
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ExceptHandler):
+            continue
+        if not _is_broad_exception_handler(node):
+            continue
+
+        is_silent, pattern = _handler_body_is_silent(node)
+        if is_silent:
+            violations.append((rel_path, node.lineno, pattern))
+
+    return violations
+
+
+def test_no_silent_broad_except_in_src():
+    """No except Exception: pass/continue without logging in src/."""
+    all_violations = []
+
+    for py_file in sorted(_SRC_DIR.rglob("*.py")):
+        if "__pycache__" in str(py_file):
+            continue
+        all_violations.extend(_scan_file(py_file))
+
+    # Filter out known violations
+    new_violations = [
+        (path, line, pattern) for path, line, pattern in all_violations if (path, line) not in _KNOWN_VIOLATIONS
+    ]
+
+    assert not new_violations, (
+        f"Found {len(new_violations)} new silent broad-except violation(s) in src/.\n"
+        "Every except Exception block must log (at minimum logger.debug(..., exc_info=True)).\n\n"
+        + "\n".join(f"  {path}:{line} — except Exception: {pattern}" for path, line, pattern in new_violations)
+        + "\n\nFix: add logging, or narrow the exception type."
+    )
+
+
+def test_known_violations_not_stale():
+    """Every allowlisted violation must still exist in the source."""
+    all_violations = []
+    for py_file in sorted(_SRC_DIR.rglob("*.py")):
+        if "__pycache__" in str(py_file):
+            continue
+        all_violations.extend(_scan_file(py_file))
+
+    actual = {(path, line) for path, line, _ in all_violations}
+    stale = _KNOWN_VIOLATIONS - actual
+
+    assert not stale, (
+        f"Found {len(stale)} stale allowlist entry(ies) — these violations were fixed.\n"
+        "Remove them from _KNOWN_VIOLATIONS:\n\n" + "\n".join(f"  ({path!r}, {line})," for path, line in sorted(stale))
+    )

--- a/tests/unit/test_architecture_no_silent_except.py
+++ b/tests/unit/test_architecture_no_silent_except.py
@@ -42,43 +42,8 @@ _ACCEPTABLE_EXCEPTION_TYPES = frozenset(
 
 # Known violations — allowlist must only shrink, never grow.
 # Format: (relative_path_from_src, line_number)
-# Each entry must have a FIXME(#1078) comment at the source location.
-_KNOWN_VIOLATIONS: set[tuple[str, int]] = {
-    # FIXME(#1078): a2a protocol error formatting — needs structured error response
-    ("a2a_server/adcp_a2a_server.py", 609),
-    # FIXME(#1078): GAM date parsing — silent row drop (H5 location 1, partial fix)
-    ("adapters/google_ad_manager.py", 1152),
-    # FIXME(#1078): mock adapter template rendering fallback
-    ("adapters/mock_ad_server.py", 685),
-    # FIXME(#1078): admin product form — silent field parse error
-    ("admin/blueprints/products.py", 2186),
-    # FIXME(#1078): tenant list — silent iteration skip
-    ("admin/blueprints/tenants.py", 51),
-    # FIXME(#1078): audit logger — tenant name lookup for Slack context (3 locations)
-    ("core/audit_logger.py", 148),
-    ("core/audit_logger.py", 228),
-    ("core/audit_logger.py", 301),
-    # FIXME(#1078): auth header fallback — transport boundary (reviewed as by-design M8)
-    ("core/auth.py", 101),
-    # FIXME(#1078): MCP auth middleware — header extraction fallback
-    ("core/mcp_auth_middleware.py", 61),
-    # FIXME(#1078): request compat — best-effort schema matching
-    ("core/request_compat.py", 55),
-    ("core/request_compat.py", 252),
-    # FIXME(#1078): testing hooks — cleanup during test teardown
-    ("core/testing_hooks.py", 167),
-    # FIXME(#1078): tool error logging — serialization fallback
-    ("core/tool_error_logging.py", 54),
-    # FIXME(#1078): transport helpers — header extraction fallback (2 locations)
-    ("core/transport_helpers.py", 72),
-    ("core/transport_helpers.py", 95),
-    # FIXME(#1078): background sync — periodic task error isolation
-    ("services/background_sync_service.py", 225),
-    # FIXME(#1078): protocol webhook — delivery failure isolation
-    ("services/protocol_webhook_service.py", 51),
-    # FIXME(#1078): slack notifier — notification delivery isolation
-    ("services/slack_notifier.py", 648),
-}
+# All 19 pre-existing violations were fixed in this PR. Allowlist is empty.
+_KNOWN_VIOLATIONS: set[tuple[str, int]] = set()
 
 
 def _is_broad_exception_handler(handler: ast.ExceptHandler) -> bool:

--- a/tests/unit/test_background_sync_no_temp_keyfile.py
+++ b/tests/unit/test_background_sync_no_temp_keyfile.py
@@ -1,0 +1,49 @@
+"""Regression test for hmcd: service account credentials must not persist on disk.
+
+background_sync_service.py wrote GAM service account JSON to a temp file, then
+read it with from_service_account_file. If os.unlink failed, credentials
+remained on disk. The fix uses from_service_account_info (dict, no file).
+
+GH #1078 follow-up — security.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_SYNC_FILE = Path("src/services/background_sync_service.py")
+
+
+class TestNoTempKeyfileForServiceAccount:
+    """GAM service account auth must not write credentials to temp files."""
+
+    def test_no_named_temporary_file_usage(self):
+        """background_sync_service must not use NamedTemporaryFile.
+
+        Service account JSON should be passed as a dict via
+        from_service_account_info, not written to a temp file via
+        from_service_account_file. Temp files risk credential leakage
+        if cleanup fails.
+        """
+        source = _SYNC_FILE.read_text()
+        tree = ast.parse(source)
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and node.attr == "NamedTemporaryFile":
+                pytest.fail(
+                    f"background_sync_service.py:{node.lineno} uses NamedTemporaryFile — "
+                    "service account credentials must use from_service_account_info "
+                    "to avoid writing secrets to disk"
+                )
+
+    def test_uses_from_service_account_info(self):
+        """background_sync_service must use from_service_account_info (not _file)."""
+        source = _SYNC_FILE.read_text()
+
+        assert "from_service_account_info" in source, (
+            "background_sync_service.py should use from_service_account_info "
+            "(dict-based, no temp file) instead of from_service_account_file"
+        )

--- a/tests/unit/test_encryption.py
+++ b/tests/unit/test_encryption.py
@@ -270,17 +270,19 @@ class TestTenantModelIntegration:
         # Internal values should be different (though we can't compare directly due to random IV)
         assert tenant._gemini_api_key != encrypted1  # Different due to new encryption
 
-    def test_tenant_property_handles_invalid_encrypted_data(self, set_encryption_key):
-        """Test that invalid encrypted data returns None with warning."""
+    def test_tenant_property_raises_on_invalid_encrypted_data(self, set_encryption_key):
+        """Test that invalid encrypted data raises AdCPConfigurationError."""
         from src.core.database.models import Tenant
+        from src.core.exceptions import AdCPConfigurationError
 
         tenant = Tenant(tenant_id="test", name="Test", subdomain="test")
 
         # Set invalid encrypted value directly
         tenant._gemini_api_key = "invalid-encrypted-data"
 
-        # Property getter should return None and log warning
-        assert tenant.gemini_api_key is None
+        # Property getter should raise AdCPConfigurationError (not return None)
+        with pytest.raises(AdCPConfigurationError, match="decrypt"):
+            _ = tenant.gemini_api_key
 
 
 class TestErrorHandling:

--- a/tests/unit/test_error_format_consistency.py
+++ b/tests/unit/test_error_format_consistency.py
@@ -744,6 +744,7 @@ class TestErrorCodeVocabularyConsistency:
         "BUDGET_EXHAUSTED",  # HTTP 422 (salesagent extension)
         "RATE_LIMIT_EXCEEDED",  # adcp-req: Rate Limiting / Quota Errors
         "ADAPTER_ERROR",  # HTTP 502 (salesagent extension)
+        "CONFIGURATION_ERROR",  # HTTP 500 — decryption/config broken (salesagent extension)
         "SERVICE_UNAVAILABLE",  # adcp-req: Service/Infrastructure Errors
     }
 

--- a/tests/unit/test_gam_discovery_parsing.py
+++ b/tests/unit/test_gam_discovery_parsing.py
@@ -1,0 +1,87 @@
+"""Tests for GAM discovery parsing — Order and LineItem from_gam_object.
+
+Verifies parse behavior for well-formed and malformed GAM API dicts.
+The bare except in discover_orders()/discover_line_items() silently drops
+parse failures — these tests verify what from_gam_object does and doesn't
+tolerate.
+
+GH #1078 H6.
+"""
+
+import pytest
+
+from src.adapters.gam_orders_discovery import LineItem, Order, OrderStatus
+
+pytestmark = pytest.mark.unit
+
+
+class TestOrderFromGamObject:
+    """Order.from_gam_object parsing behavior."""
+
+    def test_minimal_valid_order(self):
+        """Minimal valid dict parses successfully."""
+        order = Order.from_gam_object({"id": 123, "name": "Test Order", "status": "DRAFT"})
+        assert order.order_id == "123"
+        assert order.name == "Test Order"
+        assert order.status == OrderStatus.DRAFT
+
+    def test_missing_id_raises(self):
+        """Missing 'id' field raises KeyError — this is what the bare except swallows."""
+        with pytest.raises(KeyError, match="id"):
+            Order.from_gam_object({"name": "No ID Order", "status": "DRAFT"})
+
+    def test_missing_name_raises(self):
+        """Missing 'name' field raises KeyError."""
+        with pytest.raises(KeyError, match="name"):
+            Order.from_gam_object({"id": 456, "status": "DRAFT"})
+
+    def test_missing_status_uses_default(self):
+        """Missing 'status' falls back to DRAFT via safe_enum_conversion."""
+        order = Order.from_gam_object({"id": 789, "name": "No Status"})
+        assert order.status == OrderStatus.DRAFT
+
+    def test_full_order_with_budget(self):
+        """Order with budget and advertiser info parses correctly."""
+        order = Order.from_gam_object(
+            {
+                "id": 100,
+                "name": "Full Order",
+                "status": "APPROVED",
+                "advertiserId": 5001,
+                "advertiserName": "Acme Corp",
+                "totalBudget": {"microAmount": 50000000, "currencyCode": "USD"},
+            }
+        )
+        assert order.advertiser_id == "5001"
+        assert order.advertiser_name == "Acme Corp"
+        assert order.total_budget == 50.0
+        assert order.currency_code == "USD"
+
+
+class TestLineItemFromGamObject:
+    """LineItem.from_gam_object parsing behavior."""
+
+    def test_minimal_valid_line_item(self):
+        """Minimal valid dict parses successfully."""
+        li = LineItem.from_gam_object(
+            {
+                "id": 200,
+                "orderId": 100,
+                "name": "Test Line Item",
+                "lineItemType": "STANDARD",
+                "status": "READY",
+            }
+        )
+        assert li.line_item_id == "200"
+        assert li.order_id == "100"
+        assert li.name == "Test Line Item"
+
+    def test_missing_id_raises(self):
+        """Missing 'id' field raises KeyError — silently swallowed in discover_line_items."""
+        with pytest.raises(KeyError, match="id"):
+            LineItem.from_gam_object({"orderId": 100, "name": "No ID", "lineItemType": "STANDARD"})
+
+    def test_missing_order_id_raises(self):
+        """Missing 'orderId' field raises KeyError."""
+        with pytest.raises(KeyError, match="orderId"):
+            LineItem.from_gam_object({"id": 300, "name": "No OrderId", "lineItemType": "STANDARD"})

--- a/tests/unit/test_gam_reporting_row_drops.py
+++ b/tests/unit/test_gam_reporting_row_drops.py
@@ -1,0 +1,97 @@
+"""Regression test for H5: GAM reporting must not silently drop rows with data.
+
+The zero-impression filter in gam_reporting_service.py:445-448 drops rows where
+impressions=0, even if clicks or revenue are non-zero. This causes FLAT_RATE/SPONSORSHIP
+campaigns to show $0 spend and click-only campaigns to lose click data.
+
+GH #1078 H5.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _make_service():
+    """Create a GAMReportingService with mocked dependencies."""
+    from src.adapters.gam_reporting_service import GAMReportingService
+
+    service = GAMReportingService.__new__(GAMReportingService)
+    service.gam_client = MagicMock()
+    service.network_code = "12345"
+    service.logger = MagicMock()
+    return service
+
+
+class TestZeroImpressionRowRetention:
+    """Rows with zero impressions but non-zero clicks or revenue must be retained."""
+
+    def test_zero_impressions_nonzero_revenue_retained(self):
+        """FLAT_RATE/SPONSORSHIP rows (0 impressions, real revenue) must not be dropped."""
+        service = _make_service()
+
+        rows = [
+            {
+                "AD_SERVER_IMPRESSIONS": "0",
+                "AD_SERVER_CLICKS": "0",
+                "AD_SERVER_CPM_AND_CPC_REVENUE": "5000000",  # $5.00 in micros
+                "ADVERTISER_ID": "adv1",
+                "ORDER_ID": "order1",
+                "LINE_ITEM_ID": "li1",
+                "LINE_ITEM_NAME": "Sponsorship Deal",
+                "DATE": "2026-04-15",
+            },
+        ]
+
+        result = service._process_report_data(rows, granularity="daily", requested_tz="UTC")
+
+        assert len(result) >= 1, (
+            "Zero-impression row with revenue was dropped — FLAT_RATE/SPONSORSHIP spend is silently lost"
+        )
+        assert result[0]["spend"] == 5.0
+
+    def test_zero_impressions_nonzero_clicks_retained(self):
+        """Click-only rows (0 impressions, real clicks) must not be dropped."""
+        service = _make_service()
+
+        rows = [
+            {
+                "AD_SERVER_IMPRESSIONS": "0",
+                "AD_SERVER_CLICKS": "42",
+                "AD_SERVER_CPM_AND_CPC_REVENUE": "0",
+                "ADVERTISER_ID": "adv1",
+                "ORDER_ID": "order1",
+                "LINE_ITEM_ID": "li2",
+                "LINE_ITEM_NAME": "Click Tracker",
+                "DATE": "2026-04-15",
+            },
+        ]
+
+        result = service._process_report_data(rows, granularity="daily", requested_tz="UTC")
+
+        assert len(result) >= 1, (
+            "Zero-impression row with clicks was dropped — click-only campaign data is silently lost"
+        )
+        assert result[0]["clicks"] == 42
+
+    def test_all_zeros_row_dropped(self):
+        """Rows with ALL metrics at zero may be dropped (volume reduction)."""
+        service = _make_service()
+
+        rows = [
+            {
+                "AD_SERVER_IMPRESSIONS": "0",
+                "AD_SERVER_CLICKS": "0",
+                "AD_SERVER_CPM_AND_CPC_REVENUE": "0",
+                "ADVERTISER_ID": "adv1",
+                "ORDER_ID": "order1",
+                "LINE_ITEM_ID": "li3",
+                "DATE": "2026-04-15",
+            },
+        ]
+
+        result = service._process_report_data(rows, granularity="daily", requested_tz="UTC")
+
+        assert len(result) == 0, "All-zero rows should be dropped for volume reduction"

--- a/tests/unit/test_quiet_failure_propagation.py
+++ b/tests/unit/test_quiet_failure_propagation.py
@@ -178,6 +178,44 @@ class TestDynamicPricingExceptionPropagation:
             with pytest.raises(TypeError, match="not subscriptable"):
                 await _get_products_impl(_make_request(), _make_identity())
 
+    @pytest.mark.asyncio
+    async def test_runtime_error_is_graceful(self):
+        """RuntimeError (service failure) degrades gracefully — products returned without pricing enrichment.
+
+        Covers: UC-001-MAIN-42
+        GH #1078 H4 — symmetric test for the degradation path.
+        """
+        from tests.helpers.adcp_factories import create_test_product
+
+        product = create_test_product(product_id="p1")
+        mock_uow = _mock_uow_with_products([product])
+
+        mock_pricing_cls = MagicMock()
+        mock_pricing_cls.return_value.enrich_products_with_pricing.side_effect = RuntimeError("Connection refused")
+
+        patches = [
+            patch("src.core.database.repositories.uow.ProductUoW", return_value=mock_uow),
+            patch("src.core.tools.products.get_principal_object", return_value=None),
+            patch("src.core.tools.products.convert_product_model_to_schema", side_effect=lambda p, **kw: p),
+            patch(
+                "src.services.dynamic_products.generate_variants_for_brief",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch("src.services.dynamic_pricing_service.DynamicPricingService", mock_pricing_cls),
+        ]
+
+        import contextlib
+
+        from src.core.tools.products import _get_products_impl
+
+        with contextlib.ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            result = await _get_products_impl(_make_request(), _make_identity())
+            # Should still return the static product despite pricing failure
+            assert len(result.products) == 1
+
 
 class TestAIRankingExceptionPropagation:
     """AI ranking fail-open (obligation already existed).

--- a/tests/unit/test_xandr_date_parsing.py
+++ b/tests/unit/test_xandr_date_parsing.py
@@ -1,0 +1,88 @@
+"""Regression test: Xandr adapter must parse non-ISO date formats.
+
+Xandr API historically returns dates as "YYYY-MM-DD HH:MM:SS" (space-separated).
+Python's datetime.fromisoformat in Python < 3.11 rejects this format.
+Python 3.11+ is more permissive but Xandr may also return other variants.
+
+The fix uses dateutil.parser.parse() which handles any reasonable format.
+
+GH #1078 follow-up — salesagent-7jan.
+"""
+
+import ast
+from datetime import datetime
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class TestXandrDateFormats:
+    """Xandr adapter must handle various date formats from the API."""
+
+    def test_space_separated_datetime_parses(self):
+        """Xandr's historical format 'YYYY-MM-DD HH:MM:SS' must parse."""
+        from dateutil import parser as dateutil_parser
+
+        result = dateutil_parser.parse("2026-04-15 00:00:00")
+        assert result == datetime(2026, 4, 15, 0, 0, 0)
+
+    def test_iso_format_still_parses(self):
+        """Standard ISO format must still work."""
+        from dateutil import parser as dateutil_parser
+
+        result = dateutil_parser.parse("2026-04-15T00:00:00")
+        assert result == datetime(2026, 4, 15, 0, 0, 0)
+
+    def test_date_only_parses(self):
+        """Date-only strings must parse."""
+        from dateutil import parser as dateutil_parser
+
+        result = dateutil_parser.parse("2026-04-15")
+        assert result.date() == datetime(2026, 4, 15).date()
+
+    def test_xandr_adapter_uses_dateutil_not_fromisoformat(self):
+        """xandr.py must use dateutil.parser, not datetime.fromisoformat for API dates."""
+        import ast
+        from pathlib import Path
+
+        source = Path("src/adapters/xandr.py").read_text()
+        tree = ast.parse(source)
+
+        # Find fromisoformat calls that operate on external API data
+        # (io["start_date"], io["end_date"], li["start_date"], li["end_date"])
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Attribute)
+                and node.attr == "fromisoformat"
+                and isinstance(node.value, ast.Name)
+                and node.value.id == "datetime"
+            ):
+                # Check if the argument references external API data
+                # (subscript on io or li variables)
+                parent = _find_parent_call(tree, node)
+                if parent and _is_external_api_date(parent):
+                    pytest.fail(
+                        f"xandr.py:{node.lineno} uses datetime.fromisoformat on external "
+                        "Xandr API data — use dateutil.parser.parse() instead"
+                    )
+
+
+def _find_parent_call(tree: ast.AST, target: ast.AST) -> ast.Call | None:
+    """Find the Call node that contains this attribute as its func."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and node.func is target:
+            return node
+    return None
+
+
+def _is_external_api_date(call: ast.Call) -> bool:
+    """Check if a fromisoformat call argument is an API response subscript."""
+    if not call.args:
+        return False
+    arg = call.args[0]
+    # Match patterns like io["start_date"], li["end_date"]
+    if isinstance(arg, ast.Subscript) and isinstance(arg.value, ast.Name):
+        if arg.value.id in ("io", "li"):
+            return True
+    return False

--- a/uv.lock
+++ b/uv.lock
@@ -184,6 +184,7 @@ dev = [
     { name = "ruff" },
     { name = "semgrep" },
     { name = "types-psycopg2" },
+    { name = "types-python-dateutil" },
     { name = "types-pytz" },
     { name = "types-requests" },
     { name = "types-waitress" },
@@ -198,7 +199,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.0" },
     { name = "alembic", specifier = ">=1.13.0" },
     { name = "allure-pytest", marker = "extra == 'ui-tests'", specifier = "==2.13.5" },
-    { name = "authlib", specifier = ">=1.6.7" },
+    { name = "authlib", specifier = ">=1.6.11" },
     { name = "babel", specifier = ">=2.17.0" },
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "cryptography", specifier = ">=46.0.7" },
@@ -278,6 +279,7 @@ dev = [
     { name = "ruff", specifier = ">=0.8.0" },
     { name = "semgrep", specifier = ">=1.50.0" },
     { name = "types-psycopg2", specifier = ">=2.9.21.20251012" },
+    { name = "types-python-dateutil", specifier = ">=2.9.0.20260408" },
     { name = "types-pytz", specifier = ">=2025.2.0.20250809" },
     { name = "types-requests", specifier = ">=2.32.4.20250913" },
     { name = "types-waitress", specifier = ">=3.0.1.20250801" },
@@ -533,14 +535,14 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.9"
+version = "1.6.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/98/00d3dd826d46959ad8e32af2dbb2398868fd9fd0683c26e56d0789bd0e68/authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04", size = 165134, upload-time = "2026-03-02T07:44:01.998Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/10/b325d58ffe86815b399334a101e63bc6fa4e1953921cb23703b48a0a0220/authlib-1.6.11.tar.gz", hash = "sha256:64db35b9b01aeccb4715a6c9a6613a06f2bd7be2ab9d2eb89edd1dfc7580a38f", size = 165359, upload-time = "2026-04-16T07:22:50.279Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/23/b65f568ed0c22f1efacb744d2db1a33c8068f384b8c9b482b52ebdbc3ef6/authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3", size = 244197, upload-time = "2026-03-02T07:44:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/57/2f/55fca558f925a51db046e5b929deb317ddb05afed74b22d89f4eca578980/authlib-1.6.11-py2.py3-none-any.whl", hash = "sha256:c8687a9a26451c51a34a06fa17bb97cb15bba46a6a626755e2d7f50da8bff3e3", size = 244469, upload-time = "2026-04-16T07:22:48.413Z" },
 ]
 
 [[package]]
@@ -4487,6 +4489,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9b/b3/2d09eaf35a084cffd329c584970a3fa07101ca465c13cad1576d7c392587/types_psycopg2-2.9.21.20251012.tar.gz", hash = "sha256:4cdafd38927da0cfde49804f39ab85afd9c6e9c492800e42f1f0c1a1b0312935", size = 26710, upload-time = "2025-10-12T02:55:39.5Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/0c/05feaf8cb51159f2c0af04b871dab7e98a2f83a3622f5f216331d2dd924c/types_psycopg2-2.9.21.20251012-py3-none-any.whl", hash = "sha256:712bad5c423fe979e357edbf40a07ca40ef775d74043de72bd4544ca328cc57e", size = 24883, upload-time = "2025-10-12T02:55:38.439Z" },
+]
+
+[[package]]
+name = "types-python-dateutil"
+version = "2.9.0.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/f3/2427775f80cd5e19a0a71ba8e5ab7645a01a852f43a5fd0ffc24f66338e0/types_python_dateutil-2.9.0.20260408.tar.gz", hash = "sha256:8b056ec01568674235f64ecbcef928972a5fac412f5aab09c516dfa2acfbb582", size = 16981, upload-time = "2026-04-08T04:28:10.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/c6/eeba37bfee282a6a97f889faef9352d6172c6a5088eb9a4daf570d9d748d/types_python_dateutil-2.9.0.20260408-py3-none-any.whl", hash = "sha256:473139d514a71c9d1fbd8bb328974bedcb1cc3dba57aad04ffa4157f483c216f", size = 18437, upload-time = "2026-04-08T04:28:10.095Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Systematic triage of all 22 error-handling anti-patterns cataloged in #1078. Each was individually assessed: fix, close as resolved, or close as by-design.

35 files changed, +763 / -250.

## Data-loss bugs fixed

| What | File | Impact |
|------|------|--------|
| Decryption failure returned `None` instead of raising | `database/models.py` | 16+ callers treated broken encryption as "not configured" |
| Mock adapter wrote `.formats` (nonexistent attr) instead of `.format_ids` | `mock_ad_server.py` | Format selections silently lost on save |
| GAM reporting dropped zero-impression rows | `gam_reporting_service.py` | FLAT_RATE/SPONSORSHIP campaigns showed $0 spend |
| GAM reporting dropped rows with unparseable dates | `google_ad_manager.py` | Totals didn't match daily breakdowns |
| GAM service account JSON written to temp file | `background_sync_service.py` | Credentials leaked on disk if unlink failed |

## Other fixes

- **GAM discovery**: nested bare `except: pass` removed, `exc_info=True` added (H6)
- **Slack notifications**: failures now logged at warning (M9)
- **Admin TTL field**: invalid input flashes error instead of silent discard (M12)
- **Activity feed, sync_api, policy.py**: silent catches now log at debug (M15/L19/L20/L21)
- **Xandr adapter**: `fromisoformat` → `dateutil.parser.parse` for API dates (format not guaranteed)
- **19 remaining `except Exception: pass/continue`**: all replaced with logging

## Dead code removed (126 lines)

- `CreativeFormatModel` class — unused since column rename
- `@validates("formats")` validator — dead since column renamed to `format_ids`

## New infrastructure

- `AdCPConfigurationError` exception (HTTP 500, recovery: "correctable")
- **Structural guard** `test_architecture_no_silent_except.py` — AST-scans `src/` for `except Exception: pass/continue`. Allowlist is empty. New violations fail `make quality`.

## Closed without code changes

7 items from the original catalog were already resolved or correct by design:
- M7, M10, M14: already fixed in prior PRs
- M8, M11, M13, H3: defensive patterns that are correct for their context (transport fallback chains, intentionally lenient parsers, FK-protected code paths)
- L16, L18: standard Python patterns (import guards, IntegrityError upsert)

## Test results

- `make quality`: 4,263 passed, 0 failed
- `./run_all_tests.sh`: 7,454 passed, 0 failed across all 5 suites
- 30 new tests (6 integration + 24 unit)

## Related

- Related to #1091 — same class of problem (silent error swallowing). This PR establishes the precedent: log at warning for optional enrichment, raise for data integrity.
- Related to #1177 — H1 adds `AdCPConfigurationError` to the same exception hierarchy.
- Related to #1172 — H2 fixes the `.formats` naming bug, a symptom of the raw-dict problem #1172 addresses.

Closes #1078

🤖 Generated with [Claude Code](https://claude.com/claude-code)