### PR TITLE
test: restore green main — BDD strict-marker cleanup + 16 test/infra fixes

### DIFF
--- a/.claude/notes/bdd-strict-marker-cleanup-proposal.md
+++ b/.claude/notes/bdd-strict-marker-cleanup-proposal.md
@@ -1,0 +1,224 @@
+# BDD strict-marker debt — proposed GH issue structure
+
+**Status: PROPOSED, awaiting owner approval. Do NOT execute without explicit go.**
+
+## Context
+
+After the 2026-05-08 cleanup (commit `c4446267`), `tests/bdd/conftest.py`
+has zero blanket non-strict markers on scenarios where production has
+caught up. Remaining non-strict and selective-strict markers all point
+to one of 19 items catalogued in `docs/test-debt-bdd-strict-markers.md`.
+
+Each item represents either a production gap (10) or a test rewrite (7)
+or a test-helper improvement (2). Severity: 3× P1 (security/correctness),
+7× P2 (real bugs/feature gaps), 9× P3 (cosmetic/refinement).
+
+The doc is the canonical reference. FIXMEs in `conftest.py` reference it
+by item ID (`C1`–`C11`, `B1`–`B7`, `H1`–`H2`).
+
+## Recommendation
+
+**File 4 GH issues, not 19.** Keep `docs/test-debt-bdd-strict-markers.md`
+as the source of truth; use GH issues as work trackers for the items that
+need cross-team visibility.
+
+### Issue 1 — Umbrella (P2)
+
+- **Title:** `Test debt: BDD strict-marker inventory tracking (16 items)`
+- **Labels:** `test-debt`, `bdd`, `tracking`
+- **Body template:**
+
+  ```markdown
+  Tracking the non-security items from
+  `docs/test-debt-bdd-strict-markers.md`. The doc is the single source
+  of truth; please update the doc when items resolve, then check the
+  corresponding box here.
+
+  Production gaps (P2–P3):
+  - [ ] C4 — Pydantic ValidationError → AdCPError(INVALID_REQUEST, suggestion) translation
+  - [ ] C5 — include_package_daily_breakdown no-op
+  - [ ] C6 — date-range validation in success envelope vs raised
+  - [ ] C7 — end-only date_range defaults to today-30d, not creation date
+  - [ ] C8 — MCP wrapper missing output_format_ids / input_format_ids
+  - [ ] C10 — description-only spec constraints (Duration campaign-unit, Geo metro/postal system)
+  - [ ] C11 — start_date / end_date not echoed in response.reporting_period
+
+  Test rewrites (P2–P3):
+  - [ ] B1 — Gherkin uses pending_activation (not in MediaBuyStatus enum)
+  - [ ] B2 — date_range partition/boundary _dispatch_partition wiring
+  - [ ] B3 — resolution/ownership symbolic names + identity-swap rewrite
+  - [ ] B4 — sampling_method scenarios on wrong feature (move to UC-024)
+  - [ ] B5 — webhook_credentials mis-routed (rewire or delete)
+  - [ ] B6 — disclosure_positions filter + all_positions step enum fix
+  - [ ] B7 — UC-006 account_resolution step-layer fakes AdCPValidationError
+
+  Test-helper improvements (P3):
+  - [ ] H1 — _assert_partition_outcome invalid branch should isinstance-guard
+  - [ ] H2 — _assert_partition_outcome valid branch should route by domain
+
+  When resolving an item: remove its entry from
+  `docs/test-debt-bdd-strict-markers.md`, remove the FIXME from
+  `tests/bdd/conftest.py`, flip the marker to `strict=True` (or remove
+  if no rows remain xfail), and check this box.
+  ```
+
+### Issues 2–4 — Three P1 security/correctness items (separate)
+
+These get their own issues so they surface in security boards and
+warrant their own threat-model write-ups.
+
+#### Issue 2 — `bug(a2a): silently discards account parameter on get_media_buy_delivery (security)`
+
+- **Labels:** `security`, `a2a`, `P1`
+- **Body:**
+
+  ```markdown
+  ## Summary
+  `src/a2a_server/adcp_a2a_server.py:1937-1980` — the A2A skill handler
+  for `get_media_buy_delivery` does not forward the `account` parameter
+  to `_raw()` and does not call `enrich_identity_with_account`.
+
+  ## Impact
+  Security gap. A buyer with a token scoped to one tenant could request
+  delivery against another account, and the account scope is silently
+  ignored. The REST transport correctly resolves account at
+  `src/routes/api_v1.py:265-289`; A2A and IMPL skip the step.
+
+  ## Reproduction
+  BDD scenarios `T-UC-004-partition-account` and
+  `T-UC-004-boundary-account`, error-code rows on the `[a2a]` transport,
+  currently xpass on REST/MCP and xfail on IMPL/A2A.
+
+  ## Threat model
+  - Is the A2A endpoint exposed to untrusted callers in production?
+    (yes — that's the protocol's purpose)
+  - Does a tenant's token authorize them to query any account, or only
+    accounts they own? (the latter — but the parameter that scopes that
+    is being dropped)
+  - Has this been exploited? (no known abuse; logs may not even surface
+    the discard since the parameter is silently ignored at deserialize time)
+
+  ## Fix
+  Forward `account` to `_raw()` in `_handle_get_media_buy_delivery_skill`;
+  call `enrich_identity_with_account` on the A2A path. Paired with C2
+  (move the resolution into `_impl` so all transports share the step).
+
+  Tracked: `docs/test-debt-bdd-strict-markers.md#c1`
+  ```
+
+#### Issue 3 — `bug(impl): _get_media_buy_delivery_impl does not resolve AccountReference`
+
+- **Labels:** `correctness`, `core`, `P1`
+- **Body:**
+
+  ```markdown
+  ## Summary
+  `src/core/tools/media_buy_delivery.py` — IMPL accepts the `account`
+  kwarg but never resolves it against the DB. Account resolution only
+  happens at the REST wrapper boundary
+  (`src/routes/api_v1.py:265-289`); A2A and MCP and direct-IMPL calls
+  skip it.
+
+  ## Impact
+  Cross-transport contract is broken. Same buyer with same token gets
+  different behavior depending on which transport they use.
+  `account_not_found` rows pass through IMPL silently.
+
+  ## Fix
+  Move `enrich_identity_with_account` from the REST wrapper into
+  `_impl` (or into a shared helper that every transport calls before
+  `_impl`). Paired with the A2A fix (Issue 2).
+
+  Tracked: `docs/test-debt-bdd-strict-markers.md#c2`
+  ```
+
+#### Issue 4 — `bug(repo): cross-principal media_buy access returns 200+empty instead of 403 (security)`
+
+- **Labels:** `security`, `core`, `P1`
+- **Body:**
+
+  ```markdown
+  ## Summary
+  `src/core/database/repositories/media_buy.py:99-107`,
+  `MediaBuyRepository.get_by_principal`, filters silently by
+  `principal_id`. A request from a principal who does not own any of
+  the requested media_buys receives an empty deliveries list, not an
+  authorization error.
+
+  ## Impact
+  Security gap. A 200 OK with empty body is indistinguishable from
+  "everything ran, nothing matched." A 403 (or 404 with suggestion)
+  would correctly indicate the access was denied. The BDD ownership
+  scenarios were the only place this could be observed and they do
+  not actually swap identity (see B3 — separate test bug), so the gap
+  is invisible to the suite today.
+
+  ## Threat model
+  - Allowed to enumerate other principals' media_buy_ids? (no — but
+    a guess-and-check attacker could)
+  - Caching layer might cache the empty response — would that leak?
+    (probably not, but worth checking)
+
+  ## Fix
+  Raise `AdCPAuthorizationError` (or `AdCPNotFoundError` with
+  suggestion text "media_buy not found or not owned by you") when the
+  requesting principal does not own any of the requested media_buys.
+
+  Tracked: `docs/test-debt-bdd-strict-markers.md#c3`
+  ```
+
+## FIXME wiring plan (after issues land)
+
+For each FIXME comment in `tests/bdd/conftest.py` (currently pointing
+at `docs/test-debt-bdd-strict-markers.md`), append the GH issue number
+once the issues are filed:
+
+- C1, C2 → reference Issue 2, Issue 3
+- C3 → reference Issue 4
+- C4, C5, C6, C7, C8, C10, C11 → reference Issue 1 (umbrella checkbox)
+- B1, B2, B3, B4, B5, B6, B7 → reference Issue 1
+- H1, H2 → reference Issue 1 (or leave doc-only)
+
+Format (per `feedback_no_beads_in_code` memory):
+
+```python
+# FIXME(gh-#nnnn, see docs/test-debt-bdd-strict-markers.md#c4)
+```
+
+Beads IDs are never used in code per project convention.
+
+## Verification after issues land
+
+1. Open each issue body; spot-check at least one link to the doc
+   resolves correctly.
+2. `grep -n "FIXME" tests/bdd/conftest.py` — every FIXME has both an
+   issue number and a doc-anchor reference.
+3. `make quality` still passes.
+4. No commit needs to add or remove a test marker; only the FIXME
+   comment text changes.
+
+## Open questions for the owner
+
+1. **Single umbrella or split prod-gaps from test-rewrites into two
+   umbrellas?** Umbrella stays manageable at 16 items; splitting adds
+   another tracker without clear benefit.
+2. **For the 3 P1 security issues, should those also reference the
+   umbrella, or stand fully alone?** Recommendation: stand alone; the
+   umbrella covers the non-security work.
+3. **Labels:** project has its own label taxonomy
+   (`bug`/`feature`/`task`/`tracking` per release-please convention).
+   Verify before filing — `gh label list` will confirm.
+4. **Assignee:** unset (let the team triage).
+5. **Milestone:** umbrella → next adcp library upgrade milestone?
+   Security issues → whatever the next hot-fix milestone is?
+
+## Risks
+
+- Filing 4 issues makes it look like a bigger initiative than it is.
+  Mitigation: the umbrella body explicitly says "test debt tracking,"
+  signalling this is a passive list, not active work.
+- The 3 security issues might attract security review attention. That's
+  desirable — they're real gaps and should be triaged independently.
+- If the team prefers all-in-one tracking, drop to 1 umbrella with the
+  security items as P1 sub-checkboxes labelled `security`. Less precise
+  but simpler.

--- a/.claude/notes/handoff-bdd-strict-cleanup.md
+++ b/.claude/notes/handoff-bdd-strict-cleanup.md
@@ -1,0 +1,217 @@
+# Handoff — BDD strict-marker cleanup + green-main restoration
+
+**Last touched: 2026-05-08. Status: paused after Wave 3 / strict-marker
+cleanup, awaiting owner approval to file GH issues.**
+
+If you are picking this up cold, read this top to bottom before doing
+anything. Then read the plan in `.claude/notes/bdd-strict-marker-cleanup-proposal.md`.
+
+## TL;DR — where we are
+
+Local `main` is at `c4446267`, **13 commits ahead of `origin/main`**
+(local merges only, no push per project convention). All commits
+authored as Constantine Mirin.
+
+```
+c4446267 test(bdd): clear ~244 stale xfail markers and tighten 4 blanket scopes
+ea2181cc fix(test-stack): raise readiness deadline 120s -> 360s for cold-boot
+3c1bae94 fix(deploy): raise migration timeout to 300s and stream output
+cf731023 refactor(test): route UC-004 webhook BDD scenarios through CircuitBreakerEnv
+44c8c2b0 fix(test): include valid identifier in test_create_property_saves_to_db POST
+ab43f116 test: xfail UC-004 by_geo/by_device_type breakdown scenarios — production gap
+15eed75a fix(test): inventory_profiles list test asserts on JS-rendered content
+c6cfb99f fix(prod): _build_sync_result must populate account_id on sync responses
+5315f543 test: xfail authorized_properties list page tests for missing template
+731b177e fix(test): UC-011 advertiser assertion conflates schema with model_dump
+a353cd5b fix(test): BDD webhook conftest branch missing integration_db fixture
+8a325683 fix(test): inventory_profiles delete test calls POST instead of DELETE
+00a468dc fix(test): _resolve_media_buy_id helper not defined in uc004_delivery.py (4 failures)
+6c9017c8 fix(test): admin Principal fixture uses empty platform_mappings dict
+5011855d (origin/main) feat: upgrade adcp SDK 3.12→4.3 and import protocol metadata (#1266)
+```
+
+Working tree: clean except for the untracked `.claude/skills/.agent-db.env`
+file, which is a worktree-local DB env stub that the skill writes when
+spawning containers. Not part of this work; leave alone.
+
+## Test status
+
+Last full green run: **`test-results/070526_2244/`** (2026-05-07).
+
+```
+admin:        78p 0f 0e  3 xfailed
+bdd:         999p 0f 0e  2839 xfailed   (after Wave-2 webhook routing fix)
+e2e:          87p 0f 0e  28 skipped
+integration: 1880p 0f 0e  39 xfailed
+ui:            5p 0e
+unit:       4550p 0f 0e  19 xfailed
+```
+
+After the `c4446267` strict-marker cleanup, the BDD xpasses dropped
+further (from 427 to 0 for in-scope scenarios; the targeted post-cleanup
+run showed 224 passed, 0 failed, 0 xpassed, 68 strict xfailed). Full
+`./run_all_tests.sh` was not re-run after `c4446267`; if you want
+absolute confidence before doing anything destructive, re-run it.
+
+## Three documents you should read
+
+1. **`docs/test-debt-bdd-strict-markers.md`** — canonical inventory of
+   the 19 items still wearing non-strict markers. Each has a unique ID
+   (C1–C11, B1–B7, H1–H2). FIXME comments in `tests/bdd/conftest.py`
+   reference these IDs.
+
+2. **`.claude/notes/bdd-strict-marker-cleanup-proposal.md`** — proposed GH
+   issue structure (1 umbrella + 3 P1 security issues). Awaiting owner
+   approval; do NOT file issues until they say go.
+
+3. **This file** — operational state.
+
+## What's done
+
+- [x] Wave 1 (9 BDD/admin fixes) — all 9 sub-tasks of `salesagent-4ku`
+      closed, rebased onto post-#1266 main
+- [x] Wave 2 (`salesagent-ww2`) — UC-004 webhook BDD routing through
+      `CircuitBreakerEnv` instead of legacy `deliver_webhook_with_retry`
+- [x] 13j follow-up bug — TestPropertyCreate identifier fix
+- [x] Migration timeout bump (60s → 300s) — `scripts/deploy/run_all_services.py`
+- [x] Test-stack readiness deadline bump (120s → 360s) — `scripts/test-stack.sh`
+- [x] Wave 3 verification — `./run_all_tests.sh` fully green at
+      `070526_2244`
+- [x] Local fast-forward merge of `fix/restore-green-main` → `main`
+      (post-Wave-3, see commit ladder above)
+- [x] `salesagent-4ku` epic closed
+- [x] BDD strict-marker audit via 6 parallel Explore agents
+- [x] Strict-marker cleanup committed as `c4446267` (~244 stale
+      markers cleared, 14 precise strict=True added)
+- [x] `docs/test-debt-bdd-strict-markers.md` created with full
+      inventory and lifecycle instructions
+
+## What's pending (in priority order)
+
+1. **Owner decision on GH issue structure** — see plan doc. Options:
+   - (a) 1 umbrella + 3 P1 security issues (recommended)
+   - (b) 1 umbrella only, security folded in as P1 sub-checkboxes
+   - (c) Doc-only, no GH issues
+2. **If (a) or (b): file issues, then wire FIXME comments** in
+   `tests/bdd/conftest.py` to reference issue numbers. Per
+   `feedback_no_beads_in_code` memory, use GH issue refs in code
+   comments, never beads IDs.
+3. **Eventually: work the 19 items** — each item has its own scope,
+   spec source, production gap (if any), and unblock criterion. Engineers
+   pick from the umbrella checklist, fix the gap, flip the marker, remove
+   the doc entry, check the box.
+
+## Open beads tickets (this work created)
+
+These were filed during the parent epic and remain open after `c4446267`:
+
+- `salesagent-u6n` (P2 feat) — implement authorized_properties_list page
+- `salesagent-zk1` (P2 feat) — implement reporting_dimensions breakdowns
+  (by_geo, by_device_type, by_audience) per BR-RULE-091
+- `salesagent-3d1` (P2 bug) — agent-db skill keys container off skills
+  basename, collides between concurrent worktree executors
+- `salesagent-13j` is **closed** (fixed in commit `44c8c2b0`)
+- `salesagent-4ku` epic is **closed**
+
+Do NOT file beads tickets for the items in
+`docs/test-debt-bdd-strict-markers.md`. Per the owner's direction
+(2026-05-08 session), GitHub is the right tracker for cross-team
+visibility; beads is reserved for the active session-bridging
+backlog.
+
+## Critical project conventions (read these or risk losing work)
+
+From `/Users/konst/.claude/projects/-Users-konst-projects-salesagent/memory/MEMORY.md`:
+
+- **NEVER run any `bd sync` variant.** Overwrites shared JSONL,
+  destroys tickets across all worktrees. Use `bd import -i .beads/issues.jsonl`
+  if the local DB goes stale.
+- **NEVER touch `.beads/` during merge conflicts.** Stop and ask.
+- **NEVER drop/pop/clear stashes** without explicit permission. Lost
+  completed #1162 work this way once.
+- **NEVER remove worktrees** without explicit permission. They exist
+  for a reason.
+- **NEVER mention Claude in commit messages.** Project rule.
+- **Code comments use GH issue/PR numbers, never beads IDs.**
+- **`./run_all_tests.sh` is the only valid final verification.**
+  Targeted runs are for iteration only.
+- **Test integrity is zero-tolerance.** Never use `--ignore`,
+  `-k "not"`, or pytest skip flags to silence failures. Fix or report
+  as blocker.
+
+## Source-of-truth principle (recently affirmed by owner)
+
+For enum values, schema shapes, and protocol constraints, the AdCP
+library types (`.venv/lib/python3.12/site-packages/adcp/types/...`)
+and the AdCP spec are authoritative — **NOT** the existing codebase.
+If a test references an enum value that exists in the codebase but
+not in the library, the test is wrong, regardless of how long the
+codebase has had the value. Example: B1 (Gherkin uses
+`pending_activation` which is not in `MediaBuyStatus`); the fix is
+to align with the library, not preserve the codebase value.
+
+## How to verify nothing has broken since this handoff
+
+```bash
+cd /Users/konst/projects/salesagent-main
+git status                                            # should be clean
+git log --oneline origin/main..HEAD | head            # should show 13 commits
+git log -1 --format=%H                                # should be c4446267
+make quality                                           # should pass
+```
+
+If you want to verify the strict-marker cleanup specifically:
+
+```bash
+scripts/run-test.sh tests/bdd/test_uc004_deliver_media_buy_metrics.py \
+  tests/bdd/test_uc005_discover_creative_formats.py \
+  -k 'reporting_dimensions or attribution_window or asset_types_filter or daterange or filter_default or filter_empty or filter_array' \
+  --tb=line 2>&1 | tail -5
+```
+
+Expected: `224 passed, 1227 deselected, 68 xfailed`. 0 failed, 0
+xpassed in scope.
+
+If you want to confirm production gap C11 (the one we discovered
+during the strict-flip):
+
+```bash
+scripts/run-test.sh tests/bdd/test_uc004_deliver_media_buy_metrics.py \
+  -k 'test_custom_date_range_used_as_reporting_period' --tb=line 2>&1 | tail -10
+```
+
+Expected: 4 xfailed (one per transport). The marker reason mentions
+"production ignores buyer-supplied start_date." When C11 is fixed in
+production, this test will start xpassing → strict marker fails →
+forces removal. Working as designed.
+
+## Architecture context worth knowing
+
+- **All 4 in-process BDD transports** (IMPL/A2A/MCP/REST) are wired for
+  UC-004 and UC-011 via `tests/bdd/conftest.py:pytest_generate_tests`.
+  No E2E (real HTTP) surface yet — that's a separate future epic per
+  `project_bdd_e2e_direction` memory.
+- **Webhook delivery has two competing services in production**:
+  `WebhookDeliveryService.send_delivery_webhook` (the correct,
+  spec-compliant one with X-ADCP-Signature/Authorization headers) and
+  `deliver_webhook_with_retry` (the legacy one with X-Webhook-Signature,
+  different retry semantics). The Wave-2 fix `cf731023` routed BDD
+  scenarios through the correct service via `CircuitBreakerEnv`. The
+  legacy service may be dead code worth removing — out of scope.
+- **`_assert_partition_outcome`** in
+  `tests/bdd/steps/generic/then_payload.py:209-230` is the shared
+  Then-step helper for UC-005's binary `valid`/`invalid` Examples
+  columns. UC-004 uses its own richer `_assert_partition_or_boundary`
+  that parses `error "..." with suggestion` shapes. H1/H2 in the
+  inventory cover known weaknesses.
+
+## Where to ask for direction
+
+The owner is Constantine Mirin
+(`constantine@mirin.pro`). When in doubt about scope, file the question
+to them before acting. Pattern: the green-main effort was scoped tightly
+to "make main green again" and the strict-marker cleanup discovered 19
+follow-ups — those should be tracked separately, not absorbed into the
+main fix. The owner explicitly said "we don't want this main branch fix
+to become a super big refactoring of unrelated issues" — that principle
+applies to anything you discover going forward too.

--- a/docs/test-debt-bdd-strict-markers.md
+++ b/docs/test-debt-bdd-strict-markers.md
@@ -1,0 +1,340 @@
+# BDD strict-marker debt
+
+Inventory of BDD scenarios still wearing non-strict xfail markers after the
+2026-05-08 cleanup that removed ~244 stale markers from `tests/bdd/conftest.py`.
+Every entry below corresponds to a marker that requires either a production
+change or a test rewrite before it can be flipped to `strict=True`.
+
+**Goal:** zero non-strict xfail markers. Every scenario must be `pass`, `fail`,
+or `xfail-strict`. No gray zone.
+
+This file is the single source of truth referenced from FIXME comments in
+`tests/bdd/conftest.py`. When the underlying gap is closed, remove the entry
+here and the corresponding marker block.
+
+---
+
+## How to read this
+
+- **Scope** lists the affected scenario tags or selective entries in
+  `tests/bdd/conftest.py`.
+- **Impact** is the count of currently-skipped/xfailed test runs (rows ×
+  transports) that block.
+- **Unblocks** describes the production change or test rewrite that closes
+  the item; once landed, the marker can flip to `strict=True` (or be removed
+  if no rows remain xfail).
+- **Origin** points to the audit batch that surfaced the item.
+
+---
+
+## Production gaps (P0–P2) — require code changes
+
+### C1 — A2A skill silently discards `account` parameter
+- **Scope:** `T-UC-004-partition-account` and `T-UC-004-boundary-account`,
+  error-code rows on the `[a2a]` transport
+- **Where:** `src/a2a_server/adcp_a2a_server.py:1937-1980` (handler does not
+  forward `account` to `_raw()` and does not call `enrich_identity_with_account`)
+- **Impact:** Security gap. A buyer with a token scoped to one tenant could
+  request delivery and the account scope would be ignored. Surfaces as
+  asymmetric pass/fail across transports for the boundary/partition account
+  scenarios.
+- **Unblocks:** flip the error-code rows to `strict=True` once A2A forwards
+  the parameter and `enrich_identity_with_account` runs on the A2A path.
+- **Severity:** P1 (security gap)
+- **Origin:** Batch 3 audit
+
+### C2 — IMPL `_get_media_buy_delivery_impl` does not resolve `AccountReference`
+- **Scope:** Same as C1 (account error-code rows)
+- **Where:** `src/core/tools/media_buy_delivery.py` — only REST currently calls
+  `enrich_identity_with_account` (`src/routes/api_v1.py:265-289`); IMPL receives
+  `account` as a request kwarg but never resolves it against the DB
+- **Impact:** `account_not_found` rows pass through IMPL silently; cross-
+  transport contract is broken
+- **Unblocks:** move account resolution into the `_impl` boundary so all
+  transports share the validation step
+- **Severity:** P1 (correctness; pairs with C1)
+- **Origin:** Batch 3 audit
+
+### C3 — Cross-principal media-buy access returns 200+empty instead of 403
+- **Scope:** `T-UC-004-partition-ownership` / `-boundary-ownership`,
+  mismatch rows
+- **Where:** `src/core/database/repositories/media_buy.py:99-107`
+  (`get_by_principal` filters silently)
+- **Impact:** Security gap. A request with a foreign principal_id receives
+  an empty deliveries list rather than `AdCPAuthorizationError`.
+- **Unblocks:** raise `AdCPAuthorizationError` (or 404 with suggestion) when
+  the requesting principal does not own any of the requested media_buys.
+  Then the ownership mismatch rows can flip to `strict=True`.
+- **Severity:** P1 (security gap)
+- **Origin:** Batch 3 audit
+
+### C4 — Pydantic `ValidationError` not translated to `AdCPError(INVALID_REQUEST, suggestion)`
+- **Scope:** ~32 partition rows across UC-004 (`reporting_dimensions`,
+  `attribution_window`, possibly more) — currently `strict=True` xfail
+  pointing at this item
+- **Where:** transport boundary in `_get_media_buy_delivery_impl` and other
+  `_impl` functions
+- **Impact:** Many invalid partition rows correctly fail validation but
+  produce a Pydantic `ValidationError`, not an `AdCPError` with `error_code
+  == "INVALID_REQUEST"` and `details["suggestion"]`. The BDD step's stricter
+  invalid-with-error-code path requires the AdCPError shape.
+- **Unblocks:** add a transport-boundary translator that wraps Pydantic
+  `ValidationError` in `AdCPError(INVALID_REQUEST, suggestion=…)`. One change
+  clears ~32 currently-xfailed rows across UC-004 and probably more across
+  UC-005.
+- **Severity:** P2 (broad payoff)
+- **Origin:** Batch 1, Batch 2, Batch 4 audits
+
+### C5 — `include_package_daily_breakdown` is a no-op
+- **Scope:** `T-UC-004-partition-daily-breakdown` and
+  `-boundary-daily-breakdown` valid rows (currently strict=False)
+- **Where:** `src/core/tools/media_buy_delivery.py:480` hard-codes
+  `daily_breakdown=None` regardless of `req.include_package_daily_breakdown`
+- **Impact:** The schema declares the field; production silently ignores it.
+  All 6 valid rows pass vacuously. The Then-step does not verify response
+  shape, so coverage is illusory.
+- **Unblocks:** populate `daily_breakdown` per-package when the flag is True.
+  Strengthen the Then-step to verify shape differential. Then strict-flip.
+- **Severity:** P2 (feature gap, not security)
+- **Origin:** Batch 4 audit
+
+### C6 — Date-range validation returned in success envelope, not raised
+- **Scope:** `T-UC-004-daterange-invalid` and `T-UC-004-daterange-equal`
+  (currently strict=True with stale reason)
+- **Where:** `src/core/tools/media_buy_delivery.py:141-161` returns a
+  `GetMediaBuyDeliveryResponse` with `errors=[Error(code="VALIDATION_ERROR",
+  …)]` instead of raising. The BDD Then-step inspects `ctx["error"]` only.
+- **Impact:** 2 scenarios stuck in strict=True xfail; production validation
+  IS happening, just in the wrong shape.
+- **Unblocks:** either change production to raise `AdCPValidationError`,
+  OR change the Then-step to also inspect `response.errors[]`. Refresh
+  the strict=True reason text.
+- **Severity:** P3 (cosmetic — already strict)
+- **Origin:** Batch 2 audit
+
+### C7 — End-only date_range defaults to today-30d, not creation date (Gap G40)
+- **Scope:** `T-UC-004-daterange-end-only` (currently strict=False)
+- **Where:** `src/core/tools/media_buy_delivery.py:162-165` — when only
+  `end_date` provided, code sets `start_dt = now - 30d`. Spec says start
+  defaults to media buy creation date.
+- **Impact:** 1 scenario stuck non-strict.
+- **Unblocks:** when `end_date` provided alone, default `start_date` to
+  media buy creation date (look up `MediaBuy.created_at`).
+- **Severity:** P3
+- **Origin:** Batch 2 audit
+
+### C8 — MCP `list_creative_formats` wrapper missing `output_format_ids`, `input_format_ids`
+- **Scope:** `T-UC-005-inv-049-9-violated`, `-9-nofield`, `-10-violated`,
+  `-10-nofield` on the `[mcp]` transport (currently strict=False, labeled
+  "vacuous pass")
+- **Where:** `src/core/tools/creative_formats.py:440-494` — MCP wrapper
+  signature does not accept these filter params; `mcp_compat_middleware`
+  strips them
+- **Impact:** Tests pass on MCP for the wrong reason (the param disappears
+  before reaching the filter). 4 vacuous xpasses.
+- **Unblocks:** add both params to the MCP wrapper signature so MCP becomes
+  a real test surface. Then flip strict=True (the underlying filter is
+  already implemented in `_impl`).
+- **Severity:** P2
+- **Origin:** Batch 5 audit
+
+### C10 — Description-only spec constraints in adcp library
+- **Scope:** Two specific Examples rows already xfailed strict=True:
+  - `geo with geo_level=metro but no system` (`T-UC-004-boundary-reporting-dims`)
+  - `unit=campaign with interval=2` (`T-UC-004-boundary-attribution`,
+    `T-UC-004-attr-campaign-invalid`, `campaign_interval_not_one` partition row)
+- **Where:** `.venv/.../adcp/types/generated_poc/core/duration.py:27` and
+  `.venv/.../media_buy/get_media_buy_delivery_request.py:57-62` —
+  constraints exist in field descriptions only, no Pydantic validators
+- **Impact:** 3 scenarios xfailed strict=True awaiting either a model
+  validator addition OR an upstream AdCP spec PR
+- **Unblocks:** either (a) add a `model_validator(mode="after")` on
+  `Duration` and `Geo` in our extending classes, OR (b) file an upstream
+  AdCP PR adding the validators
+- **Severity:** P3 (cosmetic)
+- **Origin:** Batch 1 audit
+
+### C11 — `start_date` / `end_date` not echoed in `response.reporting_period`
+- **Scope:** `T-UC-004-daterange` ("Custom date range used as reporting
+  period" — added to strict=True genuine-xfails on 2026-05-08)
+- **Where:** `src/core/tools/media_buy_delivery.py` — when buyer supplies
+  explicit `start_date` and `end_date`, response's `reporting_period.start`
+  is computed as `now - 30d` instead of echoing the request value
+- **Impact:** Discovered during the 2026-05-08 strict-flip executor run.
+  4 transport variants of one scenario.
+- **Unblocks:** populate `reporting_period.start = req.start_date or
+  default` and `reporting_period.end = req.end_date or default` in the
+  response constructor.
+- **Severity:** P2 (visible buyer-facing bug)
+- **Origin:** discovered during executor verification, 2026-05-08
+
+---
+
+## Test rewrites (P2–P3) — no production change needed
+
+### B1 — Gherkin uses `pending_activation` which is not a valid `MediaBuyStatus`
+- **Scope:** `T-UC-004-filter` (Examples row at feature line 154);
+  `T-UC-004-partition-status-filter` rows `single_pending` and
+  `all_statuses_array`; `T-UC-004-boundary-status-filter` rows
+  `pending_activation (first enum value)` and `all 6 statuses`
+- **Where:** `tests/bdd/features/BR-UC-004-deliver-media-buy-metrics.feature`
+- **Source of truth:** AdCP library
+  `.venv/.../enums/media_buy_status.py:11-17` —
+  `{pending_creatives, pending_start, active, paused, completed, rejected,
+  canceled}`. Library/spec is authoritative; existing test/code is not.
+- **Fix:** replace `pending_activation` with `pending_creatives` (true first
+  enum value) or `pending_start` per scenario context. Update
+  `all_statuses_array` to `["pending_start", "active", "paused", "completed",
+  "rejected", "canceled"]`.
+- **Impact:** ~5 substring matches across 3 scenarios; once fixed, the
+  `T-UC-004-filter` selective entry shrinks to empty (remove entirely)
+- **Severity:** P2 (Gherkin error)
+- **Origin:** Batch 2 audit
+
+### B2 — `_dispatch_partition` for `date_range` sends fake `date_range="…"` kwarg
+- **Scope:** `T-UC-004-boundary-date-range` and
+  `T-UC-004-partition-date-range` (currently in `_UC004_BOUNDARY_TAGS` /
+  `_UC004_PARTITION_TAGS` blanket — scheduled for removal once this is
+  fixed)
+- **Where:** `tests/bdd/steps/domain/uc004_delivery.py:937-945`
+- **Fix:** translate symbolic partition labels (`start_before_end`,
+  `dates_omitted`, `start_equals_end`, `start_after_end`, etc.) to actual
+  `start_date` / `end_date` request kwargs
+- **Impact:** ~16 rows × 4 transports currently dispatch through Pydantic
+  `extra="forbid"` rejection by accident; once wired, those rows test the
+  real validation path
+- **Severity:** P2
+- **Origin:** Batch 2 audit
+
+### B3 — Resolution and ownership scenarios use symbolic names that never exercise the code path
+- **Scope:** `T-UC-004-partition-resolution`,
+  `T-UC-004-boundary-resolution`, `T-UC-004-partition-ownership`,
+  `T-UC-004-boundary-ownership` (currently in blanket strict=False)
+- **Where:** `tests/bdd/steps/domain/uc004_delivery.py:2076-2098`
+  (`_dispatch_partition`)
+- **Fix:** for resolution rows, construct concrete `media_buy_ids` /
+  `buyer_refs` request shapes per partition. For ownership rows, set
+  `ctx["principal_id"]` before dispatch (existing pattern at line 670-676).
+- **Impact:** ~37 scenarios currently pass vacuously; the `owner_mismatch`
+  variant cannot fail at all because identity is never swapped
+- **Severity:** P2 (test bug; pairs with C3 security gap to fully validate)
+- **Origin:** Batch 3 audit
+
+### B4 — `sampling_method` scenarios live on the wrong feature
+- **Scope:** `T-UC-004-boundary-sampling`, `T-UC-004-partition-sampling`
+  (currently in blanket strict=False)
+- **Where:** `tests/bdd/features/BR-UC-004-deliver-media-buy-metrics.feature`
+- **Source of truth:** AdCP library
+  `.venv/.../media_buy/get_media_buy_delivery_request.py:142-202` does NOT
+  declare `sampling_method`. The field belongs to content standards
+  (`docs/test-obligations/constraints.md:1396` `CONSTR-SAMPLING-METHOD-01`).
+- **Fix:** delete from `BR-UC-004.feature`; if needed under UC-024
+  (content standards) re-author there
+- **Impact:** ~17 scenarios become real passes/fails after relocation
+- **Severity:** P3 (cleanup)
+- **Origin:** Batch 3 audit
+
+### B5 — `webhook_credentials` scenarios dispatch through `get_media_buy_delivery`
+- **Scope:** `T-UC-004-boundary-credentials`,
+  `T-UC-004-partition-credentials` (currently in blanket strict=False;
+  tagged `@BR-RULE-029` which is the wrong rule — that's about retry/
+  backoff, not credentials)
+- **Where:** `tests/bdd/steps/domain/uc004_delivery.py:954-957`
+- **Fix:** either rewire through `CircuitBreakerEnv` and the real
+  `WebhookDeliveryService.send_delivery_webhook` (which has the 32-char
+  HMAC check at `webhook_delivery_service.py:337,463`), OR delete in favor
+  of the dedicated scenarios at feature lines 373-396 which already test
+  the rule properly with `when_validate_webhook_config`
+- **Impact:** 10 scenarios with mismatched dispatch
+- **Severity:** P3 (test mis-routing; rule already tested elsewhere)
+- **Origin:** Batch 4 audit
+
+### B6 — `disclosure_positions` filter not implemented; `all_positions` step uses non-existent enum values
+- **Scope:** `T-UC-005-partition-disclosure`, `-boundary-disclosure`,
+  `T-UC-005-inv-049-8-violated`, `-8-nofield` (currently strict=False)
+- **Where:** production filter missing in `src/core/tools/creative_formats.py`;
+  step bug in `tests/bdd/steps/generic/when_request.py:405-411`
+  (uses `corner, inline, before, after` — none in
+  `.venv/.../enums/disclosure_position.py:10-19`)
+- **Fix (production):** add `if req.disclosure_positions: …` filter to
+  `_list_creative_formats_impl`. AND-match per BR-RULE-049 INV-8
+  (all requested positions must be supported).
+- **Fix (test):** correct `all_positions` step to use the 8 real enum
+  values: `prominent, footer, audio, subtitle, overlay, end_card, pre_roll,
+  companion`
+- **Impact:** ~28 vacuous xpasses + 2 vacuous-exclusion xpasses
+- **Severity:** P2 (production feature gap)
+- **Origin:** Batch 5 audit
+
+### B7 — UC-006 account_resolution step layer fakes the `AdCPValidationError`
+- **Scope:** `T-UC-006-partition-account` (rows `missing_account`,
+  `invalid_oneOf_both`) and `T-UC-006-boundary-account` (rows
+  `account field absent`, `both account_id and brand`)
+- **Where:** `tests/bdd/steps/generic/_account_resolution.py:24-59` —
+  `validate_account_ref()` raises `AdCPValidationError` in the step layer
+  before production is reached
+- **Fix:** delete the step-layer synthesis blocks; let Pydantic's
+  required-field validation on the wrapper raise naturally, OR reclassify
+  the assertion as a step-layer pre-condition test (which would also
+  require the rows to assert on `AdCPValidationError` not `error_code ==
+  "INVALID_REQUEST"`)
+- **Impact:** 4 xpasses passing for the wrong reason. This is a
+  "fake test" — currently it tests the harness, not production.
+- **Severity:** P2 (test-quality bug — passes mask real coverage)
+- **Origin:** Batch 6 audit
+
+---
+
+## Cross-cutting test-helper weaknesses
+
+### H1 — `_assert_partition_outcome` invalid branch under-asserts
+- **Where:** `tests/bdd/steps/generic/then_payload.py:209-230`
+- **Issue:** the `invalid` branch only checks `"error" in ctx`. Any
+  exception type satisfies it, including unrelated bugs (e.g., `KeyError`
+  in step setup masquerading as "production rejected the input").
+- **Fix:** add `isinstance(error, (AdCPError, ValidationError))` guard,
+  matching UC-004's richer helper at
+  `tests/bdd/steps/domain/uc004_delivery.py:1966-1968`
+- **Severity:** P3 (latent risk; no current coverage harm)
+
+### H2 — `_assert_partition_outcome` valid branch lacks domain content checks
+- **Where:** same file
+- **Issue:** `valid` branch only asserts `"response" in ctx` and (for the
+  formats domain) `formats is not None`. A degenerate response with empty
+  `media_buy_deliveries` or empty `formats=[]` passes.
+- **Fix:** route by the captured `field` to a domain-specific assertion
+  (the regex already captures `field` but discards it). UC-004 has the
+  pattern at `_assert_valid_content`.
+- **Severity:** P3
+
+---
+
+## Reference: how to track these
+
+The expected lifecycle of an entry:
+
+1. Item filed here with a unique ID (B1, C1, C11, etc.).
+2. The corresponding `tests/bdd/conftest.py` marker has a FIXME pointing
+   at this doc and the item ID.
+3. Engineer fixes the gap (production change, test rewrite, or both).
+4. They flip the marker to `strict=True` (or remove if no rows remain
+   xfail), removing the FIXME.
+5. They delete the entry from this doc.
+
+Step 4 forces step 5 because once `strict=True` is set, further drift on
+that scenario causes a hard suite failure rather than silent xpass.
+
+---
+
+## Tally
+
+- **Production gaps:** 10 (C1–C11, with C9 retired by 2026-05-08 cleanup)
+- **Test rewrites:** 7 (B1–B7)
+- **Test-helper improvements:** 2 (H1, H2)
+- **Total:** ~19 items
+
+Severity distribution: 3× P1 (security/correctness), 7× P2, 9× P3.
+
+If filed as one umbrella GH issue with a checklist, this fits comfortably
+in a single tracking issue. If filed individually, only the 3 P1s warrant
+separate issues; the rest can stay in this doc as the canonical reference.

--- a/scripts/deploy/run_all_services.py
+++ b/scripts/deploy/run_all_services.py
@@ -202,21 +202,22 @@ signal.signal(signal.SIGTERM, cleanup)
 def run_migrations():
     """Run database migrations before starting services."""
     print("📦 Running database migrations...")
+    # Stream output live so a hang shows which migration is in flight (we have
+    # 170 migrations; cold-DB runs blow past short timeouts and capture_output
+    # makes them invisible to the operator).
+    timeout_seconds = 300
     try:
         result = subprocess.run(
             [sys.executable, "scripts/ops/migrate.py"],
-            capture_output=True,
-            text=True,
-            timeout=60,
+            timeout=timeout_seconds,
         )
         if result.returncode == 0:
             print("✅ Migrations complete")
         else:
-            print(f"❌ Migration failed: {result.stderr}")
-            print(result.stdout)
+            print(f"❌ Migration failed (exit code {result.returncode})")
             sys.exit(1)
     except subprocess.TimeoutExpired:
-        print("❌ Migration timed out after 60 seconds")
+        print(f"❌ Migration timed out after {timeout_seconds} seconds")
         sys.exit(1)
     except Exception as e:
         print(f"❌ Migration error: {e}")

--- a/scripts/test-stack.sh
+++ b/scripts/test-stack.sh
@@ -48,7 +48,11 @@ cmd_up() {
     dc up -d || { dc logs; exit 1; }
 
     echo "Waiting for services..."
-    local deadline=$(($(date +%s) + 120))
+    # Cold boot budget: ~10s container start + ~30s migrations (170 of them) +
+    # ~2min FastAPI/Admin/MCP/A2A/scheduler init. 120s was too tight on cold
+    # Docker image cache. 360s gives margin without making genuine hangs slow
+    # to surface.
+    local deadline=$(($(date +%s) + 360))
     local pg=false srv=false
     while [ $(date +%s) -lt $deadline ]; do
         [ "$pg" = false ] && dc exec -T postgres pg_isready -U adcp_user >/dev/null 2>&1 && pg=true && echo -e "${GREEN}PostgreSQL ready${NC}"

--- a/src/core/tools/accounts.py
+++ b/src/core/tools/accounts.py
@@ -322,18 +322,26 @@ def _build_sync_result(
     operator: str,
     action: str,
     status: str,
+    account_id: str | None = None,
     name: str | None = None,
     billing: str | None = None,
     sandbox: bool | None = None,
     errors: list[Any] | None = None,
     setup: Any | None = None,
 ) -> SyncResponseAccount:
-    """Build an AdCP sync response Account object."""
+    """Build an AdCP sync response Account object.
+
+    The seller-assigned ``account_id`` MUST be echoed back for any non-failure
+    action (created/updated/unchanged) so the buyer can reference the account
+    in subsequent calls (BR-UC-011 POST-S5). Only ``failed`` results legitimately
+    omit it because no account was provisioned.
+    """
     return SyncResponseAccount(
         brand=brand,
         operator=operator,
         action=action,
         status=status,
+        account_id=account_id,
         name=name,
         billing=billing,
         sandbox=sandbox,
@@ -535,6 +543,7 @@ async def _sync_accounts_impl(
                             operator=operator,
                             action=action,
                             status=existing.status,
+                            account_id=existing.account_id,
                             name=existing.name,
                             billing=existing.billing,
                             sandbox=existing.sandbox,
@@ -556,6 +565,7 @@ async def _sync_accounts_impl(
                         operator=operator,
                         action=action,
                         status=existing.status,
+                        account_id=existing.account_id,
                         name=existing.name,
                         billing=existing.billing,
                         sandbox=existing.sandbox,
@@ -581,12 +591,16 @@ async def _sync_accounts_impl(
                 initial_status = "pending_approval" if setup else "active"
 
                 if dry_run:
+                    # account_id was generated above (BR-RULE-062 — preview reflects
+                    # what a real create would return). It is a preview value, not a
+                    # commitment to that specific id.
                     results.append(
                         _build_sync_result(
                             brand=entry.brand,
                             operator=operator,
                             action="created",
                             status=initial_status,
+                            account_id=account_id,
                             name=account_name,
                             billing=billing_val,
                             sandbox=sandbox,
@@ -620,6 +634,7 @@ async def _sync_accounts_impl(
                         operator=operator,
                         action="created",
                         status=initial_status,
+                        account_id=account_id,
                         name=account_name,
                         billing=billing_val,
                         sandbox=sandbox,
@@ -639,6 +654,7 @@ async def _sync_accounts_impl(
                             operator=db_acct.operator or "",
                             action="updated",
                             status="closed",
+                            account_id=db_acct.account_id,
                             name=db_acct.name,
                             billing=db_acct.billing,
                             sandbox=db_acct.sandbox,

--- a/tests/admin/test_authorized_properties.py
+++ b/tests/admin/test_authorized_properties.py
@@ -70,15 +70,27 @@ def _auth_session(client, tenant_id):
         sess["test_tenant_id"] = tenant_id
 
 
+_TEMPLATE_GAP_REASON = (
+    "Production gap: authorized_properties_list.html template does not exist, so "
+    "src/admin/blueprints/authorized_properties.py:list_authorized_properties raises "
+    "TemplateNotFound, which is swallowed by the route's broad except clause "
+    "(authorized_properties.py:327-330) and 302-redirects to the tenant dashboard. "
+    "See follow-up: feat: implement authorized_properties_list page (server-side rendering). "
+    "Will xpass once the template lands."
+)
+
+
 class TestAuthorizedPropertiesListPage:
     """Test the authorized properties list page."""
 
+    @pytest.mark.xfail(strict=True, reason=_TEMPLATE_GAP_REASON)
     def test_list_page_returns_200(self, client, test_tenant):
         """GET /tenant/<tid>/authorized-properties returns 200."""
         _auth_session(client, test_tenant)
         response = client.get(f"/tenant/{test_tenant}/authorized-properties")
         assert response.status_code == 200
 
+    @pytest.mark.xfail(strict=True, reason=_TEMPLATE_GAP_REASON)
     def test_list_page_shows_existing_property(self, client, test_tenant):
         """After creating a property, the list page shows it."""
         _auth_session(client, test_tenant)

--- a/tests/admin/test_authorized_properties.py
+++ b/tests/admin/test_authorized_properties.py
@@ -132,6 +132,8 @@ class TestPropertyCreate:
                 "property_type": "website",
                 "name": "Created Test Site",
                 "publisher_domain": "created-test.example.com",
+                "identifier_type_0": "domain",
+                "identifier_value_0": "created-test.example.com",
             },
             follow_redirects=False,
         )

--- a/tests/admin/test_creatives_blueprint.py
+++ b/tests/admin/test_creatives_blueprint.py
@@ -62,7 +62,7 @@ def test_tenant(integration_db):
             tenant_id=_TENANT_ID,
             principal_id=_PRINCIPAL_ID,
             name="Creative Test Principal",
-            platform_mappings={"mock": {}},
+            platform_mappings={"mock": {"advertiser_id": "test_advertiser"}},
             access_token=f"creative-test-token-{uuid.uuid4().hex}",
         )
         session.add(principal)

--- a/tests/admin/test_inventory_profiles.py
+++ b/tests/admin/test_inventory_profiles.py
@@ -105,13 +105,21 @@ class TestInventoryProfileList:
         assert response.status_code == 200
 
     def test_list_shows_profile_names(self, client, test_tenant):
-        """List page includes names of existing profiles."""
+        """JSON API list endpoint includes names of existing profiles.
+
+        The /tenant/<tid>/inventory-profiles/ HTML page is client-side rendered
+        via JavaScript that fetches /api/list, so profile names never appear in
+        the server-rendered HTML. This test verifies the JSON API contract that
+        backs the page, not the rendered markup.
+        """
         _auth_session(client, test_tenant)
         _create_sample_profile(test_tenant, name="Visible Profile", profile_id="visible_profile")
 
-        response = client.get(f"/tenant/{test_tenant}/inventory-profiles/")
-        html = response.data.decode()
-        assert "Visible Profile" in html
+        response = client.get(f"/tenant/{test_tenant}/inventory-profiles/api/list")
+        assert response.status_code == 200
+        payload = response.get_json()
+        names = [p["name"] for p in payload["profiles"]]
+        assert "Visible Profile" in names
 
 
 class TestInventoryProfileCreate:

--- a/tests/admin/test_inventory_profiles.py
+++ b/tests/admin/test_inventory_profiles.py
@@ -217,9 +217,9 @@ class TestInventoryProfileDelete:
         assert profile is None
 
     def test_delete_nonexistent_profile_returns_404(self, client, test_tenant):
-        """POST delete for a nonexistent profile returns 404."""
+        """DELETE for a nonexistent profile returns 404."""
         _auth_session(client, test_tenant)
-        response = client.post(
+        response = client.delete(
             f"/tenant/{test_tenant}/inventory-profiles/999999/delete",
             follow_redirects=False,
         )

--- a/tests/admin/test_workflows_blueprint.py
+++ b/tests/admin/test_workflows_blueprint.py
@@ -62,7 +62,7 @@ def test_tenant(integration_db):
             tenant_id=_TENANT_ID,
             principal_id="wf_test_principal",
             name="Workflow Test Principal",
-            platform_mappings={"mock": {}},
+            platform_mappings={"mock": {"advertiser_id": "test_advertiser"}},
             access_token=f"wf-test-token-{uuid.uuid4().hex}",
         )
         session.add(principal)

--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -157,11 +157,6 @@ _SELECTIVE_XFAIL: list[tuple[str, set[str], str]] = [
         {"single position", "all 8 positions", "format has no"},
         "disclosure_positions filter not implemented",
     ),
-    (
-        "T-UC-005-boundary-asset-types",
-        {"brief", "catalog"},
-        "brief/catalog asset types not in adcp enum",
-    ),
 ]
 
 
@@ -278,7 +273,6 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
         _UC005_PARTIAL_TAGS = {
             "T-UC-005-partition-disclosure",
             "T-UC-005-boundary-disclosure",
-            "T-UC-005-boundary-asset-types",
             "T-UC-005-inv-049-8-violated",
             "T-UC-005-inv-049-8-nofield",
         }
@@ -440,21 +434,6 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
                 {"pending_activation", "rejected", "canceled", "paused", "completed"},
                 "status_filter for non-active statuses not mapped in _impl",
             ),
-            (
-                "T-UC-004-filter-default",
-                set(),  # all examples
-                "default status_filter=active not applied when no explicit IDs",
-            ),
-            (
-                "T-UC-004-filter-empty",
-                set(),
-                "status_filter empty result not returned as empty array",
-            ),
-            (
-                "T-UC-004-filter-array",
-                set(),
-                "status_filter with array not correctly applied",
-            ),
         ]
         if any(t.startswith("T-UC-004-filter") for t in marker_names):
             for tag, substrings, reason in _UC004_FILTER_SELECTIVE:
@@ -465,8 +444,6 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
 
         # UC-004 date range: custom dates partially work
         _UC004_DATE_SELECTIVE: list[tuple[str, set[str], str]] = [
-            ("T-UC-004-daterange", set(), "custom date range partially applied"),
-            ("T-UC-004-daterange-start-only", set(), "start-only date range partially applied"),
             ("T-UC-004-daterange-end-only", set(), "end-only date range not applied"),
         ]
         if any(t.startswith("T-UC-004-daterange") for t in marker_names):
@@ -476,12 +453,51 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
                         item.add_marker(pytest.mark.xfail(reason=reason, strict=False))
                     break
 
+        # Per-row strict xfails for the partition/boundary scenarios whose
+        # blanket markers were removed. Each entry corresponds to a row in
+        # the Examples table that genuinely xfails because of a real
+        # production gap. strict=True ensures we are forced to remove the
+        # marker the moment the gap is closed (e.g., when ValidationError
+        # gets translated into AdCPError(INVALID_REQUEST) at the transport
+        # boundary, the partition tests will start xpassing → fail-strict
+        # → marker removal). Tracked centrally in
+        # docs/test-debt-bdd-strict-markers.md.
+        _UC004_GENUINE_XFAIL_ROWS: list[tuple[str, set[str], str]] = [
+            (
+                "T-UC-004-partition-reporting-dims",
+                {"geo_missing_geo_level", "geo_metro_missing_system", "limit_zero", "limit_negative"},
+                "Pydantic raises ValidationError, not AdCPError(INVALID_REQUEST, suggestion). See docs/test-debt-bdd-strict-markers.md item C4.",
+            ),
+            (
+                "T-UC-004-partition-attribution",
+                {"interval_zero", "interval_negative", "invalid_unit", "invalid_model", "campaign_interval_not_one"},
+                "Pydantic raises ValidationError, not AdCPError(INVALID_REQUEST, suggestion). See docs/test-debt-bdd-strict-markers.md item C4.",
+            ),
+            (
+                "T-UC-004-boundary-reporting-dims",
+                {"geo with geo_level=metro but no system"},
+                "AdCP spec defines metro/postal_area system requirement only in field description; no validator. See docs/test-debt-bdd-strict-markers.md item C10.",
+            ),
+            (
+                "T-UC-004-boundary-attribution",
+                {"unit=campaign with interval=2"},
+                "AdCP Duration spec defines 'interval=1 when unit=campaign' only in description; no validator. Same gap as T-UC-004-attr-campaign-invalid. See docs/test-debt-bdd-strict-markers.md item C10.",
+            ),
+            (
+                "T-UC-004-daterange",
+                set(),  # all examples
+                "Production ignores buyer-supplied start_date in response.reporting_period.start (returns today-30d). See docs/test-debt-bdd-strict-markers.md item C11.",
+            ),
+        ]
+        for tag, substrings, reason in _UC004_GENUINE_XFAIL_ROWS:
+            if tag in marker_names and (not substrings or any(s in nodeid for s in substrings)):
+                item.add_marker(pytest.mark.xfail(reason=reason, strict=True))
+                break
+
         # UC-004 boundary scenarios: strict=False because some examples pass.
         # Invalid boundary values SHOULD fail validation but production doesn't validate.
         # Valid boundary values pass through fine.
         _UC004_BOUNDARY_TAGS = {
-            "T-UC-004-boundary-reporting-dims",
-            "T-UC-004-boundary-attribution",
             "T-UC-004-boundary-daily-breakdown",
             "T-UC-004-boundary-account",
             "T-UC-004-boundary-sampling",
@@ -498,8 +514,6 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
         # Partition tests exercise valid/invalid value ranges per field.
         # strict=False: some partition values pass, others fail depending on schema version.
         _UC004_PARTITION_TAGS = {
-            "T-UC-004-partition-reporting-dims",
-            "T-UC-004-partition-attribution",
             "T-UC-004-partition-daily-breakdown",
             "T-UC-004-partition-account",
             "T-UC-004-partition-sampling",

--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -400,6 +400,39 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
                 item.add_marker(pytest.mark.xfail(reason=reason, strict=strict))
                 break
 
+        # UC-004 reporting_dimensions breakdowns (by_geo, by_device_type, by_audience):
+        # PackageDelivery model only declares by_placement. The optional fields
+        # by_geo, by_device_type, by_audience and their *_truncated siblings are not
+        # on the model, and media_buy_delivery._impl only branches on req.reporting_dimensions.placement.
+        # Tracked by salesagent-zk1: feat: implement reporting_dimensions breakdowns
+        # (geo, device_type, audience) per BR-RULE-091.
+        _UC004_DIM_XFAIL_TAGS: dict[str, tuple[str, bool]] = {
+            "T-UC-004-dim-supported": (
+                "by_device_type breakdown not implemented — see salesagent-zk1: "
+                "feat: implement reporting_dimensions breakdowns (geo, device_type, audience) per BR-RULE-091",
+                True,
+            ),
+            "T-UC-004-dim-truncated": (
+                "by_geo breakdown + truncation flag not implemented — see salesagent-zk1: "
+                "feat: implement reporting_dimensions breakdowns (geo, device_type, audience) per BR-RULE-091",
+                True,
+            ),
+            "T-UC-004-dim-complete": (
+                "by_device_type breakdown + truncation flag not implemented — see salesagent-zk1: "
+                "feat: implement reporting_dimensions breakdowns (geo, device_type, audience) per BR-RULE-091",
+                True,
+            ),
+            "T-UC-004-dim-multi": (
+                "by_geo and by_device_type breakdowns not implemented — see salesagent-zk1: "
+                "feat: implement reporting_dimensions breakdowns (geo, device_type, audience) per BR-RULE-091",
+                True,
+            ),
+        }
+        for tag, (reason, strict) in _UC004_DIM_XFAIL_TAGS.items():
+            if tag in marker_names:
+                item.add_marker(pytest.mark.xfail(reason=reason, strict=strict))
+                break
+
         # UC-004 status filter: "active" works, other values may not
         _UC004_FILTER_SELECTIVE: list[tuple[str, set[str], str]] = [
             (

--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -649,9 +649,22 @@ def _detect_uc011_harness(marker_names: set[str]) -> str:
 
 
 def _detect_delivery_harness(request: pytest.FixtureRequest) -> str:
-    """Detect which delivery harness a UC-004 scenario needs."""
+    """Detect which delivery harness a UC-004 scenario needs.
+
+    The ``circuit-breaker`` env wraps :class:`WebhookDeliveryService`, the
+    real production code path, which emits ``X-ADCP-Signature`` /
+    ``Authorization: Bearer`` headers and implements proper retry/backoff
+    timing. Scenarios that exercise webhook authentication or retry/backoff
+    MUST go through this env — ``WebhookEnv`` routes through the legacy
+    ``deliver_webhook_with_retry`` function which emits the wrong header
+    name (``X-Webhook-Signature``) and has different retry timing.
+    """
     marker_names = {m.name for m in request.node.iter_markers()}
     if "webhook-reliability" in marker_names:
+        return "circuit-breaker"
+    # Auth-scheme scenarios (HMAC, Bearer) verify production-emitted headers
+    # and must use the real WebhookDeliveryService path, not WebhookEnv.
+    if "T-UC-004-webhook-hmac" in marker_names or "T-UC-004-webhook-bearer" in marker_names:
         return "circuit-breaker"
     if "webhook" in marker_names:
         return "webhook"

--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -729,12 +729,14 @@ def _harness_env(request: pytest.FixtureRequest, ctx: dict) -> Generator[None, N
                 ctx[f"db_principal_{env._principal_id}"] = principal
                 yield
         elif harness_type == "webhook":
+            request.getfixturevalue("integration_db")
             from tests.harness.delivery_webhook import WebhookEnv
 
             with WebhookEnv() as env:
                 ctx["env"] = env
                 yield
         elif harness_type == "circuit-breaker":
+            request.getfixturevalue("integration_db")
             from tests.harness.delivery_circuit_breaker import CircuitBreakerEnv
 
             with CircuitBreakerEnv() as env:

--- a/tests/bdd/steps/domain/uc004_delivery.py
+++ b/tests/bdd/steps/domain/uc004_delivery.py
@@ -54,6 +54,15 @@ def _get_last_webhook_headers(ctx: dict) -> dict[str, str]:
     return call_kwargs.get("headers", {})
 
 
+def _resolve_media_buy_id(ctx: dict, mb_id: str) -> str:
+    """Resolve a Gherkin media-buy alias (e.g., 'mb-001') to its DB id.
+
+    Currently identity since _ensure_media_buy_in_db stores the alias as-is.
+    Indirection retained for future tests that may need separate aliasing.
+    """
+    return ctx.get("media_buy_id_aliases", {}).get(mb_id, mb_id)
+
+
 # ═══════════════════════════════════════════════════════════════════════
 # GIVEN steps — media buy setup and adapter configuration
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/bdd/steps/domain/uc004_delivery.py
+++ b/tests/bdd/steps/domain/uc004_delivery.py
@@ -241,11 +241,42 @@ def _set_active_webhook(ctx: dict, mb_id: str) -> None:
     }
     env = ctx["env"]
     if getattr(env, "_session", None) is not None:
-        _persist_webhook_config_if_needed(env)
+        _persist_webhook_config_if_needed(ctx, env)
 
 
-def _persist_webhook_config_if_needed(env: Any) -> None:
-    """Idempotently create Tenant, Principal, PushNotificationConfig in DB."""
+def _auth_scheme_to_db_fields(scheme: str | None, ctx: dict) -> dict[str, Any]:
+    """Translate a Gherkin auth scheme to the PushNotificationConfig DB columns.
+
+    The ORM model exposes ``authentication_type`` (``"bearer"`` / ``"basic"`` /
+    ``None``) plus a separate ``webhook_secret`` column for HMAC. Each scheme
+    populates a different combination.
+    """
+    fields: dict[str, Any] = {}
+    if scheme is None:
+        return fields
+    normalized = scheme.lower()
+    if normalized in {"hmac-sha256", "hmac_sha256", "hmac"}:
+        secret = ctx.get("webhook_secret")
+        if secret:
+            fields["webhook_secret"] = secret
+    elif normalized == "bearer":
+        token = ctx.get("webhook_bearer_token")
+        if token:
+            fields["authentication_type"] = "bearer"
+            fields["authentication_token"] = token
+    return fields
+
+
+def _persist_webhook_config_if_needed(ctx: dict, env: Any) -> None:
+    """Idempotently create or update the PushNotificationConfig DB row.
+
+    Reads ``ctx['webhook_config']`` and ``ctx['webhook_secret']`` /
+    ``ctx['webhook_bearer_token']`` so subsequent Given-steps that set the
+    secret/token can re-run persistence and pick up the new values.
+    Sister-task ``salesagent-oy9`` ensured the
+    ``push_notification_configs`` table exists per-test, so this is safe to
+    call from any Given step.
+    """
     from sqlalchemy import select
 
     from src.core.database.models import Principal, PushNotificationConfig, Tenant
@@ -254,14 +285,33 @@ def _persist_webhook_config_if_needed(env: Any) -> None:
     tenant_id = env._tenant_id
     principal_id = env._principal_id
 
-    # Fast path: config already exists
-    if session.scalars(
+    # Derive the auth columns from the most recently configured scheme. Multiple
+    # mb_ids share a single PushNotificationConfig row keyed on the env's
+    # tenant+principal+url, so we pick the latest scheme set on any mb_id.
+    scheme: str | None = None
+    for cfg in ctx.get("webhook_config", {}).values():
+        cfg_scheme = cfg.get("auth_scheme")
+        if cfg_scheme:
+            scheme = cfg_scheme  # last one wins
+    auth_fields = _auth_scheme_to_db_fields(scheme, ctx)
+
+    existing = session.scalars(
         select(PushNotificationConfig).where(
             PushNotificationConfig.tenant_id == tenant_id,
             PushNotificationConfig.principal_id == principal_id,
             PushNotificationConfig.url == _WEBHOOK_URL,
         )
-    ).first():
+    ).first()
+    if existing is not None:
+        # Update auth fields if new ones are present (e.g., a later Given-step
+        # added webhook_secret/authentication_token after the row was created).
+        changed = False
+        for col, value in auth_fields.items():
+            if getattr(existing, col, None) != value:
+                setattr(existing, col, value)
+                changed = True
+        if changed:
+            session.commit()
         return
 
     from tests.factories import PrincipalFactory, PushNotificationConfigFactory, TenantFactory
@@ -279,6 +329,7 @@ def _persist_webhook_config_if_needed(env: Any) -> None:
         principal=principal,
         url=_WEBHOOK_URL,
         is_active=True,
+        **auth_fields,
     )
 
 
@@ -316,23 +367,42 @@ def given_reporting_frequency(ctx: dict, frequency: str) -> None:
 
 @given(parsers.parse('a media buy "{mb_id}" with webhook authentication scheme "{scheme}"'))
 def given_webhook_auth_scheme(ctx: dict, mb_id: str, scheme: str) -> None:
-    """Configure webhook with specific auth scheme."""
+    """Configure webhook with specific auth scheme.
+
+    Also creates the ``PushNotificationConfig`` DB row so a subsequent
+    ``given_shared_secret_valid`` / ``given_bearer_token_valid`` step can
+    update the same row in-place with the auth credentials.
+    """
     wh = ctx.setdefault("webhook_config", {}).setdefault(mb_id, {})
     wh["auth_scheme"] = scheme
     wh["active"] = True
-    wh["url"] = "https://buyer.example.com/webhook"
+    wh["url"] = _WEBHOOK_URL
+    env = ctx["env"]
+    if getattr(env, "_session", None) is not None:
+        _persist_webhook_config_if_needed(ctx, env)
 
 
 @given("the shared secret is a valid 32+ character string")
 def given_shared_secret_valid(ctx: dict) -> None:
     """A valid shared secret for HMAC."""
-    ctx["webhook_secret"] = "a" * 32
+    secret = "a" * 32
+    ctx["webhook_secret"] = secret
+    # ``then_hmac_computation`` reproduces the signature from
+    # ``ctx['signing_secret']`` (the production code uses the same value to
+    # generate the header). Mirror it here so both keys stay in lockstep.
+    ctx["signing_secret"] = secret
+    env = ctx["env"]
+    if getattr(env, "_session", None) is not None:
+        _persist_webhook_config_if_needed(ctx, env)
 
 
 @given("the bearer token is a valid 32+ character string")
 def given_bearer_token_valid(ctx: dict) -> None:
     """A valid bearer token."""
     ctx["webhook_bearer_token"] = "b" * 32
+    env = ctx["env"]
+    if getattr(env, "_session", None) is not None:
+        _persist_webhook_config_if_needed(ctx, env)
 
 
 @given(parsers.parse("a media buy webhook configuration with credentials of {n:d} characters"))
@@ -353,9 +423,18 @@ def given_webhook_returns_status(ctx: dict, status_code: int, reason: str) -> No
 
 @given("the webhook endpoint is unreachable (connection timeout)")
 def given_webhook_unreachable(ctx: dict) -> None:
-    """Configure webhook endpoint to timeout."""
+    """Configure webhook endpoint to timeout.
+
+    Uses ``httpx.ConnectError`` (a subclass of ``httpx.RequestError``) so
+    :class:`WebhookDeliveryService`, which catches ``httpx.RequestError`` and
+    retries with backoff, exercises the network-error retry path. Plain
+    builtin ``ConnectionError`` would fall through to the catch-all
+    ``except Exception`` branch and skip retries.
+    """
+    import httpx
+
     env = ctx["env"]
-    env.mock["post"].side_effect = ConnectionError("Connection timeout")
+    env.mock["post"].side_effect = httpx.ConnectError("Connection timeout")
 
 
 @given(parsers.parse("the webhook endpoint returns {status_code:d} Unauthorized"))

--- a/tests/bdd/steps/domain/uc011_accounts.py
+++ b/tests/bdd/steps/domain/uc011_accounts.py
@@ -463,8 +463,10 @@ def then_accounts_have_fields(ctx: dict) -> None:
 
     account_id, name, status: always required — must be non-None.
     advertiser, rate_card, payment_terms: optional fields — verify the
-    serialized output exposes them (via model_dump()), allowing callers to read
-    the field even when the value is None.
+    schema exposes them (via model_fields), allowing callers to read the
+    field even when the value is None. We use schema introspection rather
+    than model_dump() because AdCPBaseModel.model_dump() defaults to
+    exclude_none=True, which strips optional fields with None values.
     """
     resp = ctx["response"]
     for i, acct in enumerate(resp.accounts):
@@ -472,11 +474,10 @@ def then_accounts_have_fields(ctx: dict) -> None:
         assert acct.account_id is not None, f"Account {i} missing account_id"
         assert acct.name is not None, f"Account {i} missing name"
         assert acct.status is not None, f"Account {i} missing status"
-        # Optional fields — schema must expose them in serialized output
-        dumped = acct.model_dump()
-        assert "advertiser" in dumped, f"Account {i} serialized output missing 'advertiser' field"
-        assert "rate_card" in dumped, f"Account {i} serialized output missing 'rate_card' field"
-        assert "payment_terms" in dumped, f"Account {i} serialized output missing 'payment_terms' field"
+        # Optional fields — schema must expose them
+        fields = type(acct).model_fields
+        for field_name in ("advertiser", "rate_card", "payment_terms"):
+            assert field_name in fields, f"Account {i} schema missing optional field '{field_name}'"
 
 
 @then("the accounts are only those accessible to the authenticated agent")

--- a/tests/harness/_mixins.py
+++ b/tests/harness/_mixins.py
@@ -330,6 +330,50 @@ class CircuitBreakerMixin:
             **extra,
         )
 
+    def call_deliver(
+        self,
+        media_buy_id: str = "mb_001",
+        notification_type: str | None = None,
+        **kwargs: Any,
+    ) -> tuple[bool, dict[str, Any]]:
+        """Deliver via the production WebhookDeliveryService.
+
+        BDD scenarios that exercise webhook authentication (HMAC, bearer) and
+        retry/backoff timing must use the real production code path —
+        ``WebhookDeliveryService.send_delivery_webhook`` — because
+        ``deliver_webhook_with_retry`` (the legacy path used by
+        :class:`tests.harness.delivery_webhook.WebhookEnv`) emits a different
+        signature header name and has different retry timing.
+
+        ``notification_type`` is translated to the production flags:
+
+        * ``"final"``    -> ``is_final=True``
+        * ``"adjusted"`` -> ``is_adjusted=True``
+        * any other value (``None``, ``"scheduled"``, ``"delayed"``) leaves
+          both flags False, which yields a ``"scheduled"`` payload from
+          production. ``"delayed"`` is a spec-defined value that production
+          does not yet emit; tests that assert on it document a production
+          gap rather than a harness gap.
+
+        Returns ``(success, info_dict)`` to keep the call shape compatible
+        with :meth:`WebhookMixin.call_deliver`.
+        """
+        is_final = notification_type == "final"
+        is_adjusted = notification_type == "adjusted"
+        # Set a non-zero interval so production includes ``next_expected_at``
+        # in the payload for non-final notifications. The exact value does not
+        # matter — assertions check presence, not the value.
+        next_expected_interval_seconds = None if is_final else 86400.0
+
+        success = self.call_send(
+            media_buy_id=media_buy_id,
+            is_final=is_final,
+            is_adjusted=is_adjusted,
+            next_expected_interval_seconds=next_expected_interval_seconds,
+            **kwargs,
+        )
+        return success, {"success": success}
+
     def call_impl(self, **kwargs: Any) -> bool:
         """Alias for call_send to satisfy BaseTestEnv interface."""
         return self.call_send(**kwargs)

--- a/tests/unit/test_accounts_policy_helpers.py
+++ b/tests/unit/test_accounts_policy_helpers.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 
 from src.core.tenant_context import TenantContext
-from src.core.tools.accounts import _build_setup_for_approval, _check_billing_policy
+from src.core.tools.accounts import _build_setup_for_approval, _build_sync_result, _check_billing_policy
 from tests.factories import PrincipalFactory
 
 
@@ -123,3 +123,57 @@ class TestBuildSetupForApproval:
 
     def test_empty_string_mode_returns_none(self):
         assert _build_setup_for_approval("", "tenant_a") is None
+
+
+class TestBuildSyncResult:
+    """BR-UC-011 POST-S5: seller-assigned account_id round-trips through sync responses.
+
+    Regression guard for salesagent-8c5: _build_sync_result previously dropped
+    account_id, leaving buyers without the seller-assigned identifier they need
+    for subsequent account-scoped operations.
+    """
+
+    def _brand(self):
+        # Minimal brand object; SyncResponseAccount accepts the AdCP brand shape.
+        return {"domain": "example.com"}
+
+    def test_account_id_round_trips_for_created(self):
+        result = _build_sync_result(
+            brand=self._brand(),
+            operator="op_1",
+            action="created",
+            status="active",
+            account_id="acct_123",
+            name="Example",
+        )
+        assert result.account_id == "acct_123"
+
+    def test_account_id_round_trips_for_updated(self):
+        result = _build_sync_result(
+            brand=self._brand(),
+            operator="op_1",
+            action="updated",
+            status="active",
+            account_id="acct_456",
+        )
+        assert result.account_id == "acct_456"
+
+    def test_account_id_round_trips_for_unchanged(self):
+        result = _build_sync_result(
+            brand=self._brand(),
+            operator="op_1",
+            action="unchanged",
+            status="active",
+            account_id="acct_789",
+        )
+        assert result.account_id == "acct_789"
+
+    def test_account_id_omitted_for_failed(self):
+        """Failed accounts have no provisioned id — account_id stays None."""
+        result = _build_sync_result(
+            brand=self._brand(),
+            operator="op_1",
+            action="failed",
+            status="rejected",
+        )
+        assert result.account_id is None


### PR DESCRIPTION
## Summary
- Clear ~244 stale BDD xfail markers and tighten 4 blanket scopes (`ec9ec326`)
- 13 targeted test fixes (admin blueprint tests, BDD step helpers, fixture hygiene, schema/model_dump conflations)
- 3 infra fixes: test-stack readiness 120s→360s, migration timeout 300s + streaming, UC-004 webhook scenarios via CircuitBreakerEnv
- 1 prod fix: `_build_sync_result` must populate `account_id` (`8a23c98e`)
- Notes on remaining BDD strict-marker work in `.claude/notes/` and `docs/test-debt-bdd-strict-markers.md` (has to be detailed in GH issues and fixed)

## Test plan
- [ ] `make quality` passes
- [ ] `./run_all_tests.sh` passes (last green: 070526_2244)
- [ ] BDD suite collects without errors after marker cleanup