### PR TITLE
revert(scripts): undo run_all_tests.sh changes from #1264 (silent-output regression)

### DIFF
--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -47,12 +47,6 @@ collect_reports() {
     for name in unit integration e2e admin bdd ui; do
         [ -f ".tox/${name}.json" ] && cp ".tox/${name}.json" "$RESULTS_DIR/"
     done
-    # Explicit return 0 — without this, the function inherits the exit
-    # code of the last ``[ -f X ] && cp X Y`` test, which is 1 when the
-    # final file (ui.json) is missing in quick mode. Under ``set -e``
-    # that propagates to the caller and the script exits before reaching
-    # the security audit + summary block.
-    return 0
 }
 
 # --- Quick mode (no Docker) ---
@@ -60,17 +54,13 @@ if [ "$MODE" = "quick" ]; then
     validate_imports
     echo -e "${BLUE}Running unit + integration via tox...${NC}"
     set +e
-    # Write to file then cat — avoids two known issues:
-    # - ``| tee X`` hangs after tox exits because of a tox-uv fd leak
-    # - ``> >(tee X) 2>&1`` returns a stale process-substitution exit code
-    #   that makes the script appear to fail under ``set -eo pipefail``
-    #   even when tox itself returned 0.
-    tox -e unit,integration -p > "$RESULTS_DIR/tox.log" 2>&1
+    # Redirect to file + stdout via process substitution to avoid tox-uv fd leak
+    # that causes pipes (| tee) to hang after tox exits.
+    tox -e unit,integration -p > >(tee "$RESULTS_DIR/tox.log") 2>&1
     TOX_RC=$?
     set -e
-    cat "$RESULTS_DIR/tox.log"
     collect_reports
-    if [ "$TOX_RC" -ne 0 ]; then FAILURES="tox"; fi
+    [ "$TOX_RC" -ne 0 ] && FAILURES="tox"
 
 # --- CI mode (Docker + all suites) ---
 elif [ "$MODE" = "ci" ]; then
@@ -91,20 +81,18 @@ elif [ "$MODE" = "ci" ]; then
         uv run pytest "$PYTEST_TARGET" \
             -m "not requires_server and not skip_ci" \
             --json-report --json-report-file="$RESULTS_DIR/targeted.json" --json-report-indent=2 \
-            -q --tb=line $PYTEST_ARGS > "$RESULTS_DIR/targeted.log" 2>&1
+            -q --tb=line $PYTEST_ARGS > >(tee "$RESULTS_DIR/targeted.log") 2>&1
         TOX_RC=$?
         set -e
-        cat "$RESULTS_DIR/targeted.log"
-        if [ "$TOX_RC" -ne 0 ]; then FAILURES="targeted"; fi
+        [ "$TOX_RC" -ne 0 ] && FAILURES="targeted"
     else
         echo -e "${BLUE}Running all 6 suites in parallel via tox...${NC}"
         set +e
-        tox -p -o > "$RESULTS_DIR/tox.log" 2>&1
+        tox -p -o > >(tee "$RESULTS_DIR/tox.log") 2>&1
         TOX_RC=$?
         set -e
-        cat "$RESULTS_DIR/tox.log"
         collect_reports
-        if [ "$TOX_RC" -ne 0 ]; then FAILURES="tox"; fi
+        [ "$TOX_RC" -ne 0 ] && FAILURES="tox"
 
         # Coverage combine runs separately — tox -p hangs when the coverage
         # env fails (e.g. missing .coverage.e2e from HTTP-only e2e tests).


### PR DESCRIPTION
## Summary

Reverts ONLY the `run_all_tests.sh` portion of #1264. The four memory fixes (lifespan webhook close, `_pending_webhook_tasks` pinning, dead-thread reapers) remain in place — this revert is scoped to the chore-level shell change.

## Why

#1264 replaced `tee` + process-substitution with write-to-file + `cat`-at-end across all three execution paths (quick, ci-targeted, ci-full). That fixed two real bugs (process-substitution exit code under `set -eo pipefail`; `collect_reports` return-code propagation) but introduced two worse regressions:

1. **Zero output during the entire run** (5-15 min of silence). Users can't tell whether tests are running, hung, or failed.
2. **Brittle failure mode**: if the log file is missing for any reason, the trailing `cat` triggers `set -e`, the EXIT trap fires Docker teardown, and the only diagnostic the user sees is `cat: ... No such file or directory`. Reproduced today on `main`.

The exit-code bug Brian fixed will recur after this revert. The proper fix — `set +o pipefail` + `${PIPESTATUS[0]}` to keep live `tee` streaming AND capture the real exit code — is tracked separately and is the path forward.

## Test plan

- [ ] `./run_all_tests.sh` produces live tox output on stdout during the run
- [ ] `./run_all_tests.sh quick` produces live output
- [ ] Verify a passing test run still reports `ALL PASSED`
- [ ] Verify a failing test run still reports `FAILED:tox`
- [ ] Acknowledge: pre-push hook may regress to the false-failure mode #1264 was working around (will be re-fixed properly in a follow-up)