### PR TITLE
fix: bound A2A task cache + consolidate to single SQLAlchemy engine

### DIFF
--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -47,6 +47,12 @@ collect_reports() {
     for name in unit integration e2e admin bdd ui; do
         [ -f ".tox/${name}.json" ] && cp ".tox/${name}.json" "$RESULTS_DIR/"
     done
+    # Explicit return 0 — without this, the function inherits the exit
+    # code of the last ``[ -f X ] && cp X Y`` test, which is 1 when the
+    # final file (ui.json) is missing in quick mode. Under ``set -e``
+    # that propagates to the caller and the script exits before reaching
+    # the security audit + summary block.
+    return 0
 }
 
 # --- Quick mode (no Docker) ---
@@ -54,13 +60,17 @@ if [ "$MODE" = "quick" ]; then
     validate_imports
     echo -e "${BLUE}Running unit + integration via tox...${NC}"
     set +e
-    # Redirect to file + stdout via process substitution to avoid tox-uv fd leak
-    # that causes pipes (| tee) to hang after tox exits.
-    tox -e unit,integration -p > >(tee "$RESULTS_DIR/tox.log") 2>&1
+    # Write to file then cat — avoids two known issues:
+    # - ``| tee X`` hangs after tox exits because of a tox-uv fd leak
+    # - ``> >(tee X) 2>&1`` returns a stale process-substitution exit code
+    #   that makes the script appear to fail under ``set -eo pipefail``
+    #   even when tox itself returned 0.
+    tox -e unit,integration -p > "$RESULTS_DIR/tox.log" 2>&1
     TOX_RC=$?
     set -e
+    cat "$RESULTS_DIR/tox.log"
     collect_reports
-    [ "$TOX_RC" -ne 0 ] && FAILURES="tox"
+    if [ "$TOX_RC" -ne 0 ]; then FAILURES="tox"; fi
 
 # --- CI mode (Docker + all suites) ---
 elif [ "$MODE" = "ci" ]; then
@@ -81,18 +91,20 @@ elif [ "$MODE" = "ci" ]; then
         uv run pytest "$PYTEST_TARGET" \
             -m "not requires_server and not skip_ci" \
             --json-report --json-report-file="$RESULTS_DIR/targeted.json" --json-report-indent=2 \
-            -q --tb=line $PYTEST_ARGS > >(tee "$RESULTS_DIR/targeted.log") 2>&1
+            -q --tb=line $PYTEST_ARGS > "$RESULTS_DIR/targeted.log" 2>&1
         TOX_RC=$?
         set -e
-        [ "$TOX_RC" -ne 0 ] && FAILURES="targeted"
+        cat "$RESULTS_DIR/targeted.log"
+        if [ "$TOX_RC" -ne 0 ]; then FAILURES="targeted"; fi
     else
         echo -e "${BLUE}Running all 6 suites in parallel via tox...${NC}"
         set +e
-        tox -p -o > >(tee "$RESULTS_DIR/tox.log") 2>&1
+        tox -p -o > "$RESULTS_DIR/tox.log" 2>&1
         TOX_RC=$?
         set -e
+        cat "$RESULTS_DIR/tox.log"
         collect_reports
-        [ "$TOX_RC" -ne 0 ] && FAILURES="tox"
+        if [ "$TOX_RC" -ne 0 ]; then FAILURES="tox"; fi
 
         # Coverage combine runs separately — tox -p hangs when the coverage
         # env fails (e.g. missing .coverage.e2e from HTTP-only e2e tests).

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -5,7 +5,10 @@ Supports both standard A2A message format and JSON-RPC 2.0.
 """
 
 import logging
+import os
+import time
 import uuid
+from collections import OrderedDict
 from collections.abc import AsyncGenerator
 
 # Import core functions for direct calls (raw functions without FastMCP decorators)
@@ -137,13 +140,94 @@ DISCOVERY_SKILLS = frozenset(
 )
 
 
+class _BoundedTaskCache:
+    """Bounded LRU + TTL cache for in-memory A2A task state.
+
+    The previous unbounded ``self.tasks = {}`` retained every Task object
+    (with full request artifacts) forever — root cause of the production
+    memory leak (linear ramp to ~12 GB ceiling, ~3-4 day OOM cycle).
+
+    Bounds:
+    - ``max_entries`` (default 10_000) — hard ceiling; LRU evicts oldest
+    - ``ttl_seconds`` (default 86_400 = 24h) — expiry on read; expired
+      entries are dropped without re-fetching
+
+    Per-process upper bound at default settings: ``max_entries × sizeof(Task)``.
+    Tasks are A2A SDK objects with full request/response artifacts;
+    typical size ~5-50 KB, so worst-case retention is ~500 MB. Tune via
+    env vars ``ADCP_A2A_TASK_CACHE_SIZE`` and
+    ``ADCP_A2A_TASK_CACHE_TTL_SECONDS`` if your workload pushes against
+    these defaults.
+
+    Read paths follow the same TTL-eviction-on-read pattern as the
+    framework's ``CallableSubdomainTenantRouter`` cache (adcp PR #544).
+    No background sweeper — eviction is lazy on access, with the LRU
+    cap as the hard memory ceiling.
+
+    The class duck-types as a dict for ``self.tasks[id] = task`` and
+    ``self.tasks.get(id)`` — no call-site changes required.
+    """
+
+    def __init__(self, *, max_entries: int = 10_000, ttl_seconds: float = 86_400) -> None:
+        if max_entries <= 0:
+            raise ValueError(f"max_entries must be > 0, got {max_entries}")
+        if ttl_seconds <= 0:
+            raise ValueError(f"ttl_seconds must be > 0, got {ttl_seconds}")
+        self._entries: OrderedDict[str, tuple[Task, float]] = OrderedDict()
+        self._max = max_entries
+        self._ttl = ttl_seconds
+
+    def __setitem__(self, key: str, value: Task) -> None:
+        expires_at = time.monotonic() + self._ttl
+        self._entries[key] = (value, expires_at)
+        self._entries.move_to_end(key)
+        # Bound size — evict oldest until under the ceiling.
+        while len(self._entries) > self._max:
+            self._entries.popitem(last=False)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        entry = self._entries.get(key)
+        if entry is None:
+            return default
+        value, expires_at = entry
+        if time.monotonic() > expires_at:
+            # Expired — drop and miss.
+            self._entries.pop(key, None)
+            return default
+        # LRU touch
+        self._entries.move_to_end(key)
+        return value
+
+    def __contains__(self, key: object) -> bool:
+        if not isinstance(key, str):
+            return False
+        return self.get(key) is not None
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+
+def _build_task_cache() -> _BoundedTaskCache:
+    """Build the per-handler task cache, sized from environment overrides."""
+    max_entries = int(os.environ.get("ADCP_A2A_TASK_CACHE_SIZE", "10000"))
+    ttl_seconds = float(os.environ.get("ADCP_A2A_TASK_CACHE_TTL_SECONDS", "86400"))
+    return _BoundedTaskCache(max_entries=max_entries, ttl_seconds=ttl_seconds)
+
+
 class AdCPRequestHandler(RequestHandler):
     """Request handler for AdCP A2A operations supporting JSON-RPC 2.0."""
 
     def __init__(self):
         """Initialize the AdCP A2A request handler."""
-        self.tasks = {}  # In-memory task storage
-        logger.info("AdCP Request Handler initialized for direct function calls")
+        # Bounded LRU + TTL cache for tasks. Replaces the previous
+        # unbounded dict that was the dominant production memory leak.
+        # Sized via ADCP_A2A_TASK_CACHE_SIZE / _TTL_SECONDS env vars.
+        self.tasks = _build_task_cache()
+        logger.info(
+            "AdCP Request Handler initialized (task cache: max=%d entries, ttl=%ds)",
+            self.tasks._max,
+            int(self.tasks._ttl),
+        )
 
     def _get_auth_token(self, context: ServerCallContext | None = None) -> str | None:
         """Extract Bearer token from ServerCallContext.

--- a/src/services/gam_inventory_service.py
+++ b/src/services/gam_inventory_service.py
@@ -12,19 +12,23 @@ import logging
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from sqlalchemy import String, and_, create_engine, delete, func, or_, select, text
+from sqlalchemy import String, and_, delete, func, or_, select, text
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
 
 from src.adapters.gam_inventory_discovery import (
     GAMInventoryDiscovery,
 )
-from src.core.database.db_config import DatabaseConfig
+from src.core.database.database_session import get_engine
 from src.core.database.models import GAMInventory, Product, ProductInventoryMapping
 
-# Create database session factory
-engine = create_engine(DatabaseConfig.get_connection_string())
-SessionLocal = sessionmaker(bind=engine)
-# Use scoped_session for thread-local sessions
+# Reuse the canonical database engine — DO NOT call ``create_engine`` here.
+# Pre-fix history: this module created its own ``engine`` + ``SessionLocal``,
+# stacking a second connection pool on top of the one in ``database_session.py``.
+# That extra pool never got ``dispose()``-d on shutdown, contributing to the
+# production memory leak (Brian's leak triage #2). Binding ``SessionLocal`` to
+# ``get_engine()`` consolidates everything onto one shared pool.
+SessionLocal = sessionmaker(bind=get_engine())
+# Use scoped_session for thread-local sessions (admin/sync_api.py imports this).
 db_session = scoped_session(SessionLocal)
 
 logger = logging.getLogger(__name__)

--- a/src/services/gam_orders_service.py
+++ b/src/services/gam_orders_service.py
@@ -12,16 +12,21 @@ import logging
 from datetime import UTC, date, datetime
 from typing import Any, cast
 
-from sqlalchemy import create_engine, or_, select
+from sqlalchemy import or_, select
 from sqlalchemy.orm import Session, joinedload, scoped_session, sessionmaker
 
 from src.adapters.gam_orders_discovery import GAMOrdersDiscovery, LineItem, Order
-from src.core.database.db_config import DatabaseConfig
+from src.core.database.database_session import get_engine
 from src.core.database.models import GAMLineItem, GAMOrder
 
-# Create database session factory
-engine = create_engine(DatabaseConfig.get_connection_string())
-SessionLocal = sessionmaker(bind=engine)
+# Reuse the canonical database engine — DO NOT call ``create_engine`` here.
+# Pre-fix history: this module created its own ``engine`` + ``SessionLocal``,
+# stacking a third connection pool on top of the one in ``database_session.py``
+# (alongside the one in ``gam_inventory_service.py``). The extra pools never got
+# ``dispose()``-d on shutdown, contributing to the production memory leak
+# (Brian's leak triage #2). Binding ``SessionLocal`` to ``get_engine()``
+# consolidates everything onto one shared pool.
+SessionLocal = sessionmaker(bind=get_engine())
 # Use scoped_session for thread-local sessions
 db_session = scoped_session(SessionLocal)
 

--- a/tests/unit/test_a2a_task_cache_bounded.py
+++ b/tests/unit/test_a2a_task_cache_bounded.py
@@ -1,0 +1,189 @@
+"""Unit tests for the A2A bounded task cache.
+
+Replaces the previously-unbounded ``self.tasks = {}`` in
+``AdCPRequestHandler``. The unbounded dict was the dominant production
+memory leak (linear ramp to ~12 GB ceiling, ~3-4 day OOM cycle).
+
+Tests pin the eviction contract so a future refactor can't silently
+remove the bounds.
+
+Covers:
+- Bounded LRU eviction: oldest entry drops when ``max_entries`` exceeded
+- TTL expiry: entries past ``ttl_seconds`` return ``default`` and are dropped
+- Dict-shape duck-typing: ``__setitem__`` / ``get`` / ``__contains__`` /
+  ``__len__`` so existing call sites continue to work without changes
+- Constructor validation: zero or negative bounds raise ``ValueError``
+- Env-var override path: ``ADCP_A2A_TASK_CACHE_SIZE`` /
+  ``ADCP_A2A_TASK_CACHE_TTL_SECONDS`` flow through ``_build_task_cache()``
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.a2a_server.adcp_a2a_server import _BoundedTaskCache, _build_task_cache
+
+
+def _fake_task(task_id: str = "t") -> MagicMock:
+    """Stand-in for a real ``a2a.types.Task`` — only identity matters here."""
+    m = MagicMock()
+    m.id = task_id
+    return m
+
+
+# ---------------------------------------------------------------------------
+# LRU bound — the load-bearing leak fix
+# ---------------------------------------------------------------------------
+
+
+class TestLruBound:
+    def test_max_entries_is_a_hard_ceiling(self) -> None:
+        cache = _BoundedTaskCache(max_entries=3, ttl_seconds=60)
+        cache["a"] = _fake_task("a")
+        cache["b"] = _fake_task("b")
+        cache["c"] = _fake_task("c")
+        cache["d"] = _fake_task("d")  # evicts oldest (a)
+
+        assert len(cache) == 3
+        assert "a" not in cache
+        assert "b" in cache
+        assert "c" in cache
+        assert "d" in cache
+
+    def test_lru_touch_on_read_keeps_entry_alive(self) -> None:
+        """Reading an entry promotes it to MRU; older unread entries evict first."""
+        cache = _BoundedTaskCache(max_entries=2, ttl_seconds=60)
+        cache["a"] = _fake_task("a")
+        cache["b"] = _fake_task("b")
+        cache.get("a")  # 'a' becomes MRU; 'b' is now LRU
+        cache["c"] = _fake_task("c")  # evicts 'b', not 'a'
+
+        assert "a" in cache
+        assert "b" not in cache
+        assert "c" in cache
+
+    def test_overwrite_does_not_grow_past_ceiling(self) -> None:
+        """Writing the same key twice doesn't drift the cache size."""
+        cache = _BoundedTaskCache(max_entries=2, ttl_seconds=60)
+        cache["a"] = _fake_task("a-v1")
+        cache["a"] = _fake_task("a-v2")
+        cache["b"] = _fake_task("b")
+        cache["c"] = _fake_task("c")  # evicts 'a' (now LRU)
+
+        assert len(cache) == 2
+        assert "b" in cache
+        assert "c" in cache
+
+
+# ---------------------------------------------------------------------------
+# TTL — the secondary line of defence (lazy eviction on read)
+# ---------------------------------------------------------------------------
+
+
+class TestTtlEviction:
+    def test_expired_entry_returns_default_and_drops(self, monkeypatch) -> None:
+        """Entry past ``ttl_seconds`` returns the ``default`` and is removed
+        from the cache (lazy on read; no background sweeper)."""
+        clock = [1000.0]
+
+        def fake_monotonic() -> float:
+            return clock[0]
+
+        monkeypatch.setattr("src.a2a_server.adcp_a2a_server.time.monotonic", fake_monotonic)
+
+        cache = _BoundedTaskCache(max_entries=8, ttl_seconds=60)
+        task = _fake_task("a")
+        cache["a"] = task
+        assert cache.get("a") is task
+
+        clock[0] += 61  # past TTL
+        assert cache.get("a") is None
+        assert cache.get("a", "sentinel") == "sentinel"
+        assert len(cache) == 0  # entry was dropped on expired read
+
+    def test_within_ttl_returns_value(self, monkeypatch) -> None:
+        clock = [1000.0]
+        monkeypatch.setattr("src.a2a_server.adcp_a2a_server.time.monotonic", lambda: clock[0])
+
+        cache = _BoundedTaskCache(max_entries=8, ttl_seconds=60)
+        task = _fake_task("a")
+        cache["a"] = task
+
+        clock[0] += 30
+        assert cache.get("a") is task
+        assert "a" in cache
+
+
+# ---------------------------------------------------------------------------
+# Dict-shape duck-typing — call sites use [] / .get() / in / len()
+# ---------------------------------------------------------------------------
+
+
+class TestDictShape:
+    def test_setitem_and_get(self) -> None:
+        cache = _BoundedTaskCache(max_entries=8, ttl_seconds=60)
+        task = _fake_task("a")
+        cache["a"] = task
+        assert cache.get("a") is task
+
+    def test_get_default_for_missing_key(self) -> None:
+        cache = _BoundedTaskCache(max_entries=8, ttl_seconds=60)
+        assert cache.get("missing") is None
+        assert cache.get("missing", "default") == "default"
+
+    def test_contains_for_present_and_missing_keys(self) -> None:
+        cache = _BoundedTaskCache(max_entries=8, ttl_seconds=60)
+        cache["a"] = _fake_task("a")
+        assert "a" in cache
+        assert "missing" not in cache
+        # Non-string keys (defensive — A2A task ids are always strings)
+        assert 42 not in cache  # type: ignore[operator]
+
+    def test_len_reflects_active_entries(self) -> None:
+        cache = _BoundedTaskCache(max_entries=8, ttl_seconds=60)
+        assert len(cache) == 0
+        cache["a"] = _fake_task("a")
+        cache["b"] = _fake_task("b")
+        assert len(cache) == 2
+
+
+# ---------------------------------------------------------------------------
+# Constructor validation
+# ---------------------------------------------------------------------------
+
+
+class TestConstructorValidation:
+    @pytest.mark.parametrize("bad", [0, -1, -100])
+    def test_max_entries_must_be_positive(self, bad: int) -> None:
+        with pytest.raises(ValueError, match="max_entries"):
+            _BoundedTaskCache(max_entries=bad, ttl_seconds=60)
+
+    @pytest.mark.parametrize("bad", [0, -0.1, -60.0])
+    def test_ttl_must_be_positive(self, bad: float) -> None:
+        with pytest.raises(ValueError, match="ttl_seconds"):
+            _BoundedTaskCache(max_entries=10, ttl_seconds=bad)
+
+
+# ---------------------------------------------------------------------------
+# Env-var override path used by AdCPRequestHandler.__init__
+# ---------------------------------------------------------------------------
+
+
+class TestEnvOverride:
+    def test_defaults_when_env_absent(self, monkeypatch) -> None:
+        monkeypatch.delenv("ADCP_A2A_TASK_CACHE_SIZE", raising=False)
+        monkeypatch.delenv("ADCP_A2A_TASK_CACHE_TTL_SECONDS", raising=False)
+
+        cache = _build_task_cache()
+        assert cache._max == 10_000  # noqa: SLF001 — testing the bound directly
+        assert cache._ttl == 86_400.0  # noqa: SLF001
+
+    def test_env_overrides_apply(self, monkeypatch) -> None:
+        monkeypatch.setenv("ADCP_A2A_TASK_CACHE_SIZE", "500")
+        monkeypatch.setenv("ADCP_A2A_TASK_CACHE_TTL_SECONDS", "3600")
+
+        cache = _build_task_cache()
+        assert cache._max == 500  # noqa: SLF001
+        assert cache._ttl == 3600.0  # noqa: SLF001


### PR DESCRIPTION
## Summary

Production memory-leak fixes targeting the two highest-confidence sources from the leak triage. Production has been hitting ~12 GB ceiling on a ~3-4 day OOM cycle (linear ramp).

| # | Source | Fix |
|---|---|---|
| 1 | `AdCPRequestHandler.tasks = {}` retained every Task forever — never deleted, never popped, no TTL | Bounded LRU + TTL cache, duck-typed as dict for call-site compat |
| 2 | `gam_inventory_service.py` + `gam_orders_service.py` each created their own `engine + sessionmaker` at module import, stacking 3 connection pools on top of the canonical one | All three now share the engine from `database_session.py::get_engine()` |
| (bonus) | `run_all_tests.sh` `set -e` interactions caused exit=1 even when all tests passed | Two surgical fixes — function returns explicit 0; tests use `if/then/fi` instead of `[ ] && X` |

## Fix #1 — bounded A2A task cache

`src/a2a_server/adcp_a2a_server.py::AdCPRequestHandler.__init__` was:

```python
self.tasks = {}  # In-memory task storage
```

…with 4 write sites and no eviction anywhere. A2A tasks include the full request/response artifact payload (~5-50 KB each); a long-running A2A-serving process at production traffic accumulated months of state.

Replaced with a `_BoundedTaskCache` class:

```python
self.tasks = _build_task_cache()  # bounded LRU + TTL
```

Configurable per-deployment via env vars without redeploy:
- `ADCP_A2A_TASK_CACHE_SIZE` — default `10_000` (hard ceiling, LRU evicts oldest)
- `ADCP_A2A_TASK_CACHE_TTL_SECONDS` — default `86_400` (24h, lazy eviction on read)

Worst-case retention at defaults: `10_000 × ~50 KB ≈ 500 MB`. Tunable down for memory-constrained deployments. Boot log emits the active bounds:

```
AdCP Request Handler initialized (task cache: max=10000 entries, ttl=86400s)
```

The cache duck-types as a dict — `self.tasks[id] = task`, `self.tasks.get(id)`, `id in self.tasks`, `len(self.tasks)` all keep working. Same `OrderedDict`-LRU pattern as the framework's `CallableSubdomainTenantRouter`.

## Fix #2 — triple-pool collapse

Both `src/services/gam_inventory_service.py` and `src/services/gam_orders_service.py` had:

```python
engine = create_engine(DatabaseConfig.get_connection_string())
SessionLocal = sessionmaker(bind=engine)
db_session = scoped_session(SessionLocal)
```

…at module import. Three engines, three connection pools, none `dispose()`-d on shutdown.

Both now use the canonical engine:

```python
from src.core.database.database_session import get_engine
SessionLocal = sessionmaker(bind=get_engine())
db_session = scoped_session(SessionLocal)
```

Verified live against the dev stack — all three modules' engines are `is`-identical (same `id()`).

`src/admin/sync_api.py` imports `db_session` from `gam_inventory_service` and uses its `add()` / `commit()` / `remove()` methods extensively — those still work because we kept the `scoped_session` wrapper, just bound to the shared engine.

## Bonus — `run_all_tests.sh` exit-code bug

The pre-push hook was rejecting every push, even when all tests passed. Two issues:

1. **Process-substitution × `set -eo pipefail`** — `> >(tee X) 2>&1` returns the process-substitution's async exit code, which can be nonzero. Replaced with redirect-then-cat (file-based, no pipe).
2. **`set -e` × `[ ] && X` form at top level** — `[ "$TOX_RC" -ne 0 ] && FAILURES="tox"` exits the script when `TOX_RC=0` because the test returns 1 and `set -e` doesn't suppress it at top level. Replaced with `if [ ... ]; then ...; fi`.
3. **`collect_reports` function returning 1** — the function ended on a `[ -f ui.json ] && cp ...` test that returns 1 when the file is missing. Function inherits the test's exit code; under `set -e` the caller exits before reaching the summary block. Added explicit `return 0`.

`./run_all_tests.sh quick` now returns `exit=0` when all tests pass — pre-push hook now lets correct pushes through.

## Tests

- **17 new unit tests** in `tests/unit/test_a2a_task_cache_bounded.py`:
  - LRU eviction (incl. read-as-MRU-touch and overwrite-doesn't-grow)
  - TTL expiry (lazy eviction on read; expired entries return default and drop)
  - Dict-shape duck-typing (`__setitem__` / `get` / `__contains__` / `__len__`)
  - Constructor validation (positive bounds required)
  - Env-var override flow
- **4443 existing unit tests** + **1927 integration tests** pass with the bounds in place
- **Full pre-push gate** (`./run_all_tests.sh quick`) returns 0 and lets the push through

## Out of scope (separate PRs)

The remaining leak-triage items will follow:
- #3 `requests.Session` global in `protocol_webhook_service.py` never `close()`-d
- #4 Prometheus high-cardinality `tenant_id` labels growing the registry monotonically
- #5 `background_sync_service._active_syncs` retains completed daemon threads
- #6 Untracked `asyncio.create_task` for fire-and-forget webhook delivery

Each is independently shippable; this PR is the highest-ROI subset (Brian's triage assessment).

## Test plan

- [x] 17 new unit tests cover the eviction contract
- [x] All unit + integration tests still pass
- [x] Manual smoke: all three GAM-service modules now share one engine pool (verified `id()` equality)
- [x] `./run_all_tests.sh quick` exits 0 cleanly
- [ ] Production canary deploy to confirm the OOM cycle stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)