### PR TITLE
fix: correct GAM service account authorization instructions

### DIFF
--- a/docs/adapters/gam/service-account-setup.md
+++ b/docs/adapters/gam/service-account-setup.md
@@ -14,7 +14,7 @@ The Prebid Sales Agent supports two authentication methods for Google Ad Manager
 Instead of partners sending us their service account JSON credentials, we:
 1. Create a service account in our GCP project
 2. Provide you with the service account email
-3. You add this email as a user in your GAM with Trafficker role
+3. You authorize this email as an API user in your GAM (under Admin → Global Settings → API access)
 4. We handle all credential management securely
 
 ## Service Account Benefits
@@ -126,22 +126,30 @@ If you haven't set these up yet, see your system administrator or cloud platform
 6. Wait a few seconds while we create the service account in our GCP project
 7. Copy the service account email that appears
 
-### Step 2: Add Service Account to Your GAM
+### Step 2: Authorize the Service Account in Your GAM
+
+> **Important:** Service accounts are **not** added through the regular
+> **Access & authorization → Users** flow. That flow sends an email invitation,
+> which a service account has no inbox to accept. Use the **API access** flow
+> under Global Settings instead.
 
 1. Log into your [Google Ad Manager](https://admanager.google.com/) account
-2. Navigate to **Admin** → **Access & authorization** → **Users**
-3. Click **New user**
-4. Paste the service account email from Step 1
-5. Assign role: **Trafficker** (recommended)
-6. Under **Teams**, select specific advertisers (optional but recommended for security)
-7. Click **Save**
+2. Navigate to **Admin** → **Global Settings**
+3. Scroll to the **API access** section and ensure **API access** is toggled on
+4. Click **Add a service account user**
+5. Paste the service account email from Step 1
+6. Assign role: **Trafficker** (recommended)
+7. Under **Teams**, select specific advertisers (optional but recommended for security)
+8. Click **Save**
 
 ### Step 3: Test Connection
 
 1. Return to the Admin UI settings page
 2. Click **Test Connection** button
 3. If successful, you're done! If not, verify:
-   - Service account email was added correctly in GAM
+   - API access is enabled under GAM Admin → Global Settings
+   - The service account was added via **Add a service account user** (not the Users page)
+   - The service account email now appears on GAM Admin → **Access & authorization** → **Users** as an active user — this is how you confirm the authorization took effect
    - Trafficker role was assigned
    - You clicked Save in GAM
 
@@ -251,9 +259,10 @@ curl -X POST http://localhost:8000/tenant/{tenant_id}/gam/configure \
 **Cause**: Service account doesn't have required permissions in GAM
 
 **Solution**:
-1. Verify the service account is added as a user in GAM
-2. Check that "Trafficker" role (or equivalent) is assigned
-3. Ensure the service account has access to the specific advertiser
+1. Confirm the service account was authorized under Admin → Global Settings → **API access** → **Add a service account user** (not through the Users page — that path sends an email invitation and does not work for service accounts)
+2. Open Admin → **Access & authorization** → **Users** and confirm the service account email appears there as an active user — this is how you verify the authorization took effect
+3. Check that "Trafficker" role (or equivalent) is assigned
+4. Ensure the service account has access to the specific advertiser
 
 ### "Network Code Not Found" Error
 

--- a/static/js/tenant_settings.js
+++ b/static/js/tenant_settings.js
@@ -1817,7 +1817,7 @@ function saveManualServiceAccount() {
         button.innerHTML = 'Save Service Account Configuration';
 
         if (data.success) {
-            alert('✅ Service account configuration saved!\n\nMake sure the service account email (' + jsonData.client_email + ') is added as a user in GAM with Trafficker role, then test the connection.');
+            alert('✅ Service account configuration saved!\n\nNext, authorize the service account email (' + jsonData.client_email + ') in GAM:\n\n1. In GAM, go to Admin → Global Settings\n2. Scroll to API access and ensure it is enabled\n3. Click "Add a service account user"\n4. Paste the email and assign the Trafficker role\n5. Click Save\n\nNote: service accounts must be added through Global Settings → API access, not the Users page (which sends an email invitation a service account cannot accept). You can verify the account appears under Admin → Access & authorization → Users once added.\n\nThen come back here and test the connection.');
             location.reload();
         } else {
             alert('❌ Failed to save configuration:\n\n' + (data.error || data.errors?.join('\n') || 'Unknown error'));
@@ -1851,7 +1851,7 @@ function testGAMServiceAccountConnection() {
         if (data.success) {
             alert('✅ Connection successful!\n\nNetwork: ' + (data.networks?.[0]?.displayName || 'N/A') + '\nNetwork Code: ' + (data.networks?.[0]?.networkCode || 'N/A'));
         } else {
-            alert('❌ Connection failed!\n\n' + (data.error || 'Unknown error') + '\n\nPlease make sure:\n1. You added the service account email to your GAM\n2. You assigned the Trafficker role\n3. You clicked Save in GAM\n4. You saved the correct network code');
+            alert('❌ Connection failed!\n\n' + (data.error || 'Unknown error') + '\n\nPlease make sure:\n1. You authorized the service account in GAM under Admin → Global Settings → API access → "Add a service account user" (NOT through the Users page — that path sends an email invitation and will not work for service accounts)\n2. The service account now appears under Admin → Access & authorization → Users as an active user (this is how you verify the authorization took effect)\n3. You assigned the Trafficker role\n4. You clicked Save in GAM\n5. The network code is correct');
         }
     })
     .catch(error => {

--- a/templates/adapters/google_ad_manager/connection_config.html
+++ b/templates/adapters/google_ad_manager/connection_config.html
@@ -214,7 +214,7 @@ Expected context variables:
                 {% if single_tenant_mode %}
                 <p style="margin: 0 0 1rem 0; font-size: 0.875rem;">
                     To use a service account, create one in your GCP project and download the JSON key file.
-                    Then add the service account email as a user in Google Ad Manager with the Trafficker role.
+                    Then authorize the service account email as an API user in Google Ad Manager (Admin → Global Settings → API access → Add a service account user) with the Trafficker role.
                 </p>
 
                 <!-- Service Account JSON Key Input -->
@@ -245,7 +245,7 @@ Expected context variables:
                 {% else %}
                 <p style="margin: 0 0 1rem 0; font-size: 0.875rem;">
                     We'll create a service account in our GCP project and provide you with the email address.
-                    You then add this email as a user in your Google Ad Manager with the Trafficker role.
+                    You then authorize this email as an API user in your Google Ad Manager (Admin → Global Settings → API access → Add a service account user) with the Trafficker role.
                 </p>
                 <button onclick="createServiceAccount()" class="btn btn-success" id="create-service-account-btn">
                     Create Service Account

--- a/templates/tenant_settings.html
+++ b/templates/tenant_settings.html
@@ -1091,7 +1091,7 @@
                             {% if single_tenant_mode %}
                             <p style="margin: 0 0 1rem 0; font-size: 0.875rem;">
                                 To use a service account, create one in your GCP project and download the JSON key file.
-                                Then add the service account email as a user in Google Ad Manager with the Trafficker role.
+                                Then authorize the service account email as an API user in Google Ad Manager (Admin → Global Settings → API access → Add a service account user) with the Trafficker role.
                             </p>
                             <p style="margin: 0 0 1.5rem 0; font-size: 0.875rem; color: #6b7280;">
                                 See the <a href="https://developers.google.com/ad-manager/api/start" target="_blank">GAM API documentation</a> for setup instructions.
@@ -1132,7 +1132,7 @@
                             </div>
                             {% else %}
                             <p style="margin: 0 0 1rem 0; font-size: 0.875rem;">
-                                We'll create a service account in our GCP project and provide you with the email address. You then add this email as a user in your Google Ad Manager with the Trafficker role.
+                                We'll create a service account in our GCP project and provide you with the email address. You then authorize this email as an API user in your Google Ad Manager (Admin → Global Settings → API access → Add a service account user) with the Trafficker role.
                             </p>
                             <button onclick="createServiceAccount()" class="btn btn-success" id="create-service-account-btn">
                                 🔑 Create Service Account


### PR DESCRIPTION
Service accounts cannot be added through GAM's Admin → Access & authorization → Users flow. That flow sends an email invitation to the address, which a service account has no inbox to accept. The authorization silently fails to take effect, and every downstream API call (starting with getCurrentNetwork) returns the account as unauthorized — but the JWT handshake still succeeds, so the existing connection test reports success and displays N/A for the network code.

The correct path is:
  Admin → Global Settings → API access → Add a service account user

Once added there, the service account appears on the Access & authorization → Users page as an active user, which is the visual confirmation that authorization took effect.

Updates the setup doc, both Jinja templates that render the service-account instructions (single-tenant and multi-tenant paths), and the two JS alerts shown after Save / failed Test Connection.

- docs/adapters/gam/service-account-setup.md: rewrite Step 2 and the Permission Denied / Test Connection troubleshooting entries.
- templates/tenant_settings.html, templates/adapters/google_ad_manager/ connection_config.html: soften "add as a user" -> "authorize as an API user" with the correct GAM navigation path inline.
- static/js/tenant_settings.js: rewrite the post-save and failed-test alerts to walk the user through Global Settings -> API access and call out the Users-page trap explicitly.

No code behavior changes in this commit. A follow-up PR will address the connection test reporting success when getCurrentNetwork() throws (the symptom that made this instruction bug hard to diagnose).