### PR TITLE
feat(adapters): reconcile MockProductConfig schema (Phase 2 of #996)

### DIFF
--- a/src/adapters/mock_ad_server.py
+++ b/src/adapters/mock_ad_server.py
@@ -1,7 +1,7 @@
 import logging
 import random
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 logger = logging.getLogger(__name__)
 
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from src.core.schemas import Snapshot
 
 # adcp 3.6.0: BrandManifest removed from CreateMediaBuyRequest; now uses BrandReference (brand field)
-from pydantic import Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from src.adapters.base import (
     AdapterCapabilities,
@@ -40,14 +40,117 @@ class MockConnectionConfig(BaseConnectionConfig):
     dry_run: bool = Field(default=False, description="When true, simulates operations without persisting state")
 
 
-class MockProductConfig(BaseProductConfig):
-    """Product config for Mock adapter simulation parameters."""
+class MockDeliverySimulation(BaseModel):
+    """Sub-config for time-accelerated delivery simulation."""
 
-    daily_impressions: int = Field(default=10000, ge=0)
-    fill_rate: float = Field(default=0.85, ge=0.0, le=1.0)
-    ctr: float = Field(default=0.02, ge=0.0, le=1.0)
-    viewability: float = Field(default=0.65, ge=0.0, le=1.0)
-    scenario: str = Field(default="normal")
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = Field(default=False, description="Enable delivery simulation loop")
+    time_acceleration: int = Field(
+        default=3600,
+        ge=1,
+        description="Seconds of simulated time per real second (default 3600 = 1s real per 1h sim)",
+    )
+    update_interval_seconds: float = Field(
+        default=1.0,
+        gt=0,
+        description="Real-world seconds between simulated delivery updates",
+    )
+
+
+class MockProductConfig(BaseProductConfig):
+    """Product config for Mock adapter simulation parameters.
+
+    Stored in Product.implementation_config; controls the synthetic delivery,
+    pricing, and behavior of the mock ad server when fulfilling media buys
+    against this product. Used for development and testing only.
+
+    Registered as MockAdServer.product_config_class and validated at the
+    adapter boundary on read.
+    """
+
+    adapter_type: Literal["mock"] = Field(
+        default="mock",
+        description="Adapter discriminator for typed implementation_config dispatch.",
+    )
+
+    # Delivery characteristics
+    daily_impressions: int = Field(
+        default=100_000,
+        ge=1000,
+        description="Simulated daily impressions available for this product",
+    )
+    fill_rate: float = Field(
+        default=85.0,
+        ge=0.0,
+        le=100.0,
+        description="Percentage of requested impressions delivered (0-100)",
+    )
+    ctr: float = Field(
+        default=0.5,
+        ge=0.0,
+        le=100.0,
+        description="Simulated click-through rate as percent (0-100)",
+    )
+    viewability_rate: float = Field(
+        default=70.0,
+        ge=0.0,
+        le=100.0,
+        description="Simulated viewability rate as percent (0-100)",
+    )
+    latency_ms: int = Field(
+        default=50,
+        ge=0,
+        description="Simulated ad-serving latency in milliseconds",
+    )
+    error_rate: float = Field(
+        default=0.1,
+        ge=0.0,
+        le=100.0,
+        description="Simulated error rate as percent (0-100)",
+    )
+
+    # Behavior modes
+    test_mode: Literal["normal", "slow", "fast", "uneven", "error"] = Field(
+        default="normal",
+        description="Test mode profile",
+    )
+    price_variance: float = Field(
+        default=10.0,
+        ge=0.0,
+        description="Simulated price variance as percent of base CPM",
+    )
+    seasonal_factor: float = Field(
+        default=1.0,
+        gt=0.0,
+        description="Multiplier applied to delivery to simulate seasonality",
+    )
+
+    # Operator toggles
+    verbose_logging: bool = Field(
+        default=False,
+        description="Emit verbose adapter logs for this product",
+    )
+    predictable_ids: bool = Field(
+        default=False,
+        description="Generate deterministic IDs for snapshot-friendly tests",
+    )
+
+    # Time-accelerated delivery loop
+    delivery_simulation: MockDeliverySimulation = Field(
+        default_factory=MockDeliverySimulation,
+        description="Time-acceleration parameters for the delivery simulator",
+    )
+
+
+def parse_implementation_config(config: dict | None) -> MockProductConfig:
+    """Parse Product.implementation_config into MockProductConfig.
+
+    Returns default-constructed instance on empty/None input; validates strict otherwise.
+    """
+    if not config:
+        return MockProductConfig()
+    return MockProductConfig.model_validate(config)
 
 
 class MockAdServer(AdServerAdapter):
@@ -1380,57 +1483,53 @@ class MockAdServer(AdServerAdapter):
                     config = product_obj.implementation_config or {}
 
                     if request.method == "POST":
-                        # Update configuration
-                        new_config = {
-                            "daily_impressions": int(request.form.get("daily_impressions", 100000)),
-                            "fill_rate": float(request.form.get("fill_rate", 85)),
-                            "ctr": float(request.form.get("ctr", 0.5)),
-                            "viewability_rate": float(request.form.get("viewability_rate", 70)),
-                            "latency_ms": int(request.form.get("latency_ms", 50)),
-                            "error_rate": float(request.form.get("error_rate", 0.1)),
-                            "test_mode": request.form.get("test_mode", "normal"),
-                            "price_variance": float(request.form.get("price_variance", 10)),
-                            "seasonal_factor": float(request.form.get("seasonal_factor", 1.0)),
-                            "verbose_logging": "verbose_logging" in request.form,
-                            "predictable_ids": "predictable_ids" in request.form,
-                            "delivery_simulation": {
-                                "enabled": "delivery_simulation_enabled" in request.form,
-                                "time_acceleration": int(request.form.get("time_acceleration", 3600)),
-                                "update_interval_seconds": float(request.form.get("update_interval_seconds", 1.0)),
-                            },
-                        }
+                        from src.admin.blueprints.products import get_creative_formats
 
-                        # Handle format selection
-                        formats = request.form.getlist("formats")
-                        if formats:
-                            product_obj.format_ids = formats
+                        # Read form selections up-front so the user's choices survive
+                        # a validation failure (don't fall back to DB-stored selection).
+                        submitted_formats = request.form.getlist("formats")
+                        available_formats = get_creative_formats(tenant_id=tenant_id)
 
-                        # Validate the configuration
-                        validation_errors = self.validate_product_config(new_config)
-                        if validation_errors:
-                            # Get formats for re-rendering
-                            from src.admin.blueprints.products import get_creative_formats
-
-                            available_formats = get_creative_formats(tenant_id=tenant_id)
-
+                        # Build typed config from form (Pydantic validates ranges,
+                        # test_mode profile, and the adapter_type discriminator).
+                        try:
+                            validated = MockProductConfig(
+                                daily_impressions=int(request.form.get("daily_impressions", 100000)),
+                                fill_rate=float(request.form.get("fill_rate", 85)),
+                                ctr=float(request.form.get("ctr", 0.5)),
+                                viewability_rate=float(request.form.get("viewability_rate", 70)),
+                                latency_ms=int(request.form.get("latency_ms", 50)),
+                                error_rate=float(request.form.get("error_rate", 0.1)),
+                                test_mode=request.form.get("test_mode", "normal"),
+                                price_variance=float(request.form.get("price_variance", 10)),
+                                seasonal_factor=float(request.form.get("seasonal_factor", 1.0)),
+                                verbose_logging="verbose_logging" in request.form,
+                                predictable_ids="predictable_ids" in request.form,
+                                delivery_simulation=MockDeliverySimulation(
+                                    enabled="delivery_simulation_enabled" in request.form,
+                                    time_acceleration=int(request.form.get("time_acceleration", 3600)),
+                                    update_interval_seconds=float(request.form.get("update_interval_seconds", 1.0)),
+                                ),
+                            )
+                        except ValidationError as exc:
                             return render_template(
                                 "adapters/mock_product_config.html",
                                 tenant_id=tenant_id,
                                 product=product,
                                 config=config,
                                 formats=available_formats,
-                                selected_formats=product_obj.format_ids or [],
-                                error=validation_errors[0],
+                                selected_formats=submitted_formats or product_obj.format_ids or [],
+                                error="; ".join(
+                                    f"{'.'.join(str(p) for p in e['loc'])}: {e['msg']}" for e in exc.errors()
+                                ),
                             )
 
-                        # Save to database
+                        # Save format selection + validated config (commit together).
+                        if submitted_formats:
+                            product_obj.format_ids = submitted_formats
+                        new_config = validated.model_dump()
                         product_obj.implementation_config = new_config
                         session.commit()
-
-                        # Get formats for success page
-                        from src.admin.blueprints.products import get_creative_formats
-
-                        available_formats = get_creative_formats(tenant_id=tenant_id)
 
                         return render_template(
                             "adapters/mock_product_config.html",
@@ -1459,30 +1558,16 @@ class MockAdServer(AdServerAdapter):
             return wrapped_view()
 
     def validate_product_config(self, config: dict[str, Any]) -> tuple[bool, str | None]:
-        """Validate mock adapter configuration."""
-        errors: list[str] = []
+        """Validate mock adapter configuration via the typed schema.
 
-        # Validate ranges
-        if config.get("fill_rate", 0) < 0 or config.get("fill_rate", 0) > 100:
-            errors.append("Fill rate must be between 0 and 100")
-
-        if config.get("error_rate", 0) < 0 or config.get("error_rate", 0) > 100:
-            errors.append("Error rate must be between 0 and 100")
-
-        if config.get("ctr", 0) < 0 or config.get("ctr", 0) > 100:
-            errors.append("CTR must be between 0 and 100")
-
-        if config.get("viewability_rate", 0) < 0 or config.get("viewability_rate", 0) > 100:
-            errors.append("Viewability rate must be between 0 and 100")
-
-        if config.get("daily_impressions", 0) < 1000:
-            errors.append("Daily impressions must be at least 1000")
-
-        if config.get("latency_ms", 0) < 0:
-            errors.append("Latency cannot be negative")
-
-        if errors:
-            return False, "; ".join(errors)
+        Delegates to parse_implementation_config — Pydantic field validators
+        replace the previous hand-written range checks. Returns (True, None)
+        on success or (False, "field: msg; ...") on validation failure.
+        """
+        try:
+            parse_implementation_config(config)
+        except ValidationError as exc:
+            return False, "; ".join(f"{'.'.join(str(p) for p in e['loc'])}: {e['msg']}" for e in exc.errors())
         return True, None
 
     def _calculate_delivery_progress(self, profile: str, current_day: int, total_days: int) -> float:

--- a/tests/unit/adapters/test_schemas.py
+++ b/tests/unit/adapters/test_schemas.py
@@ -12,7 +12,14 @@ from src.adapters import (
     TargetingCapabilities,
     get_adapter_schemas,
 )
-from src.adapters.mock_ad_server import MockConnectionConfig, MockProductConfig
+from src.adapters.mock_ad_server import (
+    MockConnectionConfig,
+    MockDeliverySimulation,
+    MockProductConfig,
+)
+from src.adapters.mock_ad_server import (
+    parse_implementation_config as parse_mock_implementation_config,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -56,26 +63,116 @@ class TestMockSchemas:
         assert config.dry_run is True
 
     def test_mock_product_config_defaults(self):
-        """MockProductConfig should have simulation defaults."""
+        """MockProductConfig should have simulation defaults.
+
+        Reconciled in #1239: 13 fields with percent units (0-100) covering
+        delivery, behavior modes, operator toggles, and the time-acceleration
+        nested config. Replaces the earlier 5-field fraction-based shape.
+        """
         config = MockProductConfig()
-        assert config.daily_impressions == 10000
-        assert config.fill_rate == 0.85
-        assert config.ctr == 0.02
-        assert config.viewability == 0.65
-        assert config.scenario == "normal"
+        assert config.adapter_type == "mock"
+        assert config.daily_impressions == 100_000
+        assert config.fill_rate == 85.0
+        assert config.ctr == 0.5
+        assert config.viewability_rate == 70.0
+        assert config.latency_ms == 50
+        assert config.error_rate == 0.1
+        assert config.test_mode == "normal"
+        assert config.delivery_simulation.enabled is False
 
     def test_mock_product_config_validation(self):
-        """MockProductConfig should validate field constraints."""
-        # fill_rate must be between 0 and 1
+        """MockProductConfig should validate field constraints.
+
+        Range validators enforce percent semantics (0-100), replacing the
+        manual range checks in the legacy validate_product_config method.
+        """
+        # fill_rate must be between 0 and 100 (percent)
         with pytest.raises(ValidationError):
-            MockProductConfig(fill_rate=1.5)
+            MockProductConfig(fill_rate=101.0)
 
         with pytest.raises(ValidationError):
             MockProductConfig(fill_rate=-0.1)
 
-        # daily_impressions must be non-negative
+        # daily_impressions has a 1000 floor (matches legacy validate_product_config)
         with pytest.raises(ValidationError):
-            MockProductConfig(daily_impressions=-100)
+            MockProductConfig(daily_impressions=999)
+
+        # test_mode must be one of the known profiles
+        with pytest.raises(ValidationError):
+            MockProductConfig(test_mode="lightspeed")
+
+        # adapter_type Literal rejects other adapter discriminators
+        with pytest.raises(ValidationError):
+            MockProductConfig(adapter_type="google_ad_manager")
+
+    @pytest.mark.parametrize(
+        "field,bad_value",
+        [
+            ("fill_rate", -1),
+            ("fill_rate", 101),
+            ("error_rate", 100.1),
+            ("ctr", -0.5),
+            ("viewability_rate", 100.1),
+            ("daily_impressions", 999),
+            ("latency_ms", -5),
+            ("seasonal_factor", 0),
+        ],
+    )
+    def test_mock_product_config_range_validation(self, field, bad_value):
+        """MockProductConfig per-field range validators reject out-of-bounds values."""
+        with pytest.raises(ValidationError):
+            MockProductConfig(**{field: bad_value})
+
+    def test_mock_product_config_delivery_simulation_nested(self):
+        """delivery_simulation nests MockDeliverySimulation, validates its fields."""
+        config = MockProductConfig(
+            delivery_simulation={"enabled": True, "time_acceleration": 7200, "update_interval_seconds": 0.5}
+        )
+        assert isinstance(config.delivery_simulation, MockDeliverySimulation)
+        assert config.delivery_simulation.time_acceleration == 7200
+
+        # nested validation: time_acceleration must be >= 1
+        with pytest.raises(ValidationError):
+            MockProductConfig(delivery_simulation={"time_acceleration": 0})
+
+        # nested forbids extras — typo'd field rejected, not silently dropped
+        with pytest.raises(ValidationError):
+            MockProductConfig(delivery_simulation={"enabled": True, "tyepo_field": 1})
+
+
+class TestParseMockImplementationConfig:
+    """Tests for the Mock parse_implementation_config helper."""
+
+    def test_none_returns_default(self):
+        assert parse_mock_implementation_config(None) == MockProductConfig()
+
+    def test_empty_dict_returns_default(self):
+        assert parse_mock_implementation_config({}) == MockProductConfig()
+
+    def test_partial_dict_overlays_on_defaults(self):
+        config = parse_mock_implementation_config({"daily_impressions": 50_000, "test_mode": "fast"})
+        assert config.daily_impressions == 50_000
+        assert config.test_mode == "fast"
+        assert config.fill_rate == 85.0  # default preserved
+
+    def test_invalid_dict_raises(self):
+        with pytest.raises(ValidationError):
+            parse_mock_implementation_config({"fill_rate": 200})
+
+    def test_round_trip_through_dict(self):
+        original = MockProductConfig(
+            daily_impressions=50_000,
+            ctr=1.2,
+            delivery_simulation=MockDeliverySimulation(
+                enabled=True, time_acceleration=7200, update_interval_seconds=0.5
+            ),
+        )
+        round_tripped = parse_mock_implementation_config(original.model_dump())
+        assert round_tripped == original
+        assert round_tripped.adapter_type == "mock"
+        # nested model survives JSONType-shaped round-trip (dict → model → dict)
+        assert round_tripped.delivery_simulation.enabled is True
+        assert round_tripped.delivery_simulation.time_acceleration == 7200
 
 
 class TestAdapterCapabilities:
@@ -173,15 +270,18 @@ class TestSchemaJsonSerialization:
         assert "manual_approval_required" in schema["properties"]
 
     def test_mock_product_config_json_schema(self):
-        """MockProductConfig should generate valid JSON schema."""
+        """MockProductConfig should generate valid JSON schema.
+
+        Reconciled in #1239: fill_rate is now a percent (0-100) not a fraction (0-1).
+        """
         schema = MockProductConfig.model_json_schema()
         assert "properties" in schema
         assert "daily_impressions" in schema["properties"]
         assert "fill_rate" in schema["properties"]
-        # Check that constraints are in schema
+        # Check that constraints are in schema (percent units now)
         fill_rate_schema = schema["properties"]["fill_rate"]
         assert fill_rate_schema.get("minimum") == 0.0
-        assert fill_rate_schema.get("maximum") == 1.0
+        assert fill_rate_schema.get("maximum") == 100.0
 
     def test_schema_descriptions_present(self):
         """Schema fields should have descriptions."""

--- a/tests/unit/admin/test_adapter_blueprints.py
+++ b/tests/unit/admin/test_adapter_blueprints.py
@@ -87,7 +87,12 @@ class TestAdapterConfigValidation:
             schemas.connection_config(unknown_field="value")
 
     def test_mock_product_config_validates_ranges(self):
-        """MockProductConfig should enforce value ranges."""
+        """MockProductConfig should enforce value ranges.
+
+        Reconciled in #1239: percent-based (0-100) range checks via Pydantic
+        Field constraints, replacing the legacy fraction-based MockProductConfig
+        and the parallel validate_product_config method.
+        """
         from pydantic import ValidationError
 
         from src.adapters import get_adapter_schemas
@@ -95,17 +100,18 @@ class TestAdapterConfigValidation:
         schemas = get_adapter_schemas("mock")
         MockProductConfig = schemas.product_config
 
-        # Valid ranges
-        valid = MockProductConfig(fill_rate=0.5, ctr=0.05, viewability=0.7)
-        assert valid.fill_rate == 0.5
+        # Valid ranges (percents 0-100)
+        valid = MockProductConfig(fill_rate=50.0, ctr=5.0, viewability_rate=70.0)
+        assert valid.fill_rate == 50.0
+        assert valid.adapter_type == "mock"
 
-        # Invalid: fill_rate > 1
+        # Invalid: fill_rate > 100 (percent)
         with pytest.raises(ValidationError):
-            MockProductConfig(fill_rate=1.5)
+            MockProductConfig(fill_rate=150.0)
 
-        # Invalid: negative impressions
+        # Invalid: daily_impressions below 1000 floor
         with pytest.raises(ValidationError):
-            MockProductConfig(daily_impressions=-1)
+            MockProductConfig(daily_impressions=999)
 
 
 class TestCapabilitiesEndpointLogic:


### PR DESCRIPTION
## Summary

Picks up the dormant Phase 2 work from issue #996 ("Adapter Schema System") for the Mock adapter. First of three sub-issues under #1239 — Broadstreet and GAM follow in their own PRs once the pattern is approved here.

Phase 1 (#1007) registered `MockProductConfig` as `product_config_class` but the schema was 5 fields with fractional units (0–1) while the admin form actually saved a 13-field percent-units (0–100) shape that nothing validated against. The legacy `validate_product_config` method also had a tuple-truthiness bug (returns `tuple[bool, str | None]`, call site treated it as a list of error strings) — meaning validation **never fired**.

This PR collapses the two-source-of-truth into a single `MockProductConfig` used at both the form save boundary AND the runtime adapter contract.

## What changed

**`src/adapters/mock_ad_server.py`**
- `MockProductConfig`: 13 fields with percent units, `adapter_type: Literal["mock"]` discriminator, nested `MockDeliverySimulation` (with `extra="forbid"`), `test_mode: Literal[...]` (replaces hand-written `field_validator`), real Pydantic range validators on every numeric
- `parse_implementation_config()`: typed parser, returns default-constructed instance on empty/None, validates strict otherwise
- Admin POST handler: replaces inline dict-build + broken legacy validator with `try`/`except ValidationError`. **Submitted format selections now survive validation failures** (used to silently fall back to DB-stored selection). Error messages include field path via `loc` prefix.
- `validate_product_config()`: delegates to `parse_implementation_config` so the helper is wired in `src/`. Preserves base-class `tuple[bool, str | None]` contract until Broadstreet+GAM reconciliation completes.

**`tests/unit/adapters/test_schemas.py` and `tests/unit/admin/test_adapter_blueprints.py`**
- Fraction-based assertions → percent-based shape
- Parametrized range validation across 8 boundary cases
- Nested `MockDeliverySimulation` `extra="forbid"` coverage
- Round-trip test extended to validate JSONType-shaped dict→model→dict for nested `delivery_simulation`
- New `TestParseMockImplementationConfig`: helper coverage (None default, partial overlay, ValidationError propagation, round-trip)

## Reviewer feedback applied (Round 1)

`code-reviewer` and `python-expert` both reviewed before push. All block-merge and should-fix items applied:
- Format selection bug on validation failure → fixed (read submitted formats before try, pass to both branches)
- ValidationError messages losing field context → fixed (`loc` prefix in join)
- Outer-strict / inner-permissive footgun on `MockDeliverySimulation` → fixed (explicit `ConfigDict(extra="forbid")`)
- Dead `parse_implementation_config` in `src/` → fixed (wired through `validate_product_config` override)
- Test data sloppiness: `error_rate=200` against `le=100` → fixed (`100.1`)
- `test_mode: str + field_validator` → `test_mode: Literal[...]` (cleaner JSON schema, removes hand-written validator)

## Test plan

- [x] `make quality` clean (4298 unit tests pass, ruff format, ruff check, mypy)
- [x] `tox -e admin` ✓
- [x] `tox -e ui` ✓
- [x] `tox -e e2e` ✓
- [x] `tox -e unit` ✓
- [x] Targeted: `tests/integration/test_list_creatives_auth.py` and the broader Mock surface pass in isolation
- [ ] CI re-runs the full integration suite

**Note on `tox -e integration`:** the full integration suite has pre-existing test pollution that surfaces flaky failures in different tests on each run, irrespective of this PR's diff. Verified by running tox integration on HEAD~1 (without my changes): 1 setup error in `test_creative_formats_id_filters.py`. At HEAD with my changes: 3 failures in `test_list_creatives_auth.py`. Same total test count both runs; tests that fail in the suite all pass in isolation; Mock schema diff has zero overlap with the failing tests' code paths. Pushed with `--no-verify` after authorization. Worth filing a separate tracking issue for the integration pollution.

## Out of scope (deferred)

- **Broadstreet reconciliation** (`BroadstreetImplementationConfig` → `BroadstreetProductConfig` at the registered slot) — separate sub-issue under #1239
- **GAM reconciliation** — schema needs `supported_format_types` and `time_zone` added (surfaced during the audit) plus 30+ adapter-boundary read-site rewrites
- **Migration-as-audit** — Alembic step that validates all existing `Product.implementation_config` rows against the reconciled schemas
- **Phase 3 of #996**: dynamic admin form generation from `model_json_schema()`

## Refs

- Parent: #996 (reopened — was incorrectly closed during a triage sweep)
- Sub-issue tracker: #1239
- Phase 1: #1007 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)