### PR TITLE
fix: resolve delivery account references across transports

### DIFF
--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -1967,6 +1967,7 @@ class AdCPRequestHandler(RequestHandler):
                 status_filter=params.get("status_filter"),
                 start_date=params.get("start_date"),
                 end_date=params.get("end_date"),
+                account=req.account,
                 context=params.get("context"),
                 identity=identity,
             )

--- a/src/core/tools/media_buy_delivery.py
+++ b/src/core/tools/media_buy_delivery.py
@@ -105,6 +105,13 @@ def _get_media_buy_delivery_impl(
             context=context_val,
         )
 
+    account_ref = getattr(req, "account", None)
+    if account_ref is not None:
+        from src.core.transport_helpers import enrich_identity_with_account
+
+        identity = enrich_identity_with_account(identity, account_ref)
+        assert identity is not None  # identity was validated above
+
     # Get the Principal object
     principal = get_principal_object(principal_id, tenant_id=identity.tenant_id)
     if not principal:
@@ -614,12 +621,6 @@ async def get_media_buy_delivery(
     """
     identity = (await ctx.get_state("identity")) if isinstance(ctx, Context) else None
 
-    # Handle account resolution at boundary (same as sync_creatives pattern)
-    if account is not None and identity is not None:
-        from src.core.transport_helpers import enrich_identity_with_account
-
-        identity = enrich_identity_with_account(identity, account)
-
     # Create AdCP-compliant request object
     try:
         req = GetMediaBuyDeliveryRequest(
@@ -630,6 +631,7 @@ async def get_media_buy_delivery(
             reporting_dimensions=reporting_dimensions,
             attribution_window=attribution_window,
             include_package_daily_breakdown=include_package_daily_breakdown,
+            account=account,
             context=cast(ContextObject | None, context),
         )
 
@@ -676,12 +678,6 @@ def get_media_buy_delivery_raw(
 
         identity = resolve_identity_from_context(ctx)
 
-    # Handle account resolution at boundary (same as sync_creatives pattern)
-    if account is not None and identity is not None:
-        from src.core.transport_helpers import enrich_identity_with_account
-
-        identity = enrich_identity_with_account(identity, account)
-
     # Create request object
     req = GetMediaBuyDeliveryRequest(
         media_buy_ids=media_buy_ids,
@@ -691,6 +687,7 @@ def get_media_buy_delivery_raw(
         reporting_dimensions=reporting_dimensions,
         attribution_window=attribution_window,
         include_package_daily_breakdown=include_package_daily_breakdown,
+        account=account,
         context=cast(ContextObject | None, context),
     )
 

--- a/src/routes/api_v1.py
+++ b/src/routes/api_v1.py
@@ -266,16 +266,11 @@ async def update_media_buy(media_buy_id: str, body: UpdateMediaBuyBody, identity
 async def get_media_buy_delivery(body: GetMediaBuyDeliveryBody, identity: ResolvedIdentity = require_auth):
     """Get delivery metrics for media buys (auth required)."""
     try:
-        # Handle account resolution at boundary
+        account_ref = None
         if body.account is not None:
             from adcp.types import AccountReference as LibraryAccountReference
 
-            from src.core.transport_helpers import enrich_identity_with_account
-
             account_ref = LibraryAccountReference(**body.account)
-            enriched = enrich_identity_with_account(identity, account_ref)
-            assert enriched is not None  # identity is non-None (from require_auth)
-            identity = enriched
 
         response = media_buy_delivery_module.get_media_buy_delivery_raw(
             media_buy_ids=body.media_buy_ids,
@@ -285,6 +280,7 @@ async def get_media_buy_delivery(body: GetMediaBuyDeliveryBody, identity: Resolv
             reporting_dimensions=body.reporting_dimensions,
             attribution_window=body.attribution_window,
             include_package_daily_breakdown=body.include_package_daily_breakdown,
+            account=account_ref,
             identity=identity,
         )
     except ToolError as e:

--- a/tests/bdd/steps/domain/uc004_delivery.py
+++ b/tests/bdd/steps/domain/uc004_delivery.py
@@ -18,6 +18,7 @@ from typing import Any
 from pytest_bdd import given, parsers, then, when
 
 from tests.bdd.steps.generic._dispatch import dispatch_request
+from tests.helpers.account_resolution import create_accessible_delivery_account
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
@@ -52,6 +53,41 @@ def _get_last_webhook_headers(ctx: dict) -> dict[str, str]:
     assert mock_post.called, "No webhook POST was made"
     call_kwargs = mock_post.call_args_list[-1][1]
     return call_kwargs.get("headers", {})
+
+
+def _ensure_delivery_account_fixture(ctx: dict) -> None:
+    """Create the account records referenced by UC-004 delivery account rows."""
+    if ctx.get("_delivery_account_fixture_ready"):
+        return
+
+    env = ctx["env"]
+    if env is None or not hasattr(env, "_session") or env._session is None:
+        return
+
+    from tests.factories import PrincipalFactory, TenantFactory
+
+    tenant = ctx.get("db_tenant")
+    if tenant is None:
+        tenant = TenantFactory(tenant_id=ctx.get("tenant_id", "test_tenant"))
+        ctx["db_tenant"] = tenant
+
+    principal_id = getattr(env, "_principal_id", "buyer-001")
+    principal_key = f"db_principal_{principal_id}"
+    principal = ctx.get(principal_key)
+    if principal is None:
+        principal = PrincipalFactory(tenant=tenant, principal_id=principal_id)
+        ctx[principal_key] = principal
+
+    account = create_accessible_delivery_account(tenant=tenant, principal=principal)
+
+    from src.core.database.models import MediaBuy
+
+    for mb_id in ctx.get("media_buys", {}):
+        media_buy = env._session.get(MediaBuy, mb_id)
+        if media_buy is not None:
+            media_buy.account_id = account.account_id
+    env._session.commit()
+    ctx["_delivery_account_fixture_ready"] = True
 
 
 def _resolve_media_buy_id(ctx: dict, mb_id: str) -> str:
@@ -912,12 +948,14 @@ def when_boundary_daily_breakdown(ctx: dict, value: str) -> None:
 @when(parsers.parse("the Buyer Agent requests delivery metrics with account {value}"))
 def when_partition_account(ctx: dict, value: str) -> None:
     """Partition test: account value."""
+    _ensure_delivery_account_fixture(ctx)
     _dispatch_partition(ctx, "account", value)
 
 
 @when(parsers.parse("the Buyer Agent requests delivery metrics at account boundary {value}"))
 def when_boundary_account(ctx: dict, value: str) -> None:
     """Boundary test: account value."""
+    _ensure_delivery_account_fixture(ctx)
     _dispatch_partition(ctx, "account", value)
 
 

--- a/tests/harness/test_delivery_account_resolution.py
+++ b/tests/harness/test_delivery_account_resolution.py
@@ -1,0 +1,102 @@
+"""Regression coverage for delivery account resolution across transports."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests.factories import MediaBuyFactory
+from tests.harness.delivery_poll import DeliveryPollEnv
+from tests.harness.transport import Transport
+from tests.helpers.account_resolution import create_accessible_delivery_account
+
+pytestmark = [pytest.mark.integration, pytest.mark.requires_db]
+
+ALL_TRANSPORTS = (Transport.IMPL, Transport.A2A, Transport.MCP, Transport.REST)
+
+
+def _seed_delivery_account(env: DeliveryPollEnv) -> None:
+    tenant, principal = env.setup_default_data()
+    account = create_accessible_delivery_account(tenant=tenant, principal=principal)
+    MediaBuyFactory(
+        tenant=tenant,
+        principal=principal,
+        media_buy_id="mb-account-001",
+        status="active",
+        account_id=account.account_id,
+    )
+    env.set_adapter_response(media_buy_id="mb-account-001")
+
+
+def _assert_delivery_success(result: Any) -> None:
+    assert result.is_success, result.error
+    assert result.payload is not None
+    deliveries = result.payload.media_buy_deliveries
+    assert [delivery.media_buy_id for delivery in deliveries] == ["mb-account-001"]
+
+
+@pytest.mark.parametrize("transport", ALL_TRANSPORTS, ids=[t.value for t in ALL_TRANSPORTS])
+def test_delivery_resolves_explicit_account_id_across_transports(integration_db, transport: Transport) -> None:
+    with DeliveryPollEnv(
+        tenant_id=f"delivery_acct_explicit_{transport.value}",
+        principal_id="buyer-001",
+    ) as env:
+        _seed_delivery_account(env)
+
+        result = env.call_via(
+            transport,
+            media_buy_ids=["mb-account-001"],
+            account={"account_id": "acc_acme_001"},
+        )
+
+    _assert_delivery_success(result)
+
+
+@pytest.mark.parametrize("transport", ALL_TRANSPORTS, ids=[t.value for t in ALL_TRANSPORTS])
+def test_delivery_resolves_natural_key_account_across_transports(integration_db, transport: Transport) -> None:
+    with DeliveryPollEnv(
+        tenant_id=f"delivery_acct_natural_{transport.value}",
+        principal_id="buyer-001",
+    ) as env:
+        _seed_delivery_account(env)
+
+        result = env.call_via(
+            transport,
+            media_buy_ids=["mb-account-001"],
+            account={"brand": {"domain": "acme-corp.com"}, "operator": "acme-corp.com"},
+        )
+
+    _assert_delivery_success(result)
+
+
+@pytest.mark.parametrize("transport", ALL_TRANSPORTS, ids=[t.value for t in ALL_TRANSPORTS])
+def test_delivery_account_not_found_across_transports(integration_db, transport: Transport) -> None:
+    with DeliveryPollEnv(
+        tenant_id=f"delivery_acct_missing_{transport.value}",
+        principal_id="buyer-001",
+    ) as env:
+        _seed_delivery_account(env)
+
+        result = env.call_via(
+            transport,
+            media_buy_ids=["mb-account-001"],
+            account={"account_id": "acc_nonexistent"},
+        )
+
+    assert result.is_error
+    assert getattr(result.error, "error_code", None) == "ACCOUNT_NOT_FOUND"
+
+
+def test_a2a_forwards_account_to_delivery_raw(integration_db) -> None:
+    with DeliveryPollEnv(tenant_id="delivery_acct_a2a_forward", principal_id="buyer-001") as env:
+        _seed_delivery_account(env)
+
+        result = env.call_via(
+            Transport.A2A,
+            media_buy_ids=["mb-account-001"],
+            account={"account_id": "acc_nonexistent"},
+        )
+
+    assert result.is_error
+    assert getattr(result.error, "error_code", None) == "ACCOUNT_NOT_FOUND"

--- a/tests/helpers/account_resolution.py
+++ b/tests/helpers/account_resolution.py
@@ -1,0 +1,28 @@
+"""Shared account fixtures for account-resolution tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tests.factories import AccountFactory, AgentAccountAccessFactory
+
+
+def create_accessible_delivery_account(
+    *,
+    tenant: Any,
+    principal: Any,
+    account_id: str = "acc_acme_001",
+    brand_domain: str = "acme-corp.com",
+    operator: str = "acme-corp.com",
+    status: str = "active",
+) -> Any:
+    """Create an account fixture that the supplied principal can access."""
+    account = AccountFactory(
+        tenant=tenant,
+        account_id=account_id,
+        status=status,
+        brand={"domain": brand_domain},
+        operator=operator,
+    )
+    AgentAccountAccessFactory(tenant_id=tenant.tenant_id, principal=principal, account=account)
+    return account

--- a/tests/integration/test_delivery_account_resolution.py
+++ b/tests/integration/test_delivery_account_resolution.py
@@ -11,7 +11,7 @@ from tests.harness.delivery_poll import DeliveryPollEnv
 from tests.harness.transport import Transport
 from tests.helpers.account_resolution import create_accessible_delivery_account
 
-pytestmark = [pytest.mark.integration, pytest.mark.requires_db]
+pytestmark = [pytest.mark.integration, pytest.mark.requires_db, pytest.mark.delivery]
 
 ALL_TRANSPORTS = (Transport.IMPL, Transport.A2A, Transport.MCP, Transport.REST)
 

--- a/tests/unit/test_delivery_account_resolution_flow.py
+++ b/tests/unit/test_delivery_account_resolution_flow.py
@@ -1,0 +1,134 @@
+"""Unit regressions for delivery AccountReference propagation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from adcp.types.generated_poc.core.account_ref import AccountReference, AccountReference1
+
+from src.core.resolved_identity import ResolvedIdentity
+from src.core.schemas import GetMediaBuyDeliveryRequest
+
+
+def _account_id(account: Any) -> str:
+    return account.root.account_id
+
+
+def test_delivery_raw_preserves_account_for_shared_impl(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.core.tools import media_buy_delivery
+
+    captured: dict[str, Any] = {}
+    account = AccountReference(AccountReference1(account_id="acc_001"))
+    identity = ResolvedIdentity(principal_id="buyer-001", tenant_id="tenant-001")
+
+    def fake_impl(req: GetMediaBuyDeliveryRequest, got_identity: ResolvedIdentity | None) -> str:
+        captured["account"] = req.account
+        captured["identity"] = got_identity
+        return "ok"
+
+    monkeypatch.setattr(media_buy_delivery, "_get_media_buy_delivery_impl", fake_impl)
+
+    result = media_buy_delivery.get_media_buy_delivery_raw(
+        media_buy_ids=["mb-001"],
+        account=account,
+        identity=identity,
+    )
+
+    assert result == "ok"
+    assert _account_id(captured["account"]) == "acc_001"
+    assert captured["identity"] is identity
+
+
+def test_delivery_impl_resolves_account_before_principal_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.core.tools import media_buy_delivery
+
+    calls: dict[str, Any] = {}
+    account = AccountReference(AccountReference1(account_id="acc_001"))
+    identity = ResolvedIdentity(
+        principal_id="buyer-001",
+        tenant_id="tenant-001",
+        tenant={"tenant_id": "tenant-001"},
+    )
+    enriched = identity.model_copy(update={"account_id": "acc_001"})
+
+    def fake_enrich_identity(got_identity: ResolvedIdentity | None, got_account: Any) -> ResolvedIdentity:
+        calls["account"] = got_account
+        return enriched
+
+    def stop_after_account_resolution(principal_id: str, tenant_id: str | None = None) -> None:
+        calls["principal_lookup"] = (principal_id, tenant_id)
+        raise RuntimeError("stop before database access")
+
+    monkeypatch.setattr("src.core.transport_helpers.enrich_identity_with_account", fake_enrich_identity)
+    monkeypatch.setattr(media_buy_delivery, "get_principal_object", stop_after_account_resolution)
+
+    req = GetMediaBuyDeliveryRequest(media_buy_ids=["mb-001"], account=account)
+    with pytest.raises(RuntimeError, match="stop before database access"):
+        media_buy_delivery._get_media_buy_delivery_impl(req, identity)
+
+    assert _account_id(calls["account"]) == "acc_001"
+    assert calls["principal_lookup"] == ("buyer-001", "tenant-001")
+
+
+@pytest.mark.asyncio
+async def test_a2a_delivery_handler_forwards_account_to_raw(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.a2a_server import adcp_a2a_server
+
+    captured: dict[str, Any] = {}
+
+    def fake_raw(**kwargs: Any) -> dict[str, bool]:
+        captured.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(adcp_a2a_server, "core_get_media_buy_delivery_tool", fake_raw)
+
+    handler = adcp_a2a_server.AdCPRequestHandler()
+    identity = ResolvedIdentity(
+        principal_id="buyer-001",
+        tenant_id="tenant-001",
+        tenant={"tenant_id": "tenant-001"},
+        protocol="a2a",
+    )
+
+    result = await handler._handle_get_media_buy_delivery_skill(
+        {"media_buy_ids": ["mb-001"], "account": {"account_id": "acc_001"}},
+        identity,
+    )
+
+    assert result == {"ok": True}
+    assert _account_id(captured["account"]) == "acc_001"
+    assert captured["identity"] is identity
+
+
+@pytest.mark.asyncio
+async def test_rest_delivery_route_passes_account_to_raw(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.routes import api_v1
+
+    captured: dict[str, Any] = {}
+    identity = ResolvedIdentity(
+        principal_id="buyer-001",
+        tenant_id="tenant-001",
+        tenant={"tenant_id": "tenant-001"},
+        protocol="rest",
+    )
+
+    class FakeResponse:
+        def model_dump(self, mode: str = "python") -> dict[str, bool]:
+            return {"ok": mode == "json"}
+
+    def fake_raw(**kwargs: Any) -> FakeResponse:
+        captured.update(kwargs)
+        return FakeResponse()
+
+    monkeypatch.setattr(api_v1.media_buy_delivery_module, "get_media_buy_delivery_raw", fake_raw)
+
+    body = api_v1.GetMediaBuyDeliveryBody(
+        media_buy_ids=["mb-001"],
+        account={"account_id": "acc_001"},
+    )
+    result = await api_v1.get_media_buy_delivery(body, identity)
+
+    assert result == {"ok": True}
+    assert _account_id(captured["account"]) == "acc_001"
+    assert captured["identity"] is identity

--- a/tests/unit/test_pydantic_schema_alignment.py
+++ b/tests/unit/test_pydantic_schema_alignment.py
@@ -74,8 +74,8 @@ KNOWN_SCHEMA_LIBRARY_MISMATCHES: dict[str, set[str]] = {
         "invoice_recipient",  # Schema refs BusinessEntity type, not in library or our models yet
     },
     "/schemas/latest/media-buy/get-media-buy-delivery-request.json": {
-        "account",  # Schema says 'account' (object), library uses 'account_id' (string)
-        "reporting_dimensions",  # Schema defines it, library doesn't have it yet
+        "include_window_breakdown",  # Schema defines windowed pull payloads, library doesn't have it yet
+        "time_granularity",  # Schema defines windowed pull granularity, library doesn't have it yet
     },
     "/schemas/latest/media-buy/sync-creatives-request.json": {
         "account",  # Schema says 'account' (object), library uses 'account_id' (string)


### PR DESCRIPTION
## Summary
- Resolve `GetMediaBuyDeliveryRequest.account` in the shared delivery `_impl` path after identity/principal-id validation and before principal lookup.
- Pass account references through A2A, REST, MCP, and raw delivery callers so transport behavior stays consistent.
- Add account-resolution regression coverage for explicit account IDs, natural-key accounts, missing accounts, and A2A forwarding.
- Seed UC-004 account rows with real account/access fixtures without editing generated feature files.

## Validation
- `make quality`
- `uv run ruff check tests/integration/test_delivery_account_resolution.py tests/helpers/account_resolution.py`
- `uv run pytest tests/unit/test_delivery.py tests/unit/test_rest_api_endpoints.py tests/unit/test_mcp_tool_type_alignment.py tests/harness/test_harness_delivery_poll.py -q`
- `uv run pytest tests/unit/test_delivery_account_resolution_flow.py -q`
- `uv run pytest tests/unit/test_auth_consistency.py::TestMissingTokenConsistency::test_get_media_buy_delivery_missing_auth_returns_error_response -q`
- `uv run pytest tests/unit/test_pydantic_schema_alignment.py::TestPydanticSchemaAlignment::test_model_accepts_all_schema_fields[/schemas/latest/media-buy/get-media-buy-delivery-request.json-GetMediaBuyDeliveryRequest] -q`
- `uv run pytest tests/integration/test_delivery_account_resolution.py --collect-only -q -m "delivery"`

## Not fully verified locally
- `uv run pytest tests/integration/test_delivery_account_resolution.py -q -rs` skipped 13 DB-backed cases because local PostgreSQL `DATABASE_URL` is unavailable.
- `scripts/run-test.sh --db tests/integration/test_delivery_account_resolution.py -q -rs` could not start the local test database because the Docker daemon is unavailable on this machine.
- `uv run pytest tests/bdd/test_uc004_deliver_media_buy_metrics.py -k "account" -q -rs` skipped 60 selected UC-004 BDD cases for the same local DB reason.

## CI coverage note
The DB-backed delivery account regression now lives under `tests/integration` and is marked `integration`, `requires_db`, and `delivery`, matching the repo GitHub Actions integration-test path for the media-buy/delivery matrix.

## Scope note
This PR covers the account-reference resolution path discussed in #1316 and #1317. #1318 remains separate because the cross-principal ownership case also needs the B3 identity-swap test rewrite. Delivery-result filtering by `account_id` is also left as a separate semantic follow-up.