### PR TITLE
fix: bust browser cache on favicon re-upload

### DIFF
--- a/templates/tenant_settings.html
+++ b/templates/tenant_settings.html
@@ -556,7 +556,7 @@
                             <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem; padding: 1rem; background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 8px;">
                                 <div style="width: 48px; height: 48px; display: flex; align-items: center; justify-content: center; background: white; border: 1px solid #e2e8f0; border-radius: 6px;">
                                     {% if tenant.favicon_url %}
-                                    <img src="{{ script_name }}{{ tenant.favicon_url }}" alt="Current favicon" style="max-width: 32px; max-height: 32px;">
+                                    <img src="{{ script_name }}{{ tenant.favicon_url }}?v={{ tenant.updated_at.timestamp() | int }}" alt="Current favicon" style="max-width: 32px; max-height: 32px;">
                                     {% else %}
                                     <img src="{{ script_name }}/static/favicons/default/favicon.jpg" alt="Default favicon" style="max-width: 32px; max-height: 32px;">
                                     {% endif %}


### PR DESCRIPTION
Append ?v={updated_at_timestamp} to the favicon preview <img> src. Since tenant.updated_at is set to datetime.now(UTC) on every upload, each new file gets a unique URL and the browser fetches fresh instead of serving the stale cached image.

Fixes #1254