### PR TITLE
refactor: reconcile MockProductConfig — merge to 12-field percent sch…

### DIFF
--- a/src/adapters/mock_ad_server.py
+++ b/src/adapters/mock_ad_server.py
@@ -1,7 +1,7 @@
 import logging
 import random
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ class MockProductConfig(BaseProductConfig):
     viewability_rate: float = Field(default=70.0, ge=0.0, le=100.0)
     latency_ms: int = Field(default=50, ge=0)
     error_rate: float = Field(default=0.1, ge=0.0, le=100.0)
-    test_mode: str = Field(default="normal")
+    test_mode: Literal["normal", "high_demand", "degraded", "outage"] = Field(default="normal")
     price_variance: float = Field(default=10.0, ge=0.0)
     seasonal_factor: float = Field(default=1.0, ge=0.0)
     verbose_logging: bool = Field(default=False)

--- a/src/adapters/mock_ad_server.py
+++ b/src/adapters/mock_ad_server.py
@@ -41,13 +41,23 @@ class MockConnectionConfig(BaseConnectionConfig):
 
 
 class DeliverySimulationConfig(BaseModel):
-    """Nested config for delivery simulation timing in MockProductConfig."""
+    """Nested config for delivery simulation timing in MockProductConfig.
+
+    Upper bounds mirror the form validator in
+    ``src/admin/blueprints/adapters.py``:
+      - ``time_acceleration`` capped at 86400 (24 hours' worth of seconds —
+        beyond which "accelerated simulation" loses meaning).
+      - ``update_interval_seconds`` capped at 60 (one minute — beyond which
+        the UI update cadence becomes irrelevant for delivery polling).
+    Schema-side and form-side bounds stay in lockstep so REST + UI paths
+    accept the same values.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
     enabled: bool = Field(default=False)
-    time_acceleration: int = Field(default=3600, ge=1)
-    update_interval_seconds: float = Field(default=1.0, ge=0.1)
+    time_acceleration: int = Field(default=3600, ge=1, le=86400)
+    update_interval_seconds: float = Field(default=1.0, ge=0.1, le=60.0)
 
 
 class MockProductConfig(BaseProductConfig):

--- a/src/adapters/mock_ad_server.py
+++ b/src/adapters/mock_ad_server.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from src.core.schemas import Snapshot
 
 # adcp 3.6.0: BrandManifest removed from CreateMediaBuyRequest; now uses BrandReference (brand field)
-from pydantic import Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from src.adapters.base import (
     AdapterCapabilities,
@@ -40,14 +40,35 @@ class MockConnectionConfig(BaseConnectionConfig):
     dry_run: bool = Field(default=False, description="When true, simulates operations without persisting state")
 
 
-class MockProductConfig(BaseProductConfig):
-    """Product config for Mock adapter simulation parameters."""
+class DeliverySimulationConfig(BaseModel):
+    """Nested config for delivery simulation timing in MockProductConfig."""
 
-    daily_impressions: int = Field(default=10000, ge=0)
-    fill_rate: float = Field(default=0.85, ge=0.0, le=1.0)
-    ctr: float = Field(default=0.02, ge=0.0, le=1.0)
-    viewability: float = Field(default=0.65, ge=0.0, le=1.0)
-    scenario: str = Field(default="normal")
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = Field(default=False)
+    time_acceleration: int = Field(default=3600, ge=1)
+    update_interval_seconds: float = Field(default=1.0, ge=0.1)
+
+
+class MockProductConfig(BaseProductConfig):
+    """Product config for Mock adapter simulation parameters.
+
+    All rate fields (fill_rate, ctr, viewability_rate, error_rate) use percents (0–100),
+    matching what the admin form stores in implementation_config.
+    """
+
+    daily_impressions: int = Field(default=100000, ge=0)
+    fill_rate: float = Field(default=85.0, ge=0.0, le=100.0)
+    ctr: float = Field(default=0.5, ge=0.0, le=100.0)
+    viewability_rate: float = Field(default=70.0, ge=0.0, le=100.0)
+    latency_ms: int = Field(default=50, ge=0)
+    error_rate: float = Field(default=0.1, ge=0.0, le=100.0)
+    test_mode: str = Field(default="normal")
+    price_variance: float = Field(default=10.0, ge=0.0)
+    seasonal_factor: float = Field(default=1.0, ge=0.0)
+    verbose_logging: bool = Field(default=False)
+    predictable_ids: bool = Field(default=False)
+    delivery_simulation: DeliverySimulationConfig = Field(default_factory=DeliverySimulationConfig)
 
 
 class MockAdServer(AdServerAdapter):
@@ -1346,8 +1367,6 @@ class MockAdServer(AdServerAdapter):
     def register_ui_routes(self, app):
         """Register Flask routes for the mock adapter configuration UI."""
 
-        from flask import render_template, request
-
         @app.route("/adapters/mock/config/<tenant_id>/<product_id>", methods=["GET", "POST"])
         def mock_product_config(tenant_id, product_id):
             # Import here to avoid circular imports
@@ -1361,6 +1380,7 @@ class MockAdServer(AdServerAdapter):
             @require_auth()
             @wraps(mock_product_config)
             def wrapped_view():
+                from flask import render_template, request
                 from sqlalchemy import select
 
                 with get_db_session() as session:
@@ -1377,39 +1397,42 @@ class MockAdServer(AdServerAdapter):
                     config = product_obj.implementation_config or {}
 
                     if request.method == "POST":
-                        # Update configuration
-                        new_config = {
-                            "daily_impressions": int(request.form.get("daily_impressions", 100000)),
-                            "fill_rate": float(request.form.get("fill_rate", 85)),
-                            "ctr": float(request.form.get("ctr", 0.5)),
-                            "viewability_rate": float(request.form.get("viewability_rate", 70)),
-                            "latency_ms": int(request.form.get("latency_ms", 50)),
-                            "error_rate": float(request.form.get("error_rate", 0.1)),
-                            "test_mode": request.form.get("test_mode", "normal"),
-                            "price_variance": float(request.form.get("price_variance", 10)),
-                            "seasonal_factor": float(request.form.get("seasonal_factor", 1.0)),
-                            "verbose_logging": "verbose_logging" in request.form,
-                            "predictable_ids": "predictable_ids" in request.form,
-                            "delivery_simulation": {
-                                "enabled": "delivery_simulation_enabled" in request.form,
-                                "time_acceleration": int(request.form.get("time_acceleration", 3600)),
-                                "update_interval_seconds": float(request.form.get("update_interval_seconds", 1.0)),
-                            },
-                        }
-
                         # Handle format selection
                         formats = request.form.getlist("formats")
                         if formats:
                             product_obj.format_ids = formats
 
-                        # Validate the configuration
-                        validation_errors = self.validate_product_config(new_config)
-                        if validation_errors:
-                            # Get formats for re-rendering
+                        # Build and validate config via Pydantic — raises ValidationError or
+                        # ValueError on bad form input
+                        try:
+                            new_config = MockProductConfig(
+                                daily_impressions=int(request.form.get("daily_impressions", 100000)),
+                                fill_rate=float(request.form.get("fill_rate", 85)),
+                                ctr=float(request.form.get("ctr", 0.5)),
+                                viewability_rate=float(request.form.get("viewability_rate", 70)),
+                                latency_ms=int(request.form.get("latency_ms", 50)),
+                                error_rate=float(request.form.get("error_rate", 0.1)),
+                                test_mode=request.form.get("test_mode", "normal"),
+                                price_variance=float(request.form.get("price_variance", 10)),
+                                seasonal_factor=float(request.form.get("seasonal_factor", 1.0)),
+                                verbose_logging="verbose_logging" in request.form,
+                                predictable_ids="predictable_ids" in request.form,
+                                delivery_simulation={
+                                    "enabled": "delivery_simulation_enabled" in request.form,
+                                    "time_acceleration": int(request.form.get("time_acceleration", 3600)),
+                                    "update_interval_seconds": float(request.form.get("update_interval_seconds", 1.0)),
+                                },
+                            ).model_dump()
+                        except (ValidationError, ValueError) as exc:
                             from src.admin.blueprints.products import get_creative_formats
 
                             available_formats = get_creative_formats(tenant_id=tenant_id)
-
+                            if isinstance(exc, ValidationError):
+                                first = exc.errors()[0]
+                                field = first["loc"][0] if first["loc"] else "config"
+                                error_msg = f"{field}: {first['msg']}"
+                            else:
+                                error_msg = str(exc)
                             return render_template(
                                 "adapters/mock_product_config.html",
                                 tenant_id=tenant_id,
@@ -1417,7 +1440,7 @@ class MockAdServer(AdServerAdapter):
                                 config=config,
                                 formats=available_formats,
                                 selected_formats=product_obj.format_ids or [],
-                                error=validation_errors[0],
+                                error=error_msg,
                             )
 
                         # Save to database
@@ -1454,33 +1477,6 @@ class MockAdServer(AdServerAdapter):
                     )
 
             return wrapped_view()
-
-    def validate_product_config(self, config: dict[str, Any]) -> tuple[bool, str | None]:
-        """Validate mock adapter configuration."""
-        errors: list[str] = []
-
-        # Validate ranges
-        if config.get("fill_rate", 0) < 0 or config.get("fill_rate", 0) > 100:
-            errors.append("Fill rate must be between 0 and 100")
-
-        if config.get("error_rate", 0) < 0 or config.get("error_rate", 0) > 100:
-            errors.append("Error rate must be between 0 and 100")
-
-        if config.get("ctr", 0) < 0 or config.get("ctr", 0) > 100:
-            errors.append("CTR must be between 0 and 100")
-
-        if config.get("viewability_rate", 0) < 0 or config.get("viewability_rate", 0) > 100:
-            errors.append("Viewability rate must be between 0 and 100")
-
-        if config.get("daily_impressions", 0) < 1000:
-            errors.append("Daily impressions must be at least 1000")
-
-        if config.get("latency_ms", 0) < 0:
-            errors.append("Latency cannot be negative")
-
-        if errors:
-            return False, "; ".join(errors)
-        return True, None
 
     def _calculate_delivery_progress(self, profile: str, current_day: int, total_days: int) -> float:
         """Calculate delivery progress based on profile.

--- a/src/admin/blueprints/adapters.py
+++ b/src/admin/blueprints/adapters.py
@@ -1,6 +1,7 @@
 """Adapters management blueprint."""
 
 import logging
+from typing import get_args
 
 from flask import Blueprint, flash, jsonify, redirect, render_template, request, url_for
 from pydantic import ValidationError
@@ -8,6 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import attributes
 
 from src.adapters import get_adapter_schemas
+from src.adapters.mock_ad_server import MockProductConfig
 from src.admin.utils import require_tenant_access
 from src.admin.utils.audit_decorator import log_admin_action
 from src.core.database.database_session import get_db_session
@@ -69,9 +71,11 @@ def mock_config(tenant_id, product_id, **kwargs):
                 config["latency_ms"] = parse_int("latency_ms", 50, min_val=0, max_val=60000)
                 config["error_rate"] = parse_float("error_rate", 0.1, min_val=0, max_val=100)
 
-                # Test scenarios (validated choices)
+                # Test scenarios (validated choices) — single source of truth is the
+                # Literal annotation on MockProductConfig.test_mode; derive the allowed
+                # set here so the two surfaces can't drift.
                 test_mode = request.form.get("test_mode", "normal")
-                valid_modes = ["normal", "high_demand", "degraded", "outage"]
+                valid_modes = get_args(MockProductConfig.model_fields["test_mode"].annotation)
                 if test_mode not in valid_modes:
                     raise ValueError(f"Invalid test_mode: {test_mode}")
                 config["test_mode"] = test_mode

--- a/src/admin/blueprints/creatives.py
+++ b/src/admin/blueprints/creatives.py
@@ -656,9 +656,7 @@ def approve_creative(tenant_id, creative_id, **kwargs):
 
         # Use the status snapshot from the first loop — no need for a second UoW
         buys_to_push = [
-            buy_id
-            for buy_id in assignment_buy_ids
-            if assignment_buy_statuses.get(buy_id) in _LIVE_BUY_STATUSES
+            buy_id for buy_id in assignment_buy_ids if assignment_buy_statuses.get(buy_id) in _LIVE_BUY_STATUSES
         ]
 
         for buy_id in buys_to_push:

--- a/src/core/tools/media_buy_create.py
+++ b/src/core/tools/media_buy_create.py
@@ -2939,9 +2939,9 @@ async def _create_media_buy_impl(
                 # Merge dimensions from product's format_ids if request format_ids don't have them
                 # This handles the case where buyer specifies format_id but not dimensions
                 # Build lookup of product format dimensions by (normalized_url, id)
-                product_format_dimensions: dict[tuple[str | None, str], tuple[int | None, int | None, float | None]] = (
-                    {}
-                )
+                product_format_dimensions: dict[
+                    tuple[str | None, str], tuple[int | None, int | None, float | None]
+                ] = {}
                 if pkg_product.format_ids:
                     for fmt in pkg_product.format_ids:
                         agent_url = fmt.agent_url

--- a/tests/admin/test_creatives_blueprint.py
+++ b/tests/admin/test_creatives_blueprint.py
@@ -245,9 +245,7 @@ def _create_assignment(session, tenant_id: str, creative_id: str, media_buy_id: 
     from src.core.database.models import MediaBuy as MediaBuyModel
     from tests.factories import CreativeAssignmentFactory
 
-    creative = session.scalars(
-        sa_select(CreativeModel).filter_by(tenant_id=tenant_id, creative_id=creative_id)
-    ).first()
+    creative = session.scalars(sa_select(CreativeModel).filter_by(tenant_id=tenant_id, creative_id=creative_id)).first()
     media_buy = session.scalars(
         sa_select(MediaBuyModel).filter_by(tenant_id=tenant_id, media_buy_id=media_buy_id)
     ).first()

--- a/tests/integration/test_gam_lifecycle.py
+++ b/tests/integration/test_gam_lifecycle.py
@@ -25,12 +25,12 @@ def _assert_unsupported_feature_for_action(response, action: str) -> None:
     forces re-evaluation of that test's contract. Helper is private to
     this module — DRY per CLAUDE.md, intentionally not exported.
     """
-    assert (
-        response.errors is not None and len(response.errors) > 0
-    ), f"Expected Error response for action={action!r}; GAM currently rejects with UNSUPPORTED_FEATURE"
-    assert (
-        response.errors[0].code == "UNSUPPORTED_FEATURE"
-    ), f"Expected UNSUPPORTED_FEATURE for action={action!r}, got {response.errors[0].code}"
+    assert response.errors is not None and len(response.errors) > 0, (
+        f"Expected Error response for action={action!r}; GAM currently rejects with UNSUPPORTED_FEATURE"
+    )
+    assert response.errors[0].code == "UNSUPPORTED_FEATURE", (
+        f"Expected UNSUPPORTED_FEATURE for action={action!r}, got {response.errors[0].code}"
+    )
 
 
 class TestGAMOrderLifecycleIntegration:

--- a/tests/integration/test_property_targeting_allowed_enforcement.py
+++ b/tests/integration/test_property_targeting_allowed_enforcement.py
@@ -154,9 +154,9 @@ async def test_create_accepts_property_list_when_product_allows(property_targeti
     # checks, leaving the happy-path proof vacuous. If the response IS an
     # error variant, accept any failure cause that isn't the property_targeting
     # rule itself (test stays decoupled from unrelated downstream errors).
-    assert not isinstance(
-        response, CreateMediaBuyError
-    ), f"Expected success but got CreateMediaBuyError: {[err.message for err in (response.errors or [])]}"
+    assert not isinstance(response, CreateMediaBuyError), (
+        f"Expected success but got CreateMediaBuyError: {[err.message for err in (response.errors or [])]}"
+    )
     assert all("property_targeting_allowed" not in err.message for err in (response.errors or []))
 
 
@@ -190,9 +190,9 @@ async def test_create_accepts_collection_list_without_property_list(property_tar
     # happy-path proof vacuous. Separate ``not isinstance`` gates the success
     # branch with a real check; the follow-up ``all(...)`` ensures the
     # property_list rule still doesn't fire if an unrelated error did appear.
-    assert not isinstance(
-        response, CreateMediaBuyError
-    ), f"Expected success but got CreateMediaBuyError: {[err.message for err in (response.errors or [])]}"
+    assert not isinstance(response, CreateMediaBuyError), (
+        f"Expected success but got CreateMediaBuyError: {[err.message for err in (response.errors or [])]}"
+    )
     assert all("property_targeting_allowed" not in err.message for err in (response.errors or []))
 
 

--- a/tests/integration/test_targeting_overlay_roundtrip.py
+++ b/tests/integration/test_targeting_overlay_roundtrip.py
@@ -209,9 +209,9 @@ def test_collection_list_roundtrips_through_postgres(roundtrip_tenant):
     assert len(response.media_buys) == 1
     pkg = response.media_buys[0].packages[0]
     assert pkg.targeting_overlay is not None
-    assert (
-        pkg.targeting_overlay.collection_list is not None
-    ), "collection_list nested reference must survive JSON SerDes"
+    assert pkg.targeting_overlay.collection_list is not None, (
+        "collection_list nested reference must survive JSON SerDes"
+    )
     assert pkg.targeting_overlay.collection_list.list_id == "C_collection_v1"
 
 

--- a/tests/unit/adapters/test_mock_product_config_post.py
+++ b/tests/unit/adapters/test_mock_product_config_post.py
@@ -1,0 +1,132 @@
+"""Unit tests for the MockProductConfig POST form handler.
+
+Covers the three paths in the mock_product_config route:
+  - Valid form data → config saved to DB via MockProductConfig.model_dump()
+  - Out-of-range value → ValidationError caught, error rendered to template
+  - Non-numeric input → ValueError caught, error rendered to template
+"""
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+VALID_FORM_DATA = {
+    "daily_impressions": "50000",
+    "fill_rate": "75.0",
+    "ctr": "2.0",
+    "viewability_rate": "60.0",
+    "latency_ms": "100",
+    "error_rate": "5.0",
+    "test_mode": "stress",
+    "price_variance": "5.0",
+    "seasonal_factor": "1.2",
+}
+
+
+def _make_test_app():
+    from flask import Flask
+
+    from src.adapters.mock_ad_server import MockAdServer
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["SECRET_KEY"] = "test-secret"
+    MockAdServer(config=MagicMock(), principal=MagicMock(), tenant_id="tenant1").register_ui_routes(app)
+    return app
+
+
+def _mock_db(product_obj):
+    session = MagicMock()
+    session.scalars.return_value.first.return_value = product_obj
+
+    @contextmanager
+    def _get_db_session():
+        yield session
+
+    return session, _get_db_session
+
+
+def _make_product():
+    p = MagicMock()
+    p.implementation_config = {}
+    p.format_ids = []
+    p.name = "Test Product"
+    return p
+
+
+class TestMockProductConfigPost:
+    """POST path: save, ValidationError, ValueError."""
+
+    def test_valid_post_saves_config_to_db(self):
+        """Valid form data is validated by MockProductConfig and saved to DB."""
+        app = _make_test_app()
+        product = _make_product()
+        session, mock_get_db = _mock_db(product)
+
+        with patch("src.admin.utils.require_auth", return_value=lambda f: f), \
+             patch("src.core.database.database_session.get_db_session", mock_get_db), \
+             patch("src.admin.blueprints.products.get_creative_formats", return_value=[]), \
+             patch("flask.render_template", return_value="ok"):
+            with app.test_client() as client:
+                resp = client.post(
+                    "/adapters/mock/config/tenant1/prod1",
+                    data=VALID_FORM_DATA,
+                )
+
+        assert resp.status_code == 200
+        saved = product.implementation_config
+        assert saved["fill_rate"] == 75.0
+        assert saved["test_mode"] == "stress"
+        assert saved["daily_impressions"] == 50000
+        session.commit.assert_called_once_with()
+
+    def test_out_of_range_value_returns_error(self):
+        """fill_rate > 100 triggers ValidationError; template rendered with error, DB not touched."""
+        app = _make_test_app()
+        product = _make_product()
+        session, mock_get_db = _mock_db(product)
+        render_kwargs: dict = {}
+
+        def capture(template, **kwargs):
+            render_kwargs.update(kwargs)
+            return "rendered"
+
+        with patch("src.admin.utils.require_auth", return_value=lambda f: f), \
+             patch("src.core.database.database_session.get_db_session", mock_get_db), \
+             patch("src.admin.blueprints.products.get_creative_formats", return_value=[]), \
+             patch("flask.render_template", side_effect=capture):
+            with app.test_client() as client:
+                client.post(
+                    "/adapters/mock/config/tenant1/prod1",
+                    data={**VALID_FORM_DATA, "fill_rate": "200"},
+                )
+
+        assert render_kwargs.get("error") is not None
+        session.commit.assert_not_called()
+
+    def test_non_numeric_input_returns_error(self):
+        """Non-numeric fill_rate triggers ValueError; template rendered with error, DB not touched."""
+        app = _make_test_app()
+        product = _make_product()
+        session, mock_get_db = _mock_db(product)
+        render_kwargs: dict = {}
+
+        def capture(template, **kwargs):
+            render_kwargs.update(kwargs)
+            return "rendered"
+
+        with patch("src.admin.utils.require_auth", return_value=lambda f: f), \
+             patch("src.core.database.database_session.get_db_session", mock_get_db), \
+             patch("src.admin.blueprints.products.get_creative_formats", return_value=[]), \
+             patch("flask.render_template", side_effect=capture):
+            with app.test_client() as client:
+                client.post(
+                    "/adapters/mock/config/tenant1/prod1",
+                    data={**VALID_FORM_DATA, "fill_rate": "not_a_number"},
+                )
+
+        assert render_kwargs.get("error") is not None
+        session.commit.assert_not_called()

--- a/tests/unit/adapters/test_mock_product_config_post.py
+++ b/tests/unit/adapters/test_mock_product_config_post.py
@@ -108,7 +108,10 @@ class TestMockProductConfigPost:
                     data={**VALID_FORM_DATA, "fill_rate": "200"},
                 )
 
-        assert render_kwargs.get("error") is not None
+        error_msg = render_kwargs.get("error", "")
+        assert "fill_rate" in error_msg, (
+            f"Pydantic out-of-range error must reference the offending field; got: {error_msg!r}"
+        )
         session.commit.assert_not_called()
 
     def test_non_numeric_input_returns_error(self):
@@ -134,5 +137,10 @@ class TestMockProductConfigPost:
                     data={**VALID_FORM_DATA, "fill_rate": "not_a_number"},
                 )
 
-        assert render_kwargs.get("error") is not None
+        error_msg = render_kwargs.get("error", "")
+        # ValueError from float conversion typically says "could not convert string to float"
+        # or surfaces the field name via the form-validator's coerce wrapper.
+        assert "fill_rate" in error_msg or "float" in error_msg.lower() or "numeric" in error_msg.lower(), (
+            f"Non-numeric conversion error must mention the field or the conversion failure; got: {error_msg!r}"
+        )
         session.commit.assert_not_called()

--- a/tests/unit/adapters/test_mock_product_config_post.py
+++ b/tests/unit/adapters/test_mock_product_config_post.py
@@ -66,10 +66,12 @@ class TestMockProductConfigPost:
         product = _make_product()
         session, mock_get_db = _mock_db(product)
 
-        with patch("src.admin.utils.require_auth", return_value=lambda f: f), \
-             patch("src.core.database.database_session.get_db_session", mock_get_db), \
-             patch("src.admin.blueprints.products.get_creative_formats", return_value=[]), \
-             patch("flask.render_template", return_value="ok"):
+        with (
+            patch("src.admin.utils.require_auth", return_value=lambda f: f),
+            patch("src.core.database.database_session.get_db_session", mock_get_db),
+            patch("src.admin.blueprints.products.get_creative_formats", return_value=[]),
+            patch("flask.render_template", return_value="ok"),
+        ):
             with app.test_client() as client:
                 resp = client.post(
                     "/adapters/mock/config/tenant1/prod1",
@@ -94,10 +96,12 @@ class TestMockProductConfigPost:
             render_kwargs.update(kwargs)
             return "rendered"
 
-        with patch("src.admin.utils.require_auth", return_value=lambda f: f), \
-             patch("src.core.database.database_session.get_db_session", mock_get_db), \
-             patch("src.admin.blueprints.products.get_creative_formats", return_value=[]), \
-             patch("flask.render_template", side_effect=capture):
+        with (
+            patch("src.admin.utils.require_auth", return_value=lambda f: f),
+            patch("src.core.database.database_session.get_db_session", mock_get_db),
+            patch("src.admin.blueprints.products.get_creative_formats", return_value=[]),
+            patch("flask.render_template", side_effect=capture),
+        ):
             with app.test_client() as client:
                 client.post(
                     "/adapters/mock/config/tenant1/prod1",
@@ -118,10 +122,12 @@ class TestMockProductConfigPost:
             render_kwargs.update(kwargs)
             return "rendered"
 
-        with patch("src.admin.utils.require_auth", return_value=lambda f: f), \
-             patch("src.core.database.database_session.get_db_session", mock_get_db), \
-             patch("src.admin.blueprints.products.get_creative_formats", return_value=[]), \
-             patch("flask.render_template", side_effect=capture):
+        with (
+            patch("src.admin.utils.require_auth", return_value=lambda f: f),
+            patch("src.core.database.database_session.get_db_session", mock_get_db),
+            patch("src.admin.blueprints.products.get_creative_formats", return_value=[]),
+            patch("flask.render_template", side_effect=capture),
+        ):
             with app.test_client() as client:
                 client.post(
                     "/adapters/mock/config/tenant1/prod1",

--- a/tests/unit/adapters/test_mock_product_config_post.py
+++ b/tests/unit/adapters/test_mock_product_config_post.py
@@ -20,7 +20,7 @@ VALID_FORM_DATA = {
     "viewability_rate": "60.0",
     "latency_ms": "100",
     "error_rate": "5.0",
-    "test_mode": "stress",
+    "test_mode": "high_demand",
     "price_variance": "5.0",
     "seasonal_factor": "1.2",
 }
@@ -79,7 +79,7 @@ class TestMockProductConfigPost:
         assert resp.status_code == 200
         saved = product.implementation_config
         assert saved["fill_rate"] == 75.0
-        assert saved["test_mode"] == "stress"
+        assert saved["test_mode"] == "high_demand"
         assert saved["daily_impressions"] == 50000
         session.commit.assert_called_once_with()
 

--- a/tests/unit/adapters/test_schemas.py
+++ b/tests/unit/adapters/test_schemas.py
@@ -56,26 +56,56 @@ class TestMockSchemas:
         assert config.dry_run is True
 
     def test_mock_product_config_defaults(self):
-        """MockProductConfig should have simulation defaults."""
+        """MockProductConfig should have simulation defaults (percents)."""
         config = MockProductConfig()
-        assert config.daily_impressions == 10000
-        assert config.fill_rate == 0.85
-        assert config.ctr == 0.02
-        assert config.viewability == 0.65
-        assert config.scenario == "normal"
+        assert config.daily_impressions == 100000
+        assert config.fill_rate == 85.0
+        assert config.ctr == 0.5
+        assert config.viewability_rate == 70.0
+        assert config.test_mode == "normal"
+        assert config.latency_ms == 50
+        assert config.error_rate == 0.1
+        assert config.verbose_logging is False
+        assert config.predictable_ids is False
+        assert config.delivery_simulation.enabled is False
 
     def test_mock_product_config_validation(self):
-        """MockProductConfig should validate field constraints."""
-        # fill_rate must be between 0 and 1
+        """MockProductConfig should validate field constraints (percents 0-100)."""
+        # fill_rate must be between 0 and 100
         with pytest.raises(ValidationError):
-            MockProductConfig(fill_rate=1.5)
+            MockProductConfig(fill_rate=101.0)
 
         with pytest.raises(ValidationError):
-            MockProductConfig(fill_rate=-0.1)
+            MockProductConfig(fill_rate=-1.0)
 
         # daily_impressions must be non-negative
         with pytest.raises(ValidationError):
             MockProductConfig(daily_impressions=-100)
+
+        # viewability_rate must be between 0 and 100
+        with pytest.raises(ValidationError):
+            MockProductConfig(viewability_rate=101.0)
+
+        # error_rate must be between 0 and 100
+        with pytest.raises(ValidationError):
+            MockProductConfig(error_rate=-0.1)
+
+    def test_mock_product_config_round_trip(self):
+        """MockProductConfig should round-trip through model_dump/model_validate."""
+        config = MockProductConfig(
+            daily_impressions=50000,
+            fill_rate=75.0,
+            ctr=1.5,
+            viewability_rate=60.0,
+            test_mode="stress",
+            delivery_simulation={"enabled": True, "time_acceleration": 1800, "update_interval_seconds": 2.0},
+        )
+        dumped = config.model_dump()
+        restored = MockProductConfig.model_validate(dumped)
+        assert restored.fill_rate == 75.0
+        assert restored.test_mode == "stress"
+        assert restored.delivery_simulation.enabled is True
+        assert restored.delivery_simulation.time_acceleration == 1800
 
 
 class TestAdapterCapabilities:
@@ -178,10 +208,11 @@ class TestSchemaJsonSerialization:
         assert "properties" in schema
         assert "daily_impressions" in schema["properties"]
         assert "fill_rate" in schema["properties"]
-        # Check that constraints are in schema
+        assert "viewability_rate" in schema["properties"]
+        # Rate fields use percents (0–100)
         fill_rate_schema = schema["properties"]["fill_rate"]
         assert fill_rate_schema.get("minimum") == 0.0
-        assert fill_rate_schema.get("maximum") == 1.0
+        assert fill_rate_schema.get("maximum") == 100.0
 
     def test_schema_descriptions_present(self):
         """Schema fields should have descriptions."""

--- a/tests/unit/adapters/test_schemas.py
+++ b/tests/unit/adapters/test_schemas.py
@@ -97,13 +97,13 @@ class TestMockSchemas:
             fill_rate=75.0,
             ctr=1.5,
             viewability_rate=60.0,
-            test_mode="stress",
+            test_mode="high_demand",
             delivery_simulation={"enabled": True, "time_acceleration": 1800, "update_interval_seconds": 2.0},
         )
         dumped = config.model_dump()
         restored = MockProductConfig.model_validate(dumped)
         assert restored.fill_rate == 75.0
-        assert restored.test_mode == "stress"
+        assert restored.test_mode == "high_demand"
         assert restored.delivery_simulation.enabled is True
         assert restored.delivery_simulation.time_acceleration == 1800
 

--- a/tests/unit/admin/test_adapter_blueprints.py
+++ b/tests/unit/admin/test_adapter_blueprints.py
@@ -87,7 +87,7 @@ class TestAdapterConfigValidation:
             schemas.connection_config(unknown_field="value")
 
     def test_mock_product_config_validates_ranges(self):
-        """MockProductConfig should enforce value ranges."""
+        """MockProductConfig should enforce value ranges (percents 0-100)."""
         from pydantic import ValidationError
 
         from src.adapters import get_adapter_schemas
@@ -95,13 +95,13 @@ class TestAdapterConfigValidation:
         schemas = get_adapter_schemas("mock")
         MockProductConfig = schemas.product_config
 
-        # Valid ranges
-        valid = MockProductConfig(fill_rate=0.5, ctr=0.05, viewability=0.7)
-        assert valid.fill_rate == 0.5
+        # Valid ranges (percents)
+        valid = MockProductConfig(fill_rate=50.0, ctr=5.0, viewability_rate=70.0)
+        assert valid.fill_rate == 50.0
 
-        # Invalid: fill_rate > 1
+        # Invalid: fill_rate > 100
         with pytest.raises(ValidationError):
-            MockProductConfig(fill_rate=1.5)
+            MockProductConfig(fill_rate=101.0)
 
         # Invalid: negative impressions
         with pytest.raises(ValidationError):

--- a/tests/unit/test_media_buy.py
+++ b/tests/unit/test_media_buy.py
@@ -918,7 +918,9 @@ class TestCreateMediaBuyCreativeValidation:
         package.creative_ids = ["c_gen"]
         package.package_id = "pkg_1"
 
-        with (patch("src.core.tools.media_buy_create._get_format_spec_sync", return_value=mock_format_spec),):
+        with (
+            patch("src.core.tools.media_buy_create._get_format_spec_sync", return_value=mock_format_spec),
+        ):
             session = MagicMock()
             session.scalars.return_value.all.return_value = [mock_creative]
 

--- a/tests/unit/test_update_media_buy_behavioral.py
+++ b/tests/unit/test_update_media_buy_behavioral.py
@@ -1826,9 +1826,9 @@ class TestUC003UpdateTargetingOverlay:
         # response_data) gets caught — that would silently lose the
         # structured payload on the webhook path.
         fail_calls = standard_mocks["ctx_mgr_instance"].fail_workflow_step_for_exception.call_args_list
-        assert (
-            len(fail_calls) == 1
-        ), f"Expected exactly one fail_workflow_step_for_exception call on raise, got {len(fail_calls)}"
+        assert len(fail_calls) == 1, (
+            f"Expected exactly one fail_workflow_step_for_exception call on raise, got {len(fail_calls)}"
+        )
         fail_call = fail_calls[0]
         # Positional args: (step_id, exception)
         assert fail_call.args[0] == standard_mocks["step"].step_id
@@ -1936,9 +1936,9 @@ class TestUC003UpdateTargetingOverlay:
             persisted_list_id = persisted_pl.list_id if persisted_pl is not None else None
         else:
             persisted_list_id = persisted["property_list"]["list_id"]
-        assert (
-            persisted_list_id == "B"
-        ), f"replacement semantic broken — persisted list_id={persisted_list_id!r}, expected 'B'"
+        assert persisted_list_id == "B", (
+            f"replacement semantic broken — persisted list_id={persisted_list_id!r}, expected 'B'"
+        )
         # The original "A" must not survive on list_id specifically (don't
         # substring-match the whole overlay repr — 'AnyUrl' contains 'A' too).
         assert persisted_list_id != "A", "original list_id was not replaced"


### PR DESCRIPTION
…ema with Pydantic validation

Replaces the 5-field fraction-based MockProductConfig (0–1 rates) with the 12-field percent-based schema (0–100) that matches what the admin form already stores in implementation_config. Removes the broken validate_product_config() method (returned a tuple but was used as a bool, so it always silently passed). POST handler now constructs and validates via Pydantic, raising ValidationError or ValueError on bad input and rendering the error back to the template.

Closes #1267