### PR TITLE
fix(memory): leak triage #3 + #5 + #6 + sibling reapers (4 fixes)

### DIFF
--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -47,6 +47,12 @@ collect_reports() {
     for name in unit integration e2e admin bdd ui; do
         [ -f ".tox/${name}.json" ] && cp ".tox/${name}.json" "$RESULTS_DIR/"
     done
+    # Explicit return 0 — without this, the function inherits the exit
+    # code of the last ``[ -f X ] && cp X Y`` test, which is 1 when the
+    # final file (ui.json) is missing in quick mode. Under ``set -e``
+    # that propagates to the caller and the script exits before reaching
+    # the security audit + summary block.
+    return 0
 }
 
 # --- Quick mode (no Docker) ---
@@ -54,13 +60,17 @@ if [ "$MODE" = "quick" ]; then
     validate_imports
     echo -e "${BLUE}Running unit + integration via tox...${NC}"
     set +e
-    # Redirect to file + stdout via process substitution to avoid tox-uv fd leak
-    # that causes pipes (| tee) to hang after tox exits.
-    tox -e unit,integration -p > >(tee "$RESULTS_DIR/tox.log") 2>&1
+    # Write to file then cat — avoids two known issues:
+    # - ``| tee X`` hangs after tox exits because of a tox-uv fd leak
+    # - ``> >(tee X) 2>&1`` returns a stale process-substitution exit code
+    #   that makes the script appear to fail under ``set -eo pipefail``
+    #   even when tox itself returned 0.
+    tox -e unit,integration -p > "$RESULTS_DIR/tox.log" 2>&1
     TOX_RC=$?
     set -e
+    cat "$RESULTS_DIR/tox.log"
     collect_reports
-    [ "$TOX_RC" -ne 0 ] && FAILURES="tox"
+    if [ "$TOX_RC" -ne 0 ]; then FAILURES="tox"; fi
 
 # --- CI mode (Docker + all suites) ---
 elif [ "$MODE" = "ci" ]; then
@@ -81,18 +91,20 @@ elif [ "$MODE" = "ci" ]; then
         uv run pytest "$PYTEST_TARGET" \
             -m "not requires_server and not skip_ci" \
             --json-report --json-report-file="$RESULTS_DIR/targeted.json" --json-report-indent=2 \
-            -q --tb=line $PYTEST_ARGS > >(tee "$RESULTS_DIR/targeted.log") 2>&1
+            -q --tb=line $PYTEST_ARGS > "$RESULTS_DIR/targeted.log" 2>&1
         TOX_RC=$?
         set -e
-        [ "$TOX_RC" -ne 0 ] && FAILURES="targeted"
+        cat "$RESULTS_DIR/targeted.log"
+        if [ "$TOX_RC" -ne 0 ]; then FAILURES="targeted"; fi
     else
         echo -e "${BLUE}Running all 6 suites in parallel via tox...${NC}"
         set +e
-        tox -p -o > >(tee "$RESULTS_DIR/tox.log") 2>&1
+        tox -p -o > "$RESULTS_DIR/tox.log" 2>&1
         TOX_RC=$?
         set -e
+        cat "$RESULTS_DIR/tox.log"
         collect_reports
-        [ "$TOX_RC" -ne 0 ] && FAILURES="tox"
+        if [ "$TOX_RC" -ne 0 ]; then FAILURES="tox"; fi
 
         # Coverage combine runs separately — tox -p hangs when the coverage
         # env fails (e.g. missing .coverage.e2e from HTTP-only e2e tests).

--- a/src/app.py
+++ b/src/app.py
@@ -52,6 +52,20 @@ async def app_lifespan(app: FastAPI):
     logger.info("FastAPI application starting up")
     yield
     logger.info("FastAPI application shutting down")
+    # Close long-lived HTTP sessions / connection pools so the worker's
+    # file descriptors are released before process exit. The webhook
+    # service's ``requests.Session`` has a ``close()`` method that was
+    # never wired here — that's leak triage item #3 from the production
+    # OOM-cycle investigation. Adding more shutdown hooks below as
+    # we close out items #4-#6.
+    try:
+        from src.services.protocol_webhook_service import _webhook_service
+
+        if _webhook_service is not None:
+            await _webhook_service.close()
+    except Exception:
+        # Shutdown errors must not mask the actual yielded exit.
+        logger.exception("Error closing protocol_webhook_service on shutdown")
 
 
 # Build the MCP sub-application.

--- a/src/core/context_manager.py
+++ b/src/core/context_manager.py
@@ -22,6 +22,15 @@ logger = logging.getLogger(__name__)
 
 console = Console()
 
+# Strong references to in-flight fire-and-forget webhook tasks. asyncio only
+# keeps weak references to tasks, so a task whose only strong reference is a
+# local variable can be garbage-collected mid-execution if the calling
+# function returns before the task finishes — silently dropping webhooks.
+# Push tasks here on create, remove via add_done_callback. (Leak triage #6
+# from the production OOM-cycle investigation: untracked create_task at
+# context_manager.py was the smoking gun.)
+_pending_webhook_tasks: set[asyncio.Task] = set()
+
 
 class ContextManager(DatabaseManager):
     """Manages persistent context for conversations and tasks.
@@ -734,9 +743,18 @@ class ContextManager(DatabaseManager):
                                 )
                             )
 
+                            # Strong-ref pin to the module-level set so asyncio's
+                            # weak-ref task tracker doesn't GC the task before it
+                            # completes — see _pending_webhook_tasks docstring.
+                            _pending_webhook_tasks.add(task)
+
                             def _log_task_result(
                                 t: asyncio.Task, config_url: str = push_notification_config.url
                             ) -> None:
+                                # Always remove from pending set first so the
+                                # log-and-swallow below can't hold the ref past
+                                # completion.
+                                _pending_webhook_tasks.discard(t)
                                 try:
                                     t.result()
                                     console.print(f"[green]✅ Webhook sent successfully for {config_url}[/green]")

--- a/src/services/background_approval_service.py
+++ b/src/services/background_approval_service.py
@@ -21,6 +21,19 @@ _active_approval_tasks: dict[str, threading.Thread] = {}
 _approval_lock = threading.Lock()
 
 
+def _reap_dead_approval_tasks() -> None:
+    """Drop ``_active_approval_tasks`` entries whose threads are no longer alive.
+
+    Same defensive cleanup pattern as
+    ``background_sync_service._reap_dead_syncs`` — see that docstring
+    for the rationale (production memory-leak triage #5). Caller MUST
+    hold ``_approval_lock``.
+    """
+    dead = [tid for tid, t in _active_approval_tasks.items() if not t.is_alive()]
+    for tid in dead:
+        _active_approval_tasks.pop(tid, None)
+
+
 def start_order_approval_polling(
     tenant_id: str,
     order_id: str,
@@ -261,12 +274,20 @@ def _send_approval_webhook(tenant_id: str, order_id: str, workflow_step_id: str,
 
 
 def get_active_approval_tasks() -> list[str]:
-    """Get list of approval task IDs currently running in background threads."""
+    """Get list of approval task IDs currently running in background threads.
+
+    Reaps dead threads on read so the returned list reflects live state.
+    """
     with _approval_lock:
+        _reap_dead_approval_tasks()
         return list(_active_approval_tasks.keys())
 
 
 def is_approval_task_running(order_id: str) -> bool:
-    """Check if approval polling is running for a specific order."""
+    """Check if approval polling is running for a specific order.
+
+    Reaps dead threads on read.
+    """
     with _approval_lock:
+        _reap_dead_approval_tasks()
         return any(order_id in task_id for task_id in _active_approval_tasks)

--- a/src/services/background_sync_service.py
+++ b/src/services/background_sync_service.py
@@ -22,6 +22,28 @@ _active_syncs: dict[str, threading.Thread] = {}
 _sync_lock = threading.Lock()
 
 
+def _reap_dead_syncs() -> None:
+    """Drop ``_active_syncs`` entries whose threads are no longer alive.
+
+    Defensive against any path where the worker's ``finally`` block in
+    ``_run_sync_thread`` doesn't run — e.g. ``KeyboardInterrupt`` /
+    ``SystemExit`` raised during sync, or a bug that lets the thread
+    exit before the cleanup. Without this reap, dead threads keep
+    references to their captured DB sessions, GAM clients, and result
+    payloads — slow growth as syncs fail abnormally over weeks of
+    uptime (leak triage #5 from the production OOM-cycle).
+
+    Called from every accessor so the dict reflects live state on read.
+    O(n) over the live + recently-dead set; n is small (one entry per
+    in-flight sync, capped by the per-tenant concurrency check upstream).
+
+    Caller MUST hold ``_sync_lock``.
+    """
+    dead = [sid for sid, t in _active_syncs.items() if not t.is_alive()]
+    for sid in dead:
+        _active_syncs.pop(sid, None)
+
+
 def start_inventory_sync_background(
     tenant_id: str,
     sync_mode: str = "incremental",
@@ -533,12 +555,24 @@ def _mark_sync_failed(sync_id: str, error_message: str):
 
 
 def get_active_syncs() -> list[str]:
-    """Get list of sync IDs currently running in background threads."""
+    """Get list of sync IDs currently running in background threads.
+
+    Reaps dead threads on read so the returned list reflects live state
+    even if the worker's ``finally`` block didn't fire (e.g. abnormal
+    exit). See :func:`_reap_dead_syncs`.
+    """
     with _sync_lock:
+        _reap_dead_syncs()
         return list(_active_syncs.keys())
 
 
 def is_sync_running(sync_id: str) -> bool:
-    """Check if a sync is currently running in a background thread."""
+    """Check if a sync is currently running in a background thread.
+
+    Reaps dead threads on read — a sync_id with a dead thread is no
+    longer running, so this returns False (and the dict entry is
+    pruned as a side effect).
+    """
     with _sync_lock:
+        _reap_dead_syncs()
         return sync_id in _active_syncs

--- a/src/services/order_approval_service.py
+++ b/src/services/order_approval_service.py
@@ -23,6 +23,19 @@ _active_approvals: dict[str, threading.Thread] = {}
 _approval_lock = threading.Lock()
 
 
+def _reap_dead_approvals() -> None:
+    """Drop ``_active_approvals`` entries whose threads are no longer alive.
+
+    Same defensive cleanup pattern as
+    ``background_sync_service._reap_dead_syncs`` — see that docstring
+    for the rationale (production memory-leak triage #5). Caller MUST
+    hold ``_approval_lock``.
+    """
+    dead = [aid for aid, t in _active_approvals.items() if not t.is_alive()]
+    for aid in dead:
+        _active_approvals.pop(aid, None)
+
+
 def start_order_approval_background(
     order_id: str,
     media_buy_id: str,
@@ -428,14 +441,24 @@ def _send_approval_webhook(
 
 
 def get_active_approvals() -> list[str]:
-    """Get list of approval IDs currently running in background threads."""
+    """Get list of approval IDs currently running in background threads.
+
+    Reaps dead threads on read so the returned list reflects live state
+    even if the worker's ``finally`` cleanup didn't fire.
+    """
     with _approval_lock:
+        _reap_dead_approvals()
         return list(_active_approvals.keys())
 
 
 def is_approval_running(approval_id: str) -> bool:
-    """Check if an approval is currently running in a background thread."""
+    """Check if an approval is currently running in a background thread.
+
+    Reaps dead threads on read — a sync_id with a dead thread is no
+    longer running, so this returns False (and the entry is pruned).
+    """
     with _approval_lock:
+        _reap_dead_approvals()
         return approval_id in _active_approvals
 
 

--- a/tests/unit/test_background_sync_reaper.py
+++ b/tests/unit/test_background_sync_reaper.py
@@ -1,0 +1,123 @@
+"""Unit tests for the dead-thread reaper in ``background_sync_service``.
+
+Pins the defensive cleanup that catches threads which exited without
+hitting the worker's ``finally`` block — uncatchable exceptions
+(``KeyboardInterrupt``, ``SystemExit``), abnormal exits, etc.
+
+Without the reaper, dead threads keep references to their captured DB
+sessions, GAM clients, and result payloads — slow growth as syncs fail
+abnormally over weeks of uptime (production memory-leak triage #5).
+"""
+
+from __future__ import annotations
+
+import threading
+
+from src.services.background_sync_service import (
+    _active_syncs,
+    _reap_dead_syncs,
+    get_active_syncs,
+    is_sync_running,
+)
+
+
+def _dead_thread() -> threading.Thread:
+    """Create and immediately drain a thread (returns a dead one)."""
+    t = threading.Thread(target=lambda: None)
+    t.start()
+    t.join()
+    assert not t.is_alive()
+    return t
+
+
+def _live_thread() -> threading.Thread:
+    """Create a thread that blocks on an event (so it stays alive)."""
+    event = threading.Event()
+    t = threading.Thread(target=event.wait, daemon=True)
+    t.start()
+    # Stash the event so the test can release the thread later
+    t._test_release = event  # type: ignore[attr-defined]
+    return t
+
+
+def _release(t: threading.Thread) -> None:
+    t._test_release.set()  # type: ignore[attr-defined]
+    t.join(timeout=1)
+
+
+def test_reaper_drops_dead_threads():
+    """Dead threads are pruned from the registry."""
+    # Setup: poison the registry with a dead entry
+    _active_syncs.clear()
+    _active_syncs["sync_dead"] = _dead_thread()
+    assert "sync_dead" in _active_syncs
+
+    _reap_dead_syncs()
+
+    assert "sync_dead" not in _active_syncs
+
+
+def test_reaper_keeps_live_threads():
+    """Live threads survive a reap."""
+    _active_syncs.clear()
+    live = _live_thread()
+    try:
+        _active_syncs["sync_live"] = live
+        _reap_dead_syncs()
+        assert "sync_live" in _active_syncs
+    finally:
+        _release(live)
+        _active_syncs.clear()
+
+
+def test_get_active_syncs_reaps_on_read():
+    """``get_active_syncs`` returns only currently-alive syncs."""
+    _active_syncs.clear()
+    live = _live_thread()
+    try:
+        _active_syncs["sync_alive"] = live
+        _active_syncs["sync_zombie"] = _dead_thread()
+
+        result = get_active_syncs()
+
+        assert result == ["sync_alive"]
+        assert "sync_zombie" not in _active_syncs
+    finally:
+        _release(live)
+        _active_syncs.clear()
+
+
+def test_is_sync_running_reaps_on_read():
+    """``is_sync_running`` returns False for a dead-thread entry, AND drops it."""
+    _active_syncs.clear()
+    _active_syncs["sync_zombie"] = _dead_thread()
+
+    assert is_sync_running("sync_zombie") is False
+    assert "sync_zombie" not in _active_syncs
+
+
+def test_reaper_handles_empty_registry():
+    """No-op on empty registry — guards against off-by-one bugs."""
+    _active_syncs.clear()
+    _reap_dead_syncs()
+    assert _active_syncs == {}
+
+
+def test_reaper_handles_mixed_state():
+    """Mixed live/dead registry: only the dead are pruned, live remain."""
+    _active_syncs.clear()
+    live1 = _live_thread()
+    live2 = _live_thread()
+    try:
+        _active_syncs["a_live"] = live1
+        _active_syncs["b_dead"] = _dead_thread()
+        _active_syncs["c_live"] = live2
+        _active_syncs["d_dead"] = _dead_thread()
+
+        _reap_dead_syncs()
+
+        assert set(_active_syncs.keys()) == {"a_live", "c_live"}
+    finally:
+        _release(live1)
+        _release(live2)
+        _active_syncs.clear()

--- a/tests/unit/test_order_approval_service.py
+++ b/tests/unit/test_order_approval_service.py
@@ -119,22 +119,32 @@ def test_start_approval_rejects_duplicate(mock_db_session):
 
 
 def test_approval_thread_tracks_in_registry(mock_db_session):
-    """Test that approval thread is tracked in global registry."""
-    # Mock the thread execution to prevent it from actually running
-    # (which would cause it to fail and remove itself from registry)
-    with patch("src.services.order_approval_service._run_approval_thread"):
+    """Test that approval thread is tracked in global registry.
+
+    Uses a blocking mock so the worker stays alive while the test
+    inspects the registry — the dead-thread reaper added in the
+    production memory-leak fix drops dead-thread entries on read, so
+    a no-op mock that exits immediately would race the reaper.
+    """
+    import threading
+
+    keep_alive = threading.Event()
+    with patch(
+        "src.services.order_approval_service._run_approval_thread",
+        side_effect=lambda *args, **kwargs: keep_alive.wait(timeout=2.0),
+    ):
         approval_id = start_order_approval_background(
             order_id="12345",
             media_buy_id="mb_123",
             tenant_id="tenant_1",
             principal_id="principal_1",
         )
-
-        # Thread should be in registry immediately (added before thread.start())
-        # No sleep needed since we're checking the registry, not thread execution
-        active_approvals = get_active_approvals()
-        assert approval_id in active_approvals, f"Expected {approval_id} in {active_approvals}"
-        assert is_approval_running(approval_id)
+        try:
+            active_approvals = get_active_approvals()
+            assert approval_id in active_approvals, f"Expected {approval_id} in {active_approvals}"
+            assert is_approval_running(approval_id)
+        finally:
+            keep_alive.set()
 
 
 def test_get_approval_status(mock_db_session):


### PR DESCRIPTION
## Summary

Four leak-triage items from the production OOM-cycle investigation, all small surgical fixes, batched in one PR.

| # | File | Fix |
|---|---|---|
| **#3** | ``src/app.py`` lifespan | Hook ``_webhook_service.close()`` into FastAPI shutdown so the global ``requests.Session``'s connection pool is released on process exit |
| **#5** | ``src/services/background_sync_service.py`` | Reap dead threads from ``_active_syncs`` registry on read |
| **#6** | ``src/core/context_manager.py`` | Pin fire-and-forget webhook ``asyncio.create_task`` to a strong-ref set so asyncio's weak-ref tracker can't GC mid-execution |
| (siblings of #5) | ``src/services/order_approval_service.py`` + ``src/services/background_approval_service.py`` | Same dead-thread reaper applied to two sibling registries |
| (cherry-pick) | ``run_all_tests.sh`` | Process-substitution × ``set -eo pipefail`` exit-code fix from #1263 — required for pre-push hook to let any push through. Drop on rebase if #1263 merges first |

Each fix is independently revertable. Net diff is small (~250 LOC, mostly defensive helpers and tests).

## Tests

- **6 new tests** in ``tests/unit/test_background_sync_reaper.py``: dead/live/mixed registry states, accessor reaping, edge cases
- **1 test refit** for ``test_approval_thread_tracks_in_registry`` — the previous test relied on dead-thread persistence in the registry (which is exactly the leak); now uses a blocking mock to keep the thread alive during inspection
- **All existing tests pass** (4304 unit + 1927 integration)
- ``./run_all_tests.sh quick`` returns 0; pre-push hook clean

## Triage progress

| Item | Status |
|---|---|
| ✅ #1 + #2 | [salesagent#1263](https://github.com/prebid/salesagent/pull/1263) |
| ✅ **#3 + #5 + #6 + 2 sibling reapers (this PR)** | bound + reap + pin |
| 🟡 #4 Prometheus high-cardinality labels | design issue forthcoming — needs labels-vs-aggregation discussion |
| 🟡 2 instance-level sibling reapers (gam reporting, delivery simulator) | follow-up PR — instance-level state, slightly different surgery |

## Test plan

- [x] Unit tests pass (existing + new)
- [x] Pre-push hook clean
- [ ] Production canary deploy comparing memory-curve slope

🤖 Generated with [Claude Code](https://claude.com/claude-code)