### PR TITLE
fix: replace broken adcontextprotocol.org auth setup guide link

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -46,7 +46,7 @@
         </p>
     </div>
     <p style="color: #666; font-size: 13px; margin-top: 1rem;">
-        <a href="https://adcontextprotocol.org/sales-agent/deployment/environment-variables#authentication" target="_blank" style="color: #0066cc;">
+        <a href="https://github.com/prebid/salesagent/blob/main/docs/deployment/environment-variables.md#authentication" target="_blank" style="color: #0066cc;">
             View authentication setup guide
         </a>
     </p>
@@ -110,7 +110,7 @@
                 <strong>Next step:</strong> Configure SSO in Settings &rarr; Users & Access.
             </p>
             <p style="margin: 0.5rem 0 0 0; font-size: 12px;">
-                <a href="https://adcontextprotocol.org/sales-agent/deployment/environment-variables#authentication" target="_blank" style="color: #0066cc;">
+                <a href="https://github.com/prebid/salesagent/blob/main/docs/deployment/environment-variables.md#authentication" target="_blank" style="color: #0066cc;">
                     View authentication setup guide
                 </a>
             </p>


### PR DESCRIPTION
## Summary

Fixes #1252.

The login page had two broken links pointing to `https://adcontextprotocol.org/sales-agent/deployment/environment-variables#authentication` which does not resolve.

Replaced both with the GitHub-hosted equivalent that already exists in the repo:
`https://github.com/prebid/salesagent/blob/main/docs/deployment/environment-variables.md#authentication`

This is consistent with the pattern used in `templates/users.html`.

## Test plan

- [x] `make quality` — 4,284 unit tests pass
- [x] Both occurrences in `templates/login.html` updated (lines 49 and 113)

🤖 Generated with [Claude Code](https://claude.com/claude-code)