### PR TITLE
feat(adapters): reconcile BroadstreetProductConfig schema (Phase 2 of #996)

### DIFF
--- a/src/adapters/broadstreet/__init__.py
+++ b/src/adapters/broadstreet/__init__.py
@@ -12,14 +12,16 @@ from .adapter import BroadstreetAdapter
 from .client import BroadstreetAPIError, BroadstreetClient
 from .config_schema import (
     BROADSTREET_TEMPLATES,
-    BroadstreetImplementationConfig,
-    CreativeSize,
-    ZoneTargeting,
     get_template_info,
-    parse_implementation_config,
     validate_template_assets,
 )
-from .schemas import BroadstreetConnectionConfig, BroadstreetProductConfig
+from .schemas import (
+    BroadstreetConnectionConfig,
+    BroadstreetProductConfig,
+    CreativeSize,
+    ZoneTargeting,
+    parse_implementation_config,
+)
 
 __all__ = [
     "BROADSTREET_TEMPLATES",
@@ -27,7 +29,6 @@ __all__ = [
     "BroadstreetAPIError",
     "BroadstreetClient",
     "BroadstreetConnectionConfig",
-    "BroadstreetImplementationConfig",
     "BroadstreetProductConfig",
     "CreativeSize",
     "ZoneTargeting",

--- a/src/adapters/broadstreet/adapter.py
+++ b/src/adapters/broadstreet/adapter.py
@@ -24,7 +24,6 @@ from src.adapters.base import (
     TargetingCapabilities,
 )
 from src.adapters.broadstreet.client import BroadstreetClient
-from src.adapters.broadstreet.config_schema import parse_implementation_config
 from src.adapters.broadstreet.managers import (
     BroadstreetAdvertisementManager,
     BroadstreetCampaignManager,
@@ -32,7 +31,11 @@ from src.adapters.broadstreet.managers import (
     BroadstreetPlacementManager,
     BroadstreetWorkflowManager,
 )
-from src.adapters.broadstreet.schemas import BroadstreetConnectionConfig, BroadstreetProductConfig
+from src.adapters.broadstreet.schemas import (
+    BroadstreetConnectionConfig,
+    BroadstreetProductConfig,
+    parse_implementation_config,
+)
 from src.adapters.constants import REQUIRED_UPDATE_ACTIONS
 from src.core.schemas import (
     AdapterGetMediaBuyDeliveryResponse,

--- a/src/adapters/broadstreet/config_schema.py
+++ b/src/adapters/broadstreet/config_schema.py
@@ -1,13 +1,15 @@
-"""Broadstreet adapter configuration schemas.
+"""Broadstreet creative template metadata.
 
-Defines the configuration models for Broadstreet products and adapters.
+BROADSTREET_TEMPLATES enumerates the ad templates Broadstreet supports, with
+required and optional asset slots per template. Used by the advertisement
+manager to validate creative payloads before submission.
+
+Product/connection schemas live in schemas.py — this module is template
+metadata only.
 """
 
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
-
-# Broadstreet template definitions
 # Each template has required assets that must be provided
 BROADSTREET_TEMPLATES = {
     # Basic types (no template - direct content)
@@ -118,156 +120,3 @@ def validate_template_assets(template_type: str, assets: dict[str, Any]) -> tupl
         return False, f"Missing required assets for {template_type}: {', '.join(missing)}"
 
     return True, None
-
-
-class CreativeSize(BaseModel):
-    """Defines expected creative dimensions for a zone."""
-
-    width: int = Field(..., description="Creative width in pixels")
-    height: int = Field(..., description="Creative height in pixels")
-    expected_count: int = Field(1, ge=1, description="Number of creatives expected for this size")
-
-
-class ZoneTargeting(BaseModel):
-    """Broadstreet zone targeting configuration."""
-
-    zone_id: str = Field(..., description="Broadstreet zone ID")
-    zone_name: str | None = Field(None, description="Human-readable zone name")
-    sizes: list[CreativeSize] = Field(default_factory=list, description="Supported creative sizes")
-    position: str | None = Field(None, description="Ad position (above_fold, below_fold)")
-
-
-class BroadstreetImplementationConfig(BaseModel):
-    """Configuration for creating Broadstreet campaigns/placements.
-
-    This is stored in Product.implementation_config and controls how
-    campaigns are created in Broadstreet when a media buy is executed.
-    """
-
-    # Zone/placement targeting (core Broadstreet concept)
-    targeted_zone_ids: list[str] = Field(
-        default_factory=list,
-        description="Broadstreet zone IDs to target",
-    )
-    zone_targeting: list[ZoneTargeting] = Field(
-        default_factory=list,
-        description="Detailed zone targeting with sizes",
-    )
-
-    # Campaign naming
-    campaign_name_template: str = Field(
-        default="AdCP-{po_number}-{product_name}",
-        description="Template for campaign naming. Supports: {po_number}, {product_name}, {advertiser_name}, {timestamp}",
-    )
-
-    # Pricing settings
-    cost_type: str = Field(
-        default="CPM",
-        description="Pricing model: CPM or FLAT_RATE",
-    )
-
-    # Delivery settings
-    delivery_rate: str = Field(
-        default="EVEN",
-        description="Delivery pacing: EVEN, FRONTLOADED, ASAP",
-    )
-    frequency_cap: int | None = Field(
-        default=None,
-        ge=1,
-        description="Max impressions per user per day",
-    )
-
-    # Creative specifications
-    creative_sizes: list[CreativeSize] = Field(
-        default_factory=list,
-        description="Expected creative sizes for this product",
-    )
-
-    # Ad format settings
-    ad_format: str = Field(
-        default="display",
-        description="Primary ad format: display, html, text",
-    )
-    allow_html_creatives: bool = Field(
-        default=True,
-        description="Allow HTML/JavaScript creatives",
-    )
-    allow_text_creatives: bool = Field(
-        default=True,
-        description="Allow text-only creatives",
-    )
-
-    # Automation settings
-    automation_mode: str = Field(
-        default="manual",
-        description="Automation mode: 'automatic', 'confirmation_required', 'manual'",
-    )
-
-    @field_validator("cost_type")
-    @classmethod
-    def validate_cost_type(cls, v: str) -> str:
-        """Validate cost type is supported."""
-        valid_types = {"CPM", "FLAT_RATE"}
-        v_upper = v.upper()
-        if v_upper not in valid_types:
-            raise ValueError(f"Invalid cost_type '{v}'. Must be one of: {valid_types}")
-        return v_upper
-
-    @field_validator("delivery_rate")
-    @classmethod
-    def validate_delivery_rate(cls, v: str) -> str:
-        """Validate delivery rate is supported."""
-        valid_rates = {"EVEN", "FRONTLOADED", "ASAP"}
-        v_upper = v.upper()
-        if v_upper not in valid_rates:
-            raise ValueError(f"Invalid delivery_rate '{v}'. Must be one of: {valid_rates}")
-        return v_upper
-
-    @field_validator("ad_format")
-    @classmethod
-    def validate_ad_format(cls, v: str) -> str:
-        """Validate ad format is supported."""
-        valid_formats = {"display", "html", "text"}
-        v_lower = v.lower()
-        if v_lower not in valid_formats:
-            raise ValueError(f"Invalid ad_format '{v}'. Must be one of: {valid_formats}")
-        return v_lower
-
-    @field_validator("automation_mode")
-    @classmethod
-    def validate_automation_mode(cls, v: str) -> str:
-        """Validate automation mode is supported."""
-        valid_modes = {"automatic", "confirmation_required", "manual"}
-        v_lower = v.lower()
-        if v_lower not in valid_modes:
-            raise ValueError(f"Invalid automation_mode '{v}'. Must be one of: {valid_modes}")
-        return v_lower
-
-    def get_zone_ids(self) -> list[str]:
-        """Get all zone IDs from both targeted_zone_ids and zone_targeting."""
-        zone_ids = set(self.targeted_zone_ids)
-        for zt in self.zone_targeting:
-            zone_ids.add(zt.zone_id)
-        return list(zone_ids)
-
-    def get_creative_sizes_for_zone(self, zone_id: str) -> list[CreativeSize]:
-        """Get creative sizes for a specific zone."""
-        for zt in self.zone_targeting:
-            if zt.zone_id == zone_id:
-                return zt.sizes
-        # Fall back to global creative sizes
-        return self.creative_sizes
-
-
-def parse_implementation_config(config: dict[str, Any] | None) -> BroadstreetImplementationConfig:
-    """Parse implementation config dict into validated model.
-
-    Args:
-        config: Raw implementation config dict
-
-    Returns:
-        Validated BroadstreetImplementationConfig
-    """
-    if not config:
-        return BroadstreetImplementationConfig()
-    return BroadstreetImplementationConfig.model_validate(config)

--- a/src/adapters/broadstreet/managers/campaigns.py
+++ b/src/adapters/broadstreet/managers/campaigns.py
@@ -10,9 +10,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from src.adapters.broadstreet.client import BroadstreetClient
-from src.adapters.broadstreet.config_schema import (
-    parse_implementation_config,
-)
+from src.adapters.broadstreet.schemas import parse_implementation_config
 
 logger = logging.getLogger(__name__)
 

--- a/src/adapters/broadstreet/managers/placements.py
+++ b/src/adapters/broadstreet/managers/placements.py
@@ -11,7 +11,7 @@ from collections.abc import Callable
 from typing import Any
 
 from src.adapters.broadstreet.client import BroadstreetClient
-from src.adapters.broadstreet.config_schema import parse_implementation_config
+from src.adapters.broadstreet.schemas import parse_implementation_config
 
 logger = logging.getLogger(__name__)
 

--- a/src/adapters/broadstreet/schemas.py
+++ b/src/adapters/broadstreet/schemas.py
@@ -1,9 +1,24 @@
 """Broadstreet adapter configuration schemas.
 
-Defines connection and product configuration for the admin UI schema system.
+Single source of truth for Broadstreet-adapter Pydantic shapes:
+- BroadstreetConnectionConfig: tenant-level API credentials
+- BroadstreetProductConfig: per-product implementation_config (registered as
+  product_config_class on BroadstreetAdapter; validated at the adapter
+  boundary on read via parse_implementation_config)
+
+Reconciles the historical split between the admin-slot ProductConfig (7
+fields, json_schema_extra-driven) and the runtime
+BroadstreetImplementationConfig (12 fields, field-validator-driven). Phase 2
+of #996 — sister to MockProductConfig (#1240) and the upcoming GAM
+reconciliation.
+
+Creative template metadata (BROADSTREET_TEMPLATES + helpers) lives separately
+in config_schema.py — it's a different concern from product config.
 """
 
-from pydantic import Field
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, field_validator
 
 from src.adapters.base import BaseConnectionConfig, BaseProductConfig
 
@@ -31,32 +46,64 @@ class BroadstreetConnectionConfig(BaseConnectionConfig):
     )
 
 
-class BroadstreetProductConfig(BaseProductConfig):
-    """Product-level configuration for Broadstreet.
+class CreativeSize(BaseModel):
+    """Defines expected creative dimensions for a zone."""
 
-    Stored in Product.implementation_config. Controls how campaigns
-    are created in Broadstreet when a media buy is executed.
+    width: int = Field(..., description="Creative width in pixels")
+    height: int = Field(..., description="Creative height in pixels")
+    expected_count: int = Field(1, ge=1, description="Number of creatives expected for this size")
+
+
+class ZoneTargeting(BaseModel):
+    """Broadstreet zone targeting configuration."""
+
+    zone_id: str = Field(..., description="Broadstreet zone ID")
+    zone_name: str | None = Field(None, description="Human-readable zone name")
+    sizes: list[CreativeSize] = Field(default_factory=list, description="Supported creative sizes")
+    position: str | None = Field(None, description="Ad position (above_fold, below_fold)")
+
+
+class BroadstreetProductConfig(BaseProductConfig):
+    """Per-product Broadstreet adapter configuration.
+
+    Stored in Product.implementation_config; controls how Broadstreet
+    campaigns/placements are created when fulfilling a media buy. Registered
+    as BroadstreetAdapter.product_config_class and validated at the adapter
+    boundary on read.
     """
 
-    # Zone targeting (core Broadstreet concept)
+    adapter_type: Literal["broadstreet"] = Field(
+        default="broadstreet",
+        description="Adapter discriminator for typed implementation_config dispatch.",
+    )
+
+    # Zone/placement targeting (core Broadstreet concept)
     targeted_zone_ids: list[str] = Field(
         default_factory=list,
         description="Broadstreet zone IDs to target",
         json_schema_extra={"ui_component": "zone_selector"},
+    )
+    zone_targeting: list[ZoneTargeting] = Field(
+        default_factory=list,
+        description="Detailed zone targeting with sizes",
+    )
+
+    # Campaign naming
+    campaign_name_template: str = Field(
+        default="AdCP-{po_number}-{product_name}",
+        description="Campaign naming template. Variables: {po_number}, {product_name}, {advertiser_name}, {timestamp}",
     )
 
     # Pricing
     cost_type: str = Field(
         default="CPM",
         description="Pricing model: CPM or FLAT_RATE",
-        json_schema_extra={"enum": ["CPM", "FLAT_RATE"]},
     )
 
-    # Delivery settings
+    # Delivery
     delivery_rate: str = Field(
         default="EVEN",
-        description="Delivery pacing",
-        json_schema_extra={"enum": ["EVEN", "FRONTLOADED", "ASAP"]},
+        description="Delivery pacing: EVEN, FRONTLOADED, ASAP",
     )
     frequency_cap: int | None = Field(
         default=None,
@@ -64,11 +111,16 @@ class BroadstreetProductConfig(BaseProductConfig):
         description="Max impressions per user per day",
     )
 
-    # Ad format settings
+    # Creative specifications
+    creative_sizes: list[CreativeSize] = Field(
+        default_factory=list,
+        description="Expected creative sizes for this product (zone-level overrides via zone_targeting)",
+    )
+
+    # Ad format
     ad_format: str = Field(
         default="display",
-        description="Primary ad format",
-        json_schema_extra={"enum": ["display", "html", "text"]},
+        description="Primary ad format: display, html, text",
     )
     allow_html_creatives: bool = Field(
         default=True,
@@ -78,3 +130,69 @@ class BroadstreetProductConfig(BaseProductConfig):
         default=True,
         description="Allow text-only creatives",
     )
+
+    # Automation
+    automation_mode: str = Field(
+        default="manual",
+        description="Automation mode: 'automatic', 'confirmation_required', 'manual'",
+    )
+
+    @field_validator("cost_type")
+    @classmethod
+    def validate_cost_type(cls, v: str) -> str:
+        valid = {"CPM", "FLAT_RATE"}
+        v_upper = v.upper()
+        if v_upper not in valid:
+            raise ValueError(f"Invalid cost_type '{v}'. Must be one of: {valid}")
+        return v_upper
+
+    @field_validator("delivery_rate")
+    @classmethod
+    def validate_delivery_rate(cls, v: str) -> str:
+        valid = {"EVEN", "FRONTLOADED", "ASAP"}
+        v_upper = v.upper()
+        if v_upper not in valid:
+            raise ValueError(f"Invalid delivery_rate '{v}'. Must be one of: {valid}")
+        return v_upper
+
+    @field_validator("ad_format")
+    @classmethod
+    def validate_ad_format(cls, v: str) -> str:
+        valid = {"display", "html", "text"}
+        v_lower = v.lower()
+        if v_lower not in valid:
+            raise ValueError(f"Invalid ad_format '{v}'. Must be one of: {valid}")
+        return v_lower
+
+    @field_validator("automation_mode")
+    @classmethod
+    def validate_automation_mode(cls, v: str) -> str:
+        valid = {"automatic", "confirmation_required", "manual"}
+        v_lower = v.lower()
+        if v_lower not in valid:
+            raise ValueError(f"Invalid automation_mode '{v}'. Must be one of: {valid}")
+        return v_lower
+
+    def get_zone_ids(self) -> list[str]:
+        """Return all zone IDs from targeted_zone_ids and zone_targeting (deduped)."""
+        zone_ids = set(self.targeted_zone_ids)
+        for zt in self.zone_targeting:
+            zone_ids.add(zt.zone_id)
+        return list(zone_ids)
+
+    def get_creative_sizes_for_zone(self, zone_id: str) -> list[CreativeSize]:
+        """Return creative sizes for a zone, falling back to global creative_sizes."""
+        for zt in self.zone_targeting:
+            if zt.zone_id == zone_id:
+                return zt.sizes
+        return self.creative_sizes
+
+
+def parse_implementation_config(config: dict[str, Any] | None) -> BroadstreetProductConfig:
+    """Parse Product.implementation_config into BroadstreetProductConfig.
+
+    Returns default-constructed instance on empty/None input; validates strict otherwise.
+    """
+    if not config:
+        return BroadstreetProductConfig()
+    return BroadstreetProductConfig.model_validate(config)

--- a/tests/unit/adapters/broadstreet/test_schemas.py
+++ b/tests/unit/adapters/broadstreet/test_schemas.py
@@ -1,9 +1,10 @@
-"""Unit tests for Broadstreet config schema."""
+"""Unit tests for Broadstreet schemas (connection + product config)."""
 
 import pytest
+from pydantic import ValidationError
 
-from src.adapters.broadstreet.config_schema import (
-    BroadstreetImplementationConfig,
+from src.adapters.broadstreet.schemas import (
+    BroadstreetProductConfig,
     CreativeSize,
     ZoneTargeting,
     parse_implementation_config,
@@ -14,7 +15,6 @@ class TestCreativeSize:
     """Tests for CreativeSize model."""
 
     def test_valid_creative_size(self):
-        """Test creating a valid creative size."""
         size = CreativeSize(width=300, height=250)
 
         assert size.width == 300
@@ -22,13 +22,11 @@ class TestCreativeSize:
         assert size.expected_count == 1
 
     def test_creative_size_with_expected_count(self):
-        """Test creative size with custom expected count."""
         size = CreativeSize(width=728, height=90, expected_count=3)
 
         assert size.expected_count == 3
 
     def test_creative_size_requires_positive_count(self):
-        """Test that expected_count must be positive."""
         with pytest.raises(ValueError):
             CreativeSize(width=300, height=250, expected_count=0)
 
@@ -37,7 +35,6 @@ class TestZoneTargeting:
     """Tests for ZoneTargeting model."""
 
     def test_minimal_zone_targeting(self):
-        """Test creating zone targeting with minimal fields."""
         zone = ZoneTargeting(zone_id="zone_123")
 
         assert zone.zone_id == "zone_123"
@@ -46,7 +43,6 @@ class TestZoneTargeting:
         assert zone.position is None
 
     def test_full_zone_targeting(self):
-        """Test creating zone targeting with all fields."""
         zone = ZoneTargeting(
             zone_id="zone_123",
             zone_name="Top Banner",
@@ -63,35 +59,56 @@ class TestZoneTargeting:
         assert zone.position == "above_fold"
 
 
-class TestBroadstreetImplementationConfig:
-    """Tests for BroadstreetImplementationConfig model."""
+class TestBroadstreetProductConfig:
+    """Tests for BroadstreetProductConfig.
+
+    Reconciled in #1239: single 12-field schema (was split between admin
+    BroadstreetProductConfig (7 fields) and runtime
+    BroadstreetImplementationConfig (12 fields)).
+    """
 
     def test_default_config(self):
-        """Test default configuration values."""
-        config = BroadstreetImplementationConfig()
+        config = BroadstreetProductConfig()
 
+        assert config.adapter_type == "broadstreet"
         assert config.targeted_zone_ids == []
         assert config.zone_targeting == []
         assert config.campaign_name_template == "AdCP-{po_number}-{product_name}"
         assert config.cost_type == "CPM"
         assert config.delivery_rate == "EVEN"
         assert config.frequency_cap is None
+        assert config.creative_sizes == []
         assert config.ad_format == "display"
+        assert config.allow_html_creatives is True
+        assert config.allow_text_creatives is True
         assert config.automation_mode == "manual"
 
+    def test_adapter_type_locked(self):
+        """adapter_type is a Literal discriminator — rejects other values."""
+        with pytest.raises(ValidationError):
+            BroadstreetProductConfig(adapter_type="google_ad_manager")
+
+    def test_round_trip_preserves_discriminator(self):
+        """model_dump → model_validate preserves adapter_type."""
+        config = BroadstreetProductConfig(targeted_zone_ids=["z1"])
+        round_tripped = BroadstreetProductConfig.model_validate(config.model_dump())
+
+        assert round_tripped.adapter_type == "broadstreet"
+        assert round_tripped == config
+
+    def test_extra_field_rejected(self):
+        """Inherits extra='forbid' from BaseProductConfig — typo rejected."""
+        with pytest.raises(ValidationError):
+            BroadstreetProductConfig(targetd_zone_ids=["z1"])  # missing 'e'
+
     def test_config_with_zones(self):
-        """Test configuration with zone IDs."""
-        config = BroadstreetImplementationConfig(
-            targeted_zone_ids=["zone_1", "zone_2"],
-        )
+        config = BroadstreetProductConfig(targeted_zone_ids=["zone_1", "zone_2"])
 
         assert config.targeted_zone_ids == ["zone_1", "zone_2"]
-        # get_zone_ids returns unique zone IDs - order not guaranteed
         assert set(config.get_zone_ids()) == {"zone_1", "zone_2"}
 
     def test_config_with_zone_targeting(self):
-        """Test configuration with detailed zone targeting."""
-        config = BroadstreetImplementationConfig(
+        config = BroadstreetProductConfig(
             zone_targeting=[
                 ZoneTargeting(
                     zone_id="zone_3",
@@ -101,12 +118,10 @@ class TestBroadstreetImplementationConfig:
             ],
         )
 
-        zone_ids = config.get_zone_ids()
-        assert "zone_3" in zone_ids
+        assert "zone_3" in config.get_zone_ids()
 
     def test_get_zone_ids_combines_both_sources(self):
-        """Test that get_zone_ids combines targeted_zone_ids and zone_targeting."""
-        config = BroadstreetImplementationConfig(
+        config = BroadstreetProductConfig(
             targeted_zone_ids=["zone_1", "zone_2"],
             zone_targeting=[
                 ZoneTargeting(zone_id="zone_3"),
@@ -115,67 +130,47 @@ class TestBroadstreetImplementationConfig:
         )
 
         zone_ids = config.get_zone_ids()
-
-        # Should have unique zone IDs from both sources
         assert len(zone_ids) == 3
         assert set(zone_ids) == {"zone_1", "zone_2", "zone_3"}
 
     def test_cost_type_validation_cpm(self):
-        """Test valid CPM cost type."""
-        config = BroadstreetImplementationConfig(cost_type="cpm")
+        config = BroadstreetProductConfig(cost_type="cpm")
         assert config.cost_type == "CPM"
 
     def test_cost_type_validation_flat_rate(self):
-        """Test valid FLAT_RATE cost type."""
-        config = BroadstreetImplementationConfig(cost_type="flat_rate")
+        config = BroadstreetProductConfig(cost_type="flat_rate")
         assert config.cost_type == "FLAT_RATE"
 
     def test_cost_type_validation_invalid(self):
-        """Test invalid cost type raises error."""
-        with pytest.raises(ValueError) as exc_info:
-            BroadstreetImplementationConfig(cost_type="invalid")
-
-        assert "Invalid cost_type" in str(exc_info.value)
+        with pytest.raises(ValueError, match="Invalid cost_type"):
+            BroadstreetProductConfig(cost_type="invalid")
 
     def test_delivery_rate_validation(self):
-        """Test delivery rate validation."""
-        config = BroadstreetImplementationConfig(delivery_rate="frontloaded")
+        config = BroadstreetProductConfig(delivery_rate="frontloaded")
         assert config.delivery_rate == "FRONTLOADED"
 
     def test_delivery_rate_validation_invalid(self):
-        """Test invalid delivery rate raises error."""
-        with pytest.raises(ValueError) as exc_info:
-            BroadstreetImplementationConfig(delivery_rate="invalid")
-
-        assert "Invalid delivery_rate" in str(exc_info.value)
+        with pytest.raises(ValueError, match="Invalid delivery_rate"):
+            BroadstreetProductConfig(delivery_rate="invalid")
 
     def test_ad_format_validation(self):
-        """Test ad format validation."""
-        config = BroadstreetImplementationConfig(ad_format="HTML")
+        config = BroadstreetProductConfig(ad_format="HTML")
         assert config.ad_format == "html"
 
     def test_ad_format_validation_invalid(self):
-        """Test invalid ad format raises error."""
-        with pytest.raises(ValueError) as exc_info:
-            BroadstreetImplementationConfig(ad_format="video")
-
-        assert "Invalid ad_format" in str(exc_info.value)
+        with pytest.raises(ValueError, match="Invalid ad_format"):
+            BroadstreetProductConfig(ad_format="video")
 
     def test_automation_mode_validation(self):
-        """Test automation mode validation."""
-        config = BroadstreetImplementationConfig(automation_mode="AUTOMATIC")
+        config = BroadstreetProductConfig(automation_mode="AUTOMATIC")
         assert config.automation_mode == "automatic"
 
     def test_automation_mode_validation_invalid(self):
-        """Test invalid automation mode raises error."""
-        with pytest.raises(ValueError) as exc_info:
-            BroadstreetImplementationConfig(automation_mode="invalid")
-
-        assert "Invalid automation_mode" in str(exc_info.value)
+        with pytest.raises(ValueError, match="Invalid automation_mode"):
+            BroadstreetProductConfig(automation_mode="invalid")
 
     def test_get_creative_sizes_for_zone(self):
-        """Test getting creative sizes for a specific zone."""
-        config = BroadstreetImplementationConfig(
+        config = BroadstreetProductConfig(
             creative_sizes=[CreativeSize(width=728, height=90)],
             zone_targeting=[
                 ZoneTargeting(
@@ -197,49 +192,52 @@ class TestBroadstreetImplementationConfig:
 
 
 class TestParseImplementationConfig:
-    """Tests for parse_implementation_config function."""
+    """Tests for parse_implementation_config helper."""
 
     def test_parse_none_returns_default(self):
-        """Test parsing None returns default config."""
         config = parse_implementation_config(None)
 
-        assert isinstance(config, BroadstreetImplementationConfig)
+        assert isinstance(config, BroadstreetProductConfig)
+        assert config.adapter_type == "broadstreet"
         assert config.cost_type == "CPM"
 
     def test_parse_empty_dict_returns_default(self):
-        """Test parsing empty dict returns default config."""
         config = parse_implementation_config({})
 
-        assert isinstance(config, BroadstreetImplementationConfig)
+        assert isinstance(config, BroadstreetProductConfig)
+        assert config.cost_type == "CPM"
 
     def test_parse_valid_dict(self):
-        """Test parsing valid config dict."""
         config = parse_implementation_config(
             {
                 "targeted_zone_ids": ["zone_1"],
-                "cost_type": "FLAT_RATE",
+                "cost_type": "flat_rate",
                 "ad_format": "html",
             }
         )
 
         assert config.targeted_zone_ids == ["zone_1"]
-        assert config.cost_type == "FLAT_RATE"
+        assert config.cost_type == "FLAT_RATE"  # validator uppercases
         assert config.ad_format == "html"
 
     def test_parse_nested_zone_targeting(self):
-        """Test parsing config with nested zone targeting."""
         config = parse_implementation_config(
             {
                 "zone_targeting": [
                     {
                         "zone_id": "zone_1",
-                        "zone_name": "Banner",
-                        "sizes": [{"width": 300, "height": 250}],
-                    }
+                        "zone_name": "Top",
+                        "sizes": [{"width": 728, "height": 90}],
+                    },
                 ],
             }
         )
 
+        assert isinstance(config, BroadstreetProductConfig)
         assert len(config.zone_targeting) == 1
         assert config.zone_targeting[0].zone_id == "zone_1"
-        assert len(config.zone_targeting[0].sizes) == 1
+        assert config.zone_targeting[0].sizes[0].width == 728
+
+    def test_parse_invalid_dict_raises(self):
+        with pytest.raises(ValidationError):
+            parse_implementation_config({"cost_type": "INVALID"})


### PR DESCRIPTION
## Summary

Second of three sister PRs under #1239. Mirrors the Mock reconciliation pattern in #1240: collapse the parallel admin-slot and runtime `implementation_config` schemas into one Pydantic class registered as `product_config_class` on the adapter.

## What changed

**Pre-PR state**
- `src/adapters/broadstreet/schemas.py` — `BroadstreetProductConfig` (registered as `product_config_class`), 7 fields, `json_schema_extra`-driven
- `src/adapters/broadstreet/config_schema.py` — `BroadstreetImplementationConfig`, 12 fields, field-validator-driven, the one actually wired through `parse_implementation_config()` at 6 call sites

**Post-PR state**
- `BroadstreetProductConfig` in `schemas.py` is the single source of truth: 12 fields + `adapter_type: Literal["broadstreet"]` discriminator + nested `CreativeSize`/`ZoneTargeting` submodels + `parse_implementation_config` helper + `get_zone_ids` / `get_creative_sizes_for_zone` instance methods + all four field validators (cost_type, delivery_rate, ad_format, automation_mode)
- `config_schema.py` shrinks to template metadata only (`BROADSTREET_TEMPLATES` + `get_template_info` + `validate_template_assets`) — separate concern from product config
- `BroadstreetImplementationConfig` deleted; nothing imports it anymore
- All 6 call sites repointed to `schemas.py`
- `broadstreet/__init__.py` exports updated
- `tests/unit/adapters/broadstreet/test_config_schema.py` renamed to `test_schemas.py` (git mv preserves history) and rewritten against the new class name. Adds `adapter_type` discriminator + `extra='forbid'` rejection coverage. 28 tests, all pass.

## What this unlocks

Same as #1240: the registered schema is now the runtime contract. Sets up the Stage 3 discriminated-union view of `Product.implementation_config` — the `adapter_type` Literal field is the discriminator key. Boundary validation is already wired (`parse_implementation_config` used in 6 call sites in `adapter.py` + managers, all repointed in this PR).

## Test plan

- [x] `make quality` clean (4288 unit tests pass, ruff format/check, mypy)
- [x] `tests/unit/adapters/broadstreet/test_schemas.py` — 28 tests, all pass
- [x] Targeted: imports verified across all 6 broadstreet read sites
- [ ] CI re-runs the full integration suite

**Note on `tox -e integration`**: pre-existing test pollution (see #1240 test plan); local run skipped for the same reason. Pushed `--no-verify` after authorization.

## Out of scope

- **GAM reconciliation** (third sister PR under #1239) — schema needs `supported_format_types` and `time_zone` added (surfaced in audit) plus 30+ adapter-boundary read-site rewrites
- **Migration-as-audit** — Alembic step that validates all existing `Product.implementation_config` rows against the reconciled schemas
- **Phase 3 of #996**: dynamic admin form generation from `model_json_schema()`

## Refs

- Parent: #996 (reopened)
- Sub-issue tracker: #1239
- Sister PR: #1240 (Mock reconciliation, identical pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)