### PR TITLE
fix: GAM test-connection must not report success with no accessible network

### DIFF
--- a/src/admin/blueprints/gam.py
+++ b/src/admin/blueprints/gam.py
@@ -959,6 +959,7 @@ def test_gam_connection(tenant_id):
 
         # Get all networks user has access to
         networks = []
+        network_error = None
         try:
             # Service account auth with network_code already set - use getCurrentNetwork
             if auth_method == "service_account":
@@ -1014,11 +1015,41 @@ def test_gam_connection(tenant_id):
                 ]
             except Exception as e:
                 logger.error(f"Failed to get network info: {e}")
+                network_error = str(e)
                 networks = []
         except Exception as e:
             logger.error(f"Failed to get networks: {e}")
             logger.exception("Full exception details:")
+            network_error = str(e)
             networks = []
+
+        # If no network is accessible, the connection test must fail.
+        # The OAuth / service-account handshake can succeed while the
+        # downstream network call (getCurrentNetwork / getAllNetworks)
+        # throws or returns nothing — returning success=True with an
+        # empty networks list silently hid that case and led users to
+        # believe the connection was working.
+        if not networks:
+            if auth_method == "service_account":
+                error_msg = (
+                    "Authentication succeeded but no network is accessible to this "
+                    "service account. The most common cause is that the service "
+                    "account was added under GAM Admin → Access & authorization → "
+                    "Users, which sends an email invitation that a service account "
+                    "cannot accept. Authorize it under Admin → Global Settings → "
+                    "API access → \"Add a service account user\" instead, then "
+                    "verify the account appears under Access & authorization → "
+                    "Users as an active user."
+                )
+            else:
+                error_msg = (
+                    "Authentication succeeded but getAllNetworks() returned no "
+                    "networks. Verify your Google account has access to at least "
+                    "one Google Ad Manager network."
+                )
+            if network_error:
+                error_msg = f"{error_msg} (Underlying error: {network_error})"
+            return jsonify({"success": False, "error": error_msg}), 200
 
         result = {
             "success": True,


### PR DESCRIPTION
## Problem

`test_gam_connection` in `src/admin/blueprints/gam.py` catches any
exception from `getCurrentNetwork` / `getAllNetworks` into a bare
`networks = []` and then unconditionally returns:

```json
{
  "success": true,
  "message": "Successfully connected to Google Ad Manager",
  "networks": []
}
``` 
The admin UI's alert reads
data.networks?.[0]?.displayName || 'N/A', so the user sees a green
"✅ Connection successful!" dialog showing Network: N/A and Network
Code: N/A — even though the underlying API call threw.

This is especially misleading for service-account auth: the JWT
handshake is independent of network access, so an authentication
failure mode like "service account was added through the Users page
instead of API access" authenticates cleanly, then throws on the
first real API call, then gets swallowed and reported as success.

## Solution
Capture the underlying exception into network_error, and if
networks is empty after all fetch attempts, return success: false
with a specific error explaining the most likely cause. For
service-account auth, the error message points directly at the
correct Admin → Global Settings → API access flow (documented by the
companion PR #1218).

The HTTP status is 200 — the request itself succeeded; this is an
application-level failure, consistent with how the admin UI's JS
already branches on data.success.

## Changes
src/admin/blueprints/gam.py: test_gam_connection now returns success: false with a targeted error message when no network is accessible, instead of masquerading as success.

## How to verify
1. Configure a service account with valid JSON + network code.
2. In GAM, add the service account via the Users page (i.e., the wrong flow). The invitation will not be accepted.
3. Click Test Connection. Before this PR: green "Connection successful" with Network: N/A. After this PR: red error pointing at the Global Settings → API access flow.

I have read the IPR Policy.
