### PR TITLE
fix(ci): restore security audit and schema alignment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "python-multipart>=0.0.27",  # GHSA-wp53-j4wj-2cfg + GHSA-mj87-hwqh-73pj + GHSA-pp6c-gr5w-3c5g
     "pyasn1>=0.6.3",  # GHSA-jr27-m4p2-rc6r
     "mako>=1.3.12",  # GHSA-2h4p-vjrc-8xpq (transitive via alembic)
+    "idna>=3.15",  # GHSA-65pc-fj4g-8rjx
 ]
 
 

--- a/tests/unit/test_pydantic_schema_alignment.py
+++ b/tests/unit/test_pydantic_schema_alignment.py
@@ -74,8 +74,8 @@ KNOWN_SCHEMA_LIBRARY_MISMATCHES: dict[str, set[str]] = {
         "invoice_recipient",  # Schema refs BusinessEntity type, not in library or our models yet
     },
     "/schemas/latest/media-buy/get-media-buy-delivery-request.json": {
-        "account",  # Schema says 'account' (object), library uses 'account_id' (string)
-        "reporting_dimensions",  # Schema defines it, library doesn't have it yet
+        "include_window_breakdown",  # Schema defines windowed pull payloads, library doesn't have it yet
+        "time_granularity",  # Schema defines windowed pull granularity, library doesn't have it yet
     },
     "/schemas/latest/media-buy/sync-creatives-request.json": {
         "account",  # Schema says 'account' (object), library uses 'account_id' (string)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -121,6 +121,7 @@ dependencies = [
     { name = "google-cloud-iam" },
     { name = "googleads" },
     { name = "httpx" },
+    { name = "idna" },
     { name = "jaraco-context" },
     { name = "jinja2" },
     { name = "logfire" },
@@ -225,6 +226,7 @@ requires-dist = [
     { name = "google-cloud-iam", specifier = ">=2.19.1" },
     { name = "googleads", specifier = "==49.0.0" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "idna", specifier = ">=3.15" },
     { name = "jaraco-context", specifier = ">=6.1.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "jsonref", marker = "extra == 'dev'", specifier = ">=1.1.0" },
@@ -1905,11 +1907,11 @@ inference = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add an explicit `idna>=3.15` security floor and refresh `uv.lock` from `idna 3.11` to `3.15`.
- Update the delivery request schema-alignment allowlist for current upstream AdCP `latest` fields: `time_granularity` and `include_window_breakdown`.
- Keep this as a small CI-unblock PR separate from the delivery account-resolution behavior change in #1321.

## Why
Two independent main-branch CI gates are currently blocking PR verification:

1. `Security Audit` fails on `GHSA-65pc-fj4g-8rjx` for transitive `idna==3.11`; the advisory reports `3.15` as the fixed version.
2. `Unit Tests` fail in `test_pydantic_schema_alignment.py` because AdCP `latest` added delivery pull-window fields that are not yet in the Python library/model. This is a known schema-vs-library mismatch, not a runtime behavior change.

## Validation
- `uv lock --check`
- `uvx uv-secure --no-check-uv-tool --ignore-vulns GHSA-7gcm-g887-7qv7,GHSA-5239-wwwm-4pmq`
- `uv run --locked python -c "import idna; print(idna.__version__)"` -> `3.15`
- `uv run pytest tests/unit/test_pydantic_schema_alignment.py -q --tb=short`
- `uv run pytest tests/unit/ -q --tb=short`
- `git diff --check`

Note: local `uvx uv-secure` without `--no-check-uv-tool` also scans my local global `uv 0.9.30` and reports `GHSA-pjjw-68hj-v9mw`; GitHub Actions installs `uv 0.11.6`, so this local tool finding is not expected to reproduce in CI.