### PR TITLE
fix(tests): remove stale strict xfails on get-products schema drift

### DIFF
--- a/tests/e2e/test_schema_validation_standalone.py
+++ b/tests/e2e/test_schema_validation_standalone.py
@@ -87,14 +87,6 @@ async def test_get_products_request_validation():
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "get-products schema drift: pinned adcp library does not model "
-        "adcp_major_version / if_catalog_version / if_pricing_version, so "
-        "response validation against /schemas/latest/ fails — tracked in #1308"
-    ),
-)
 async def test_offline_mode():
     """Test that offline mode works with cached schemas."""
     # cache_scope is required on the standard (else) branch of get-products-response

--- a/tests/unit/test_pydantic_schema_alignment.py
+++ b/tests/unit/test_pydantic_schema_alignment.py
@@ -52,28 +52,14 @@ SCHEMA_TO_MODEL_MAP = {
     # Note: GetSignalsRequest removed — signals is dead code (UC-008), not exposed via MCP or A2A
 }
 
-# get-products schema drift — tracked in #1308.
-# The live AdCP `/schemas/latest/media-buy/get-products-request.json` carries
-# fields the pinned adcp library does not yet model on `GetProductsRequest`:
-# the `adcp_major_version` envelope plus `if_catalog_version` and `if_pricing_version`.
-# Only the parametrizations below that genuinely fail today are xfailed (strict=True);
-# the same parametrize set is used by other tests in this file that still pass on
-# get-products and therefore is NOT swapped in for them.
-_GET_PRODUCTS_SCHEMA_DRIFT_REASON = (
-    "get-products schema drift: pinned adcp library does not model "
-    "adcp_major_version / if_catalog_version / if_pricing_version — tracked in #1308"
-)
+# get-products schema drift — tracked in #1308. The live AdCP schema carries
+# the `adcp_major_version` envelope plus `if_catalog_version`/`if_pricing_version`;
+# the pinned adcp library does not model them yet. Coverage:
+#   - adcp_major_version → excluded via _VERSION_FIELDS
+#   - if_catalog_version, if_pricing_version → excluded via KNOWN_SCHEMA_LIBRARY_MISMATCHES
+# Tests now pass; remove the prior strict-xfail wrapper.
 SCHEMA_TO_MODEL_PARAMS_WITH_GET_PRODUCTS_DRIFT_XFAIL = [
-    pytest.param(
-        schema_ref,
-        model_class,
-        marks=(
-            pytest.mark.xfail(strict=True, reason=_GET_PRODUCTS_SCHEMA_DRIFT_REASON)
-            if "get-products-request" in schema_ref
-            else ()
-        ),
-    )
-    for schema_ref, model_class in SCHEMA_TO_MODEL_MAP.items()
+    pytest.param(schema_ref, model_class) for schema_ref, model_class in SCHEMA_TO_MODEL_MAP.items()
 ]
 
 # Version metadata fields present in AdCP JSON schemas that models don't declare explicitly.


### PR DESCRIPTION
PR #1334 added strict xfail markers asserting the get-products-request schema drift would fail; PR #1276 then added allowlist coverage (if_catalog_version, if_pricing_version in KNOWN_SCHEMA_LIBRARY_MISMATCHES; adcp_major_version in _VERSION_FIELDS). The combination made the tests xpass, breaking main CI.

Two markers removed:
- tests/unit/test_pydantic_schema_alignment.py: SCHEMA_TO_MODEL_PARAMS_WITH_GET_PRODUCTS_DRIFT_XFAIL no longer wraps get-products-request with strict xfail.
- tests/e2e/test_schema_validation_standalone.py::test_offline_mode: the standalone strict xfail removed.

Tracked: the underlying #1308 issue (adcp library doesn't model these fields natively) is still open — the allowlists are the workaround until adcp library upgrades.