### PR TITLE
fix: push held-back creatives to GAM after creative approval (#1038)

### DIFF
--- a/src/admin/blueprints/creatives.py
+++ b/src/admin/blueprints/creatives.py
@@ -41,11 +41,15 @@ from flask import Blueprint, jsonify, redirect, render_template, request, url_fo
 from src.admin.utils import require_tenant_access
 from src.admin.utils.audit_decorator import log_admin_action
 from src.core.database.repositories.uow import AdminCreativeUoW
+from src.core.tools.media_buy_create import execute_approved_media_buy, push_creative_to_existing_buy
 
 # Note: CreativeFormat table was dropped in migration f2addf453200
 # All format-related routes have been removed
 
 logger = logging.getLogger(__name__)
+
+# Buy statuses where the order is live in the ad server (retroactive creative push, #1038)
+_LIVE_BUY_STATUSES: frozenset[str] = frozenset({"active", "scheduled", "paused"})
 
 # Create Blueprint
 creatives_bp = Blueprint("creatives", __name__)
@@ -604,7 +608,7 @@ def approve_creative(tenant_id, creative_id, **kwargs):
                     )
 
                     if not unapproved_creatives:
-                        media_buy_actions.append({"media_buy_id": media_buy_id, "media_buy": media_buy})
+                        media_buy_actions.append({"media_buy_id": media_buy_id})
                     else:
                         logger.info(
                             f"[CREATIVE APPROVAL] Media buy {media_buy_id} still waiting for {len(unapproved_creatives)} creatives: {unapproved_creatives}"
@@ -628,8 +632,6 @@ def approve_creative(tenant_id, creative_id, **kwargs):
                 f"[CREATIVE APPROVAL] All creatives approved for media buy {action['media_buy_id']}, executing adapter creation"
             )
 
-            from src.core.tools.media_buy_create import execute_approved_media_buy
-
             success, error_msg = execute_approved_media_buy(action["media_buy_id"], tenant_id)
 
             if success:
@@ -651,16 +653,12 @@ def approve_creative(tenant_id, creative_id, **kwargs):
         # Retroactive push for already-live buys (#1038):
         # Buys in pending_creatives/draft were handled above. For buys that are
         # live in the ad server, push this newly-approved creative to the line item.
-        # Allowlist of statuses where the buy is actually live in the ad server.
-        _LIVE_BUY_STATUSES = frozenset({"active", "scheduled", "paused"})
-        from src.core.tools.media_buy_create import push_creative_to_existing_buy
 
-        already_handled_buy_ids = {a["media_buy_id"] for a in media_buy_actions}
         # Use the status snapshot from the first loop — no need for a second UoW
         buys_to_push = [
             buy_id
             for buy_id in assignment_buy_ids
-            if buy_id not in already_handled_buy_ids and assignment_buy_statuses.get(buy_id) in _LIVE_BUY_STATUSES
+            if assignment_buy_statuses.get(buy_id) in _LIVE_BUY_STATUSES
         ]
 
         for buy_id in buys_to_push:
@@ -674,7 +672,7 @@ def approve_creative(tenant_id, creative_id, **kwargs):
                 logger.error(
                     f"[CREATIVE APPROVAL] Retroactive push failed for creative {creative_id} → buy {buy_id}: {push_err}"
                 )
-                push_warnings.append(f"Creative push to buy {buy_id} failed: {push_err}")
+                push_warnings.append(f"Creative push to buy {buy_id} failed — see server logs for details")
 
         response_body: dict[str, Any] = {"success": True, "status": "approved"}
         if push_warnings:

--- a/src/admin/blueprints/creatives.py
+++ b/src/admin/blueprints/creatives.py
@@ -510,6 +510,7 @@ def approve_creative(tenant_id, creative_id, **kwargs):
         slack_data: dict[str, Any] = {}
         audit_data: dict[str, Any] = {}
         media_buy_actions: list[dict[str, Any]] = []
+        push_warnings: list[str] = []
 
         with AdminCreativeUoW(tenant_id) as uow:
             assert uow.creatives is not None
@@ -568,11 +569,15 @@ def approve_creative(tenant_id, creative_id, **kwargs):
 
             # Check if this creative approval unblocks any media buys
             assignments = uow.assignments.get_by_creative(creative_id)
+            # Snapshot IDs as plain strings — ORM objects expire on session close (#1038)
+            assignment_buy_ids = [a.media_buy_id for a in assignments]
 
             logger.info(
                 f"[CREATIVE APPROVAL] Creative {creative_id} approved, checking {len(assignments)} media buy assignments"
             )
 
+            # Snapshot buy statuses here to avoid a second UoW after commit
+            assignment_buy_statuses: dict[str, str] = {}
             for assignment in assignments:
                 media_buy_id = assignment.media_buy_id
                 media_buy = uow.media_buys.get_by_id(media_buy_id)
@@ -580,6 +585,7 @@ def approve_creative(tenant_id, creative_id, **kwargs):
                 if not media_buy:
                     continue
 
+                assignment_buy_statuses[media_buy_id] = media_buy.status
                 logger.info(f"[CREATIVE APPROVAL] Media buy {media_buy_id} status: {media_buy.status}")
 
                 if media_buy.status in {"pending_creatives", "draft"}:
@@ -642,7 +648,38 @@ def approve_creative(tenant_id, creative_id, **kwargs):
             else:
                 logger.error(f"[CREATIVE APPROVAL] Adapter creation failed for {action['media_buy_id']}: {error_msg}")
 
-        return jsonify({"success": True, "status": "approved"})
+        # Retroactive push for already-live buys (#1038):
+        # Buys in pending_creatives/draft were handled above. For buys that are
+        # live in the ad server, push this newly-approved creative to the line item.
+        # Allowlist of statuses where the buy is actually live in the ad server.
+        _LIVE_BUY_STATUSES = frozenset({"active", "scheduled", "paused"})
+        from src.core.tools.media_buy_create import push_creative_to_existing_buy
+
+        already_handled_buy_ids = {a["media_buy_id"] for a in media_buy_actions}
+        # Use the status snapshot from the first loop — no need for a second UoW
+        buys_to_push = [
+            buy_id
+            for buy_id in assignment_buy_ids
+            if buy_id not in already_handled_buy_ids and assignment_buy_statuses.get(buy_id) in _LIVE_BUY_STATUSES
+        ]
+
+        for buy_id in buys_to_push:
+            logger.info(f"[CREATIVE APPROVAL] Retroactive push: creative {creative_id} → live buy {buy_id}")
+            push_success, push_err = push_creative_to_existing_buy(
+                creative_id=creative_id,
+                media_buy_id=buy_id,
+                tenant_id=tenant_id,
+            )
+            if not push_success:
+                logger.error(
+                    f"[CREATIVE APPROVAL] Retroactive push failed for creative {creative_id} → buy {buy_id}: {push_err}"
+                )
+                push_warnings.append(f"Creative push to buy {buy_id} failed: {push_err}")
+
+        response_body: dict[str, Any] = {"success": True, "status": "approved"}
+        if push_warnings:
+            response_body["warnings"] = push_warnings
+        return jsonify(response_body)
 
     except Exception as e:
         logger.error(f"Error approving creative: {e}", exc_info=True)

--- a/src/core/tools/media_buy_create.py
+++ b/src/core/tools/media_buy_create.py
@@ -475,7 +475,17 @@ def _persist_adapter_package_ids(
     prefix = f"[{log_label}] " if log_label else ""
     all_pkgs = {p.package_id: p for p in media_buy_repo.get_packages(media_buy_id)}
     for pkg_record in all_pkgs.values():
-        pkg_record.package_config["platform_order_id"] = str(platform_order_id)
+        if pkg_record.package_config is None:
+            pkg_record.package_config = {}
+        existing = pkg_record.package_config.get("platform_order_id")
+        new_id = str(platform_order_id)
+        if existing and existing != new_id:
+            logger.warning(
+                f"{prefix}platform_order_id mismatch on {pkg_record.package_id}: "
+                f"existing={existing} new={new_id} — refusing to overwrite"
+            )
+            continue
+        pkg_record.package_config["platform_order_id"] = new_id
         attributes.flag_modified(pkg_record, "package_config")
     logger.info(f"{prefix}Persisted platform_order_id to {len(all_pkgs)} package(s) for {media_buy_id}")
 
@@ -487,7 +497,17 @@ def _persist_adapter_package_ids(
     for pkg_id, line_item_id in platform_line_item_ids.items():
         li_pkg = all_pkgs.get(pkg_id)
         if li_pkg:
-            li_pkg.package_config["platform_line_item_id"] = str(line_item_id)
+            if li_pkg.package_config is None:
+                li_pkg.package_config = {}
+            existing_li = li_pkg.package_config.get("platform_line_item_id")
+            new_li = str(line_item_id)
+            if existing_li and existing_li != new_li:
+                logger.warning(
+                    f"{prefix}platform_line_item_id mismatch on {pkg_id}: "
+                    f"existing={existing_li} new={new_li} — refusing to overwrite"
+                )
+                continue
+            li_pkg.package_config["platform_line_item_id"] = new_li
             attributes.flag_modified(li_pkg, "package_config")
             logger.info(f"{prefix}Updated package {pkg_id} with platform_line_item_id: {line_item_id}")
         else:
@@ -508,6 +528,7 @@ def _build_adapter_asset_from_creative(
     """
     creative_data = creative.data or {}
     format_spec = None
+    # Prefer cached spec (same as auto-approval path); fall back to live get_format on miss.
     if creative.format:
         format_spec = _get_format_spec_sync(creative.agent_url, str(creative.format))
     if format_spec is None and creative.format:
@@ -1059,7 +1080,7 @@ def push_creative_to_existing_buy(
     Called from approve_creative when the buy is already live but this creative
     was in pending_review at buy-approval time and was held back (#1038).
     Local approval has already committed — failures here are non-fatal and logged.
-    The operator can re-approve to retry; the adapter layer is idempotent.
+    Re-approval is safe: skips the adapter when platform_creative_id is already set.
 
     Returns (success, error_message). error_message is non-None only on failure.
     """
@@ -1084,6 +1105,15 @@ def push_creative_to_existing_buy(
             creative = uow.creatives.admin_get_by_id(creative_id)
             if not creative:
                 return False, f"Creative {creative_id} not found"
+            if creative.status not in {"approved", "active"}:
+                return False, f"Creative {creative_id} is not approved (status={creative.status})"
+
+            if (creative.data or {}).get("platform_creative_id"):
+                logger.info(
+                    f"[GATE-PUSH] Creative {creative_id} already has platform_creative_id — "
+                    f"skipping adapter call (already uploaded)"
+                )
+                return True, None
 
             all_assignments = uow.assignments.get_by_creative(creative_id)
             matching = [a for a in all_assignments if a.media_buy_id == media_buy_id]
@@ -1098,13 +1128,13 @@ def push_creative_to_existing_buy(
             if not (hasattr(adapter, "creatives_manager") and adapter.creatives_manager):
                 return False, "Adapter does not support creative upload"
 
-            # GAM order ID is per-buy — any package on this buy has the same platform_order_id
+            # platform_order_id is per-buy — any package on this buy has the same value
             media_package = uow.media_buys.get_package(media_buy_id, matching[0].package_id)
             if not media_package:
                 return False, f"No package found for media buy {media_buy_id}"
 
-            gam_order_id = (media_package.package_config or {}).get("platform_order_id")
-            if not gam_order_id:
+            platform_order_id = (media_package.package_config or {}).get("platform_order_id")
+            if not platform_order_id:
                 return False, f"Media buy {media_buy_id} has no platform_order_id — buy may not be live yet"
 
             package_assignments: list[PackageAssignmentDict] = [
@@ -1117,7 +1147,7 @@ def push_creative_to_existing_buy(
 
             try:
                 asset_statuses = adapter.creatives_manager.add_creative_assets(
-                    gam_order_id,
+                    platform_order_id,
                     [asset],
                     datetime.now(UTC),
                 )
@@ -1141,7 +1171,7 @@ def push_creative_to_existing_buy(
                         )
                     logger.info(
                         f"[GATE-PUSH] Pushed creative {creative_id} to live buy "
-                        f"{media_buy_id} (GAM order {gam_order_id})"
+                        f"{media_buy_id} (platform order {platform_order_id})"
                     )
                     return True, None
             return False, f"Adapter did not report status for creative {creative_id}"

--- a/src/core/tools/media_buy_create.py
+++ b/src/core/tools/media_buy_create.py
@@ -20,6 +20,8 @@ from sqlalchemy.exc import IntegrityError
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
+    from src.core.database.repositories.media_buy import MediaBuyRepository
+
 from adcp import PushNotificationConfig
 from adcp.server.helpers import valid_actions_for_status
 from adcp.types import GeneratedTaskStatus as AdcpTaskStatus
@@ -459,6 +461,94 @@ def _execute_adapter_media_buy_creation(
         raise
 
 
+def _persist_adapter_package_ids(
+    media_buy_repo: "MediaBuyRepository",
+    *,
+    media_buy_id: str,
+    platform_order_id: str,
+    platform_line_item_ids: dict[str, str] | None = None,
+    log_label: str = "",
+) -> None:
+    """Write platform_order_id (and optional line-item IDs) to all packages for a buy."""
+    from sqlalchemy.orm import attributes
+
+    prefix = f"[{log_label}] " if log_label else ""
+    all_pkgs = {p.package_id: p for p in media_buy_repo.get_packages(media_buy_id)}
+    for pkg_record in all_pkgs.values():
+        pkg_record.package_config["platform_order_id"] = str(platform_order_id)
+        attributes.flag_modified(pkg_record, "package_config")
+    logger.info(f"{prefix}Persisted platform_order_id to {len(all_pkgs)} package(s) for {media_buy_id}")
+
+    if not platform_line_item_ids:
+        logger.info(f"{prefix}No platform_line_item_ids found on response object")
+        return
+
+    logger.info(f"{prefix}Found platform_line_item_ids: {platform_line_item_ids}")
+    for pkg_id, line_item_id in platform_line_item_ids.items():
+        li_pkg = all_pkgs.get(pkg_id)
+        if li_pkg:
+            li_pkg.package_config["platform_line_item_id"] = str(line_item_id)
+            attributes.flag_modified(li_pkg, "package_config")
+            logger.info(f"{prefix}Updated package {pkg_id} with platform_line_item_id: {line_item_id}")
+        else:
+            logger.warning(f"{prefix}Could not find package {pkg_id} to save platform_line_item_id")
+    logger.info(f"{prefix}Saved platform_line_item_ids to database")
+
+
+def _build_adapter_asset_from_creative(
+    creative: Any,
+    package_assignments: list[PackageAssignmentDict],
+    *,
+    tenant_id: str,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Build the asset dict for adapter.creatives_manager.add_creative_assets.
+
+    Returns (asset, None) on success, (None, error_message) when url/width/height
+    cannot be extracted. Shared by execute_approved_media_buy and push_creative_to_existing_buy.
+    """
+    creative_data = creative.data or {}
+    format_spec = None
+    if creative.format:
+        format_spec = _get_format_spec_sync(creative.agent_url, str(creative.format))
+    if format_spec is None and creative.format:
+        try:
+            from src.core.format_resolver import get_format
+
+            format_spec = get_format(
+                str(creative.format),
+                agent_url=creative.agent_url,
+                tenant_id=tenant_id,
+                product_id=None,
+            )
+        except Exception as e:
+            logger.warning(f"[ASSET] Could not load format spec for {creative.creative_id}: {e}")
+
+    url, width, height = extract_media_url_and_dimensions(creative_data, format_spec)
+    click_url = extract_click_url(creative_data, format_spec)
+    impression_tracker_url = extract_impression_tracker_url(creative_data, format_spec)
+
+    if not url or not width or not height:
+        return None, (
+            f"Creative {creative.creative_id} missing url/width/height "
+            f"(width={width}, height={height}, url={'set' if url else 'missing'}, format={creative.format})"
+        )
+
+    asset: dict[str, Any] = {
+        "creative_id": creative.creative_id,
+        "package_assignments": package_assignments,
+        "width": width,
+        "height": height,
+        "url": url,
+        "click_url": click_url,
+        "asset_type": creative_data.get("asset_type", "image"),
+        "name": creative.name or f"Creative {creative.creative_id}",
+    }
+    if impression_tracker_url:
+        asset["delivery_settings"] = {"tracking_urls": {"impression": [impression_tracker_url]}}
+
+    return asset, None
+
+
 def execute_approved_media_buy(media_buy_id: str, tenant_id: str) -> tuple[bool, str | None]:
     """Execute adapter creation for a manually approved media buy.
 
@@ -779,30 +869,23 @@ def execute_approved_media_buy(media_buy_id: str, tenant_id: str) -> tuple[bool,
 
         logger.info(f"[APPROVAL] Adapter creation succeeded for {media_buy_id}: {response.media_buy_id}")
 
-        # Persist platform_line_item_ids from adapter response (same as auto-approval path)
-        # Adapters (GAM, Broadstreet) attach _platform_line_item_ids to the response object
-        # These are required for update_media_buy operations (budget updates, pause/resume)
+        # Persist adapter IDs to package_config.
+        # platform_order_id is per-buy — always write to all packages so retroactive creative
+        # push works regardless of whether the adapter also provides per-package line-item IDs.
+        # platform_line_item_id is per-package and only present when the adapter maps them.
         platform_line_item_ids = getattr(response, "_platform_line_item_ids", {})
-        if platform_line_item_ids:
-            logger.info(f"[APPROVAL] Found platform_line_item_ids mapping: {platform_line_item_ids}")
+        if response.media_buy_id:
             with MediaBuyUoW(tenant_id) as uow_plids:
-                # FIXME(salesagent-rva2): migrate to uow.media_buys.update_package_config()
-                assert uow_plids.session is not None
-                plid_session = uow_plids.session
-                for pkg_id, line_item_id in platform_line_item_ids.items():
-                    package_stmt = select(DBMediaPackage).filter_by(media_buy_id=media_buy_id, package_id=pkg_id)
-                    pkg_record: DBMediaPackage | None = plid_session.scalars(package_stmt).first()
-                    if pkg_record:
-                        pkg_record.package_config["platform_line_item_id"] = str(line_item_id)
-                        from sqlalchemy.orm import attributes
-
-                        attributes.flag_modified(pkg_record, "package_config")
-                        logger.info(f"[APPROVAL] Updated package {pkg_id} with platform_line_item_id: {line_item_id}")
-                    else:
-                        logger.warning(f"[APPROVAL] Could not find package {pkg_id} to save platform_line_item_id")
-                logger.info("[APPROVAL] Saved platform_line_item_ids to database")
+                assert uow_plids.media_buys is not None
+                _persist_adapter_package_ids(
+                    uow_plids.media_buys,
+                    media_buy_id=media_buy_id,
+                    platform_order_id=str(response.media_buy_id),
+                    platform_line_item_ids=platform_line_item_ids or None,
+                    log_label="APPROVAL",
+                )
         else:
-            logger.info("[APPROVAL] No platform_line_item_ids found on response object")
+            logger.info("[APPROVAL] Adapter returned no media_buy_id — skipping ID persistence")
 
         # Upload and associate inline creatives if any exist
         # This handles inline creatives that were uploaded during initial media buy creation
@@ -857,63 +940,21 @@ def execute_approved_media_buy(media_buy_id: str, tenant_id: str) -> tuple[bool,
                         logger.warning(f"[APPROVAL] Creative {creative_id} not found in database")
                         continue
 
-                    # Convert Creative model to asset dict format expected by adapter
-                    # The Creative model stores all content in the 'data' JSON field
-                    creative_data = creative.data or {}
-
-                    # Get format spec for proper extraction
-                    from src.core.format_resolver import get_format
-
-                    format_spec = None
-                    try:
-                        format_spec = get_format(
-                            str(creative.format), agent_url=creative.agent_url, tenant_id=tenant_id, product_id=None
+                    # Hold back pending_review creatives — pushed retroactively on approval (#1038)
+                    if creative.status == "pending_review":
+                        logger.info(
+                            f"[APPROVAL] Holding back creative {creative_id} (pending_review) from adapter upload"
                         )
-                    except (ValueError, Exception) as e:
-                        logger.warning(
-                            f"[APPROVAL] Could not load format spec for creative {creative_id} "
-                            f"(format={creative.format}): {e}"
-                        )
-
-                    # Extract URL and dimensions using shared helper
-                    url, width, height = extract_media_url_and_dimensions(creative_data, format_spec)
-
-                    # Extract click-through URL separately from media URL (with macro substitution)
-                    click_url = extract_click_url(creative_data, format_spec)
-
-                    # Extract impression tracker URL
-                    impression_tracker_url = extract_impression_tracker_url(creative_data, format_spec)
-
-                    asset = {
-                        "creative_id": creative.creative_id,
-                        # Include full assignment info with weights for adapter creative rotation (AdCP 2.5)
-                        "package_assignments": package_assignment_list,
-                        "width": width,
-                        "height": height,
-                        "url": url,
-                        "click_url": click_url,  # Separate click-through URL for GAM destinationUrl
-                        "asset_type": creative_data.get("asset_type", "image"),
-                        "name": creative.name or f"Creative {creative.creative_id}",
-                    }
-
-                    # Add impression tracker URL in the format expected by GAM adapter
-                    if impression_tracker_url:
-                        asset["delivery_settings"] = {"tracking_urls": {"impression": [impression_tracker_url]}}
-
-                    # GAM requires width, height, and url for creative upload
-                    # Validate required fields and accumulate all errors
-                    if not asset["width"] or not asset["height"]:
-                        error = f"Creative {creative_id} missing dimensions (width={asset['width']}, height={asset['height']}, format={creative.format})"
-                        all_validation_errors.append(error)
-                        logger.error(f"[APPROVAL] {error}")
-                    if not asset["url"]:
-                        error = f"Creative {creative_id} missing required URL field"
-                        all_validation_errors.append(error)
-                        logger.error(f"[APPROVAL] {error}")
-
-                    # Skip invalid creatives but continue checking others
-                    if any(err.startswith(f"Creative {creative_id}") for err in all_validation_errors):
                         continue
+
+                    asset, err = _build_adapter_asset_from_creative(
+                        creative, package_assignment_list, tenant_id=tenant_id
+                    )
+                    if err:
+                        all_validation_errors.append(err)
+                        logger.error(f"[APPROVAL] {err}")
+                        continue
+                    assert asset is not None
 
                     assets.append(asset)
 
@@ -1005,6 +1046,112 @@ def execute_approved_media_buy(media_buy_id: str, tenant_id: str) -> tuple[bool,
         error_msg = f"Adapter creation failed: {str(e)}"
         logger.error(f"[APPROVAL] {error_msg}\n{error_traceback}")
         return False, error_msg
+
+
+def push_creative_to_existing_buy(
+    *,
+    creative_id: str,
+    media_buy_id: str,
+    tenant_id: str,
+) -> tuple[bool, str | None]:
+    """Push a single approved creative to an already-active ad server line item.
+
+    Called from approve_creative when the buy is already live but this creative
+    was in pending_review at buy-approval time and was held back (#1038).
+    Local approval has already committed — failures here are non-fatal and logged.
+    The operator can re-approve to retry; the adapter layer is idempotent.
+
+    Returns (success, error_message). error_message is non-None only on failure.
+    """
+    from src.core.config_loader import get_tenant_by_id, set_current_tenant
+    from src.core.database.repositories.uow import AdminCreativeUoW
+
+    try:
+        with AdminCreativeUoW(tenant_id) as uow:
+            assert uow.creatives is not None
+            assert uow.assignments is not None
+            assert uow.media_buys is not None
+            assert uow.tenant_config is not None
+
+            tenant_obj = uow.tenant_config.get_tenant()
+            if not tenant_obj:
+                return False, f"Tenant {tenant_id} not found"
+
+            tenant_config = get_tenant_by_id(tenant_id)
+            if tenant_config:
+                set_current_tenant(tenant_config)
+
+            creative = uow.creatives.admin_get_by_id(creative_id)
+            if not creative:
+                return False, f"Creative {creative_id} not found"
+
+            all_assignments = uow.assignments.get_by_creative(creative_id)
+            matching = [a for a in all_assignments if a.media_buy_id == media_buy_id]
+            if not matching:
+                return False, f"No assignment of creative {creative_id} to media buy {media_buy_id}"
+
+            principal = get_principal_object(creative.principal_id, tenant_id=tenant_id)
+            if not principal:
+                return False, f"Principal {creative.principal_id} not found"
+
+            adapter = get_adapter(principal, dry_run=False, tenant=tenant_obj)
+            if not (hasattr(adapter, "creatives_manager") and adapter.creatives_manager):
+                return False, "Adapter does not support creative upload"
+
+            # GAM order ID is per-buy — any package on this buy has the same platform_order_id
+            media_package = uow.media_buys.get_package(media_buy_id, matching[0].package_id)
+            if not media_package:
+                return False, f"No package found for media buy {media_buy_id}"
+
+            gam_order_id = (media_package.package_config or {}).get("platform_order_id")
+            if not gam_order_id:
+                return False, f"Media buy {media_buy_id} has no platform_order_id — buy may not be live yet"
+
+            package_assignments: list[PackageAssignmentDict] = [
+                {"package_id": a.package_id, "weight": a.weight or 100} for a in matching
+            ]
+            asset, build_err = _build_adapter_asset_from_creative(creative, package_assignments, tenant_id=tenant_id)
+            if build_err:
+                return False, build_err
+            assert asset is not None
+
+            try:
+                asset_statuses = adapter.creatives_manager.add_creative_assets(
+                    gam_order_id,
+                    [asset],
+                    datetime.now(UTC),
+                )
+            except Exception as e:
+                logger.error(
+                    f"[GATE-PUSH] Adapter raised pushing creative {creative_id} to buy {media_buy_id}: {e}",
+                    exc_info=True,
+                )
+                return False, str(e)
+
+            for status in asset_statuses:
+                if status.creative_id == creative_id:
+                    if status.status == "failed":
+                        return False, status.message or "Adapter reported upload failure"
+                    if status.creative_id and not (creative.data or {}).get("platform_creative_id"):
+                        updated_data = dict(creative.data or {})
+                        updated_data["platform_creative_id"] = status.creative_id
+                        uow.creatives.update_data(creative, updated_data)
+                        logger.info(
+                            f"[GATE-PUSH] Updated creative {creative_id} with platform_creative_id={status.creative_id}"
+                        )
+                    logger.info(
+                        f"[GATE-PUSH] Pushed creative {creative_id} to live buy "
+                        f"{media_buy_id} (GAM order {gam_order_id})"
+                    )
+                    return True, None
+            return False, f"Adapter did not report status for creative {creative_id}"
+
+    except Exception as e:
+        logger.error(
+            f"[GATE-PUSH] Unexpected error pushing creative {creative_id} to buy {media_buy_id}: {e}",
+            exc_info=True,
+        )
+        return False, str(e)
 
 
 def _validate_pricing_model_selection(
@@ -3108,39 +3255,22 @@ async def _create_media_buy_impl(
                     f"Saved {len(packages_to_save)} packages to media_packages table for media_buy {response.media_buy_id}"
                 )
 
-                # Update packages with platform_line_item_id from adapter response
-                # This is required for update_media_buy operations (budget updates, pause/resume)
-                # Adapters (like GAM) attach a _platform_line_item_ids mapping to the response object
+                # Persist adapter IDs to package_config.
+                # platform_order_id is per-buy — always write to all packages; platform_line_item_id
+                # is per-package and conditional on the adapter providing the mapping.
                 platform_line_item_ids = getattr(response, "_platform_line_item_ids", {})
 
-                if platform_line_item_ids:
-                    logger.info(f"[DEBUG] Found platform_line_item_ids mapping: {platform_line_item_ids}")
-
-                    for pkg_id, line_item_id in platform_line_item_ids.items():
-                        # Update the package_config with platform_line_item_id
-                        from sqlalchemy import select
-
-                        from src.core.database.models import MediaPackage as DBMediaPackage
-
-                        # FIXME(salesagent-rva2): migrate to uow.media_buys.get_package()
-                        package_stmt = select(DBMediaPackage).filter_by(
-                            media_buy_id=response.media_buy_id, package_id=pkg_id
-                        )
-                        pkg_record: DBMediaPackage | None = session.scalars(package_stmt).first()
-                        if pkg_record:
-                            # Update package_config JSON with platform_line_item_id
-                            pkg_record.package_config["platform_line_item_id"] = str(line_item_id)
-                            from sqlalchemy.orm import attributes
-
-                            attributes.flag_modified(pkg_record, "package_config")
-                            logger.info(f"✓ Updated package {pkg_id} with platform_line_item_id: {line_item_id}")
-                        else:
-                            logger.warning(f"⚠️  Could not find DB package {pkg_id} to save platform_line_item_id")
-
-                    # UoW auto-commits on clean exit
-                    logger.info("✓ Saved platform_line_item_ids to database")
+                if response.media_buy_id:
+                    assert auto_pkg_uow.media_buys is not None
+                    _persist_adapter_package_ids(
+                        auto_pkg_uow.media_buys,
+                        media_buy_id=response.media_buy_id,
+                        platform_order_id=str(response.media_buy_id),
+                        platform_line_item_ids=platform_line_item_ids or None,
+                        log_label="DEBUG",
+                    )
                 else:
-                    logger.info("[DEBUG] No platform_line_item_ids found on response object")
+                    logger.info("[DEBUG] Adapter returned no media_buy_id — skipping ID persistence")
 
         # Handle creative_ids in packages if provided (immediate association)
         if req.packages:
@@ -3273,87 +3403,34 @@ async def _create_media_buy_impl(
                                 logger.error(f"Creative {creative_id} not in map despite validation - this is a bug")
                                 continue
 
-                            # Create database assignment (always create, even if not yet uploaded to GAM)
                             # Get platform_creative_id from creative.data JSON
                             platform_creative_id = creative.data.get("platform_creative_id") if creative.data else None
                             if platform_creative_id:
-                                # Add to association list for immediate GAM association
+                                # Already in GAM — add to association list
                                 platform_creative_ids.append(platform_creative_id)
+                            elif creative.status == "pending_review":
+                                # Hold back until the creative is approved; the DB assignment below
+                                # ensures approve_creative can find it for retroactive push
+                                logger.info(f"[AUTO-APPROVAL] Holding back creative {creative_id} (pending_review)")
                             else:
-                                # Creative not uploaded to GAM yet - upload it now
-                                # Use the same simple asset dict approach as manual approval (execute_approved_media_buy)
-                                logger.info(
-                                    f"Creative {creative_id} has no platform_creative_id - uploading to GAM now"
-                                )
+                                # Upload to GAM via shared asset helper
                                 try:
-                                    creative_data = creative.data or {}
-
-                                    # Get format spec for proper extraction
-                                    # Uses shared helper with in-memory cache (30min TTL)
-                                    format_spec = None
-                                    if creative.format:
-                                        format_spec = _get_format_spec_sync(creative.agent_url, str(creative.format))
-                                        if not format_spec:
-                                            logger.warning(
-                                                f"[AUTO-APPROVAL] Could not fetch format {creative.format} "
-                                                f"from {creative.agent_url}"
-                                            )
-
-                                    # Extract URL and dimensions using shared helper
-                                    url, width, height = extract_media_url_and_dimensions(creative_data, format_spec)
-
-                                    # Extract click-through URL separately from media URL (with macro substitution)
-                                    click_url = extract_click_url(creative_data, format_spec)
-
-                                    # Extract impression tracker URL
-                                    impression_tracker_url = extract_impression_tracker_url(creative_data, format_spec)
-
-                                    # Build simple asset dict (same as manual approval flow)
-                                    asset = {
-                                        "creative_id": creative.creative_id,
-                                        "package_assignments": [package_id],  # This specific package
-                                        "width": width,
-                                        "height": height,
-                                        "url": url,
-                                        "click_url": click_url,  # Separate click-through URL for GAM destinationUrl
-                                        "asset_type": creative_data.get("asset_type", "image"),
-                                        "name": creative.name or f"Creative {creative.creative_id}",
-                                    }
-
-                                    # Add impression tracker URL in the format expected by GAM adapter
-                                    if impression_tracker_url:
-                                        asset["delivery_settings"] = {
-                                            "tracking_urls": {"impression": [impression_tracker_url]}
-                                        }
-
-                                    # Validate required fields - FAIL FAST, do not skip
-                                    validation_errors = []
-                                    if not asset["width"] or not asset["height"]:
-                                        validation_errors.append(
-                                            f"Creative {creative_id} missing dimensions (width={asset['width']}, height={asset['height']})"
-                                        )
-                                    if not asset["url"]:
-                                        validation_errors.append(f"Creative {creative_id} missing required URL field")
-
-                                    if validation_errors:
-                                        error_msg = (
-                                            "Cannot create media buy with invalid creatives. "
-                                            "The following creatives are missing required fields:\n"
-                                            + "\n".join(f"  • {err}" for err in validation_errors)
-                                            + "\n\nAll creatives must have dimensions (width/height) and a content URL. "
-                                            "Please ensure creatives are properly synced before creating media buys."
-                                        )
-                                        logger.error(f"[AUTO-APPROVAL] {error_msg}")
-                                        # Raise exception for MCP - this will be caught and returned as error response
+                                    pkg_assignments: list[PackageAssignmentDict] = [
+                                        {"package_id": response_package_id, "weight": 100}
+                                    ]
+                                    asset, build_err = _build_adapter_asset_from_creative(
+                                        creative, pkg_assignments, tenant_id=tenant["tenant_id"]
+                                    )
+                                    if build_err:
                                         raise AdCPValidationError(
-                                            error_msg,
+                                            build_err,
                                             details={
                                                 "error_code": "INVALID_CREATIVES",
-                                                "creative_errors": validation_errors,
+                                                "creative_errors": [build_err],
                                             },
                                         )
+                                    assert asset is not None
 
-                                    # Upload to GAM using adapter's add_creative_assets method
                                     upload_result = adapter.add_creative_assets(
                                         response.media_buy_id if response.media_buy_id else "",
                                         [asset],
@@ -3361,10 +3438,8 @@ async def _create_media_buy_impl(
                                     )
                                     logger.info(f"Successfully uploaded creative {creative_id} to GAM: {upload_result}")
 
-                                    # Update creative in database with platform_creative_id
                                     if upload_result and len(upload_result) > 0:
                                         uploaded_status = upload_result[0]
-                                        # Only set platform_creative_id if not already set
                                         if uploaded_status.creative_id and not creative.data.get(
                                             "platform_creative_id"
                                         ):
@@ -3381,10 +3456,8 @@ async def _create_media_buy_impl(
                                             )
                                             platform_creative_ids.append(creative.data["platform_creative_id"])
                                 except AdCPError:
-                                    # Re-raise AdCPError - validation failures should fail the entire operation
                                     raise
                                 except Exception as upload_error:
-                                    # Other exceptions (network errors, etc.) - log and fail
                                     logger.error(f"Failed to upload creative {creative_id} to GAM: {upload_error}")
                                     raise AdCPAdapterError(
                                         f"Failed to upload creative {creative_id} to GAM: {str(upload_error)}",

--- a/tests/admin/test_creatives_blueprint.py
+++ b/tests/admin/test_creatives_blueprint.py
@@ -193,6 +193,216 @@ class TestCreativeApproval:
         assert response.status_code == 404
 
 
+def _create_active_media_buy(tenant_id: str, status: str = "active") -> tuple[str, str]:
+    """Create a media buy + package with a platform_order_id. Returns (media_buy_id, package_id)."""
+    from sqlalchemy import select as sa_select
+
+    from src.core.database.models import Principal as PrincipalModel
+    from src.core.database.models import Tenant as TenantModel
+    from tests.factories import MediaBuyFactory, MediaPackageFactory
+
+    with get_db_session() as session:
+        MediaBuyFactory._meta.sqlalchemy_session = session
+        MediaPackageFactory._meta.sqlalchemy_session = session
+
+        tenant = session.scalars(sa_select(TenantModel).filter_by(tenant_id=tenant_id)).first()
+        principal = session.scalars(
+            sa_select(PrincipalModel).filter_by(tenant_id=tenant_id, principal_id=_PRINCIPAL_ID)
+        ).first()
+
+        mb = MediaBuyFactory(tenant=tenant, principal=principal, status=status)
+        pkg = MediaPackageFactory(
+            media_buy=mb,
+            package_config={"platform_order_id": "gam_order_test", "platform_line_item_id": "gam_li_test"},
+        )
+        return mb.media_buy_id, pkg.package_id
+
+
+def _create_assignment(tenant_id: str, creative_id: str, media_buy_id: str, package_id: str) -> str:
+    """Create a CreativeAssignment linking creative to media buy. Returns assignment_id."""
+    from sqlalchemy import select as sa_select
+
+    from src.core.database.models import Creative as CreativeModel
+    from src.core.database.models import MediaBuy as MediaBuyModel
+    from tests.factories import CreativeAssignmentFactory
+
+    with get_db_session() as session:
+        CreativeAssignmentFactory._meta.sqlalchemy_session = session
+
+        creative = session.scalars(
+            sa_select(CreativeModel).filter_by(tenant_id=tenant_id, creative_id=creative_id)
+        ).first()
+        media_buy = session.scalars(
+            sa_select(MediaBuyModel).filter_by(tenant_id=tenant_id, media_buy_id=media_buy_id)
+        ).first()
+
+        asgn = CreativeAssignmentFactory(
+            creative=creative,
+            media_buy=media_buy,
+            package_id=package_id,
+        )
+        return asgn.assignment_id
+
+
+_PUSH_PATCH = "src.core.tools.media_buy_create.push_creative_to_existing_buy"
+
+
+class TestCreativeApprovalRetroactivePush:
+    """approve_creative triggers retroactive push for already-active media buys (#1038)."""
+
+    def test_active_buy_triggers_retroactive_push(self, client, test_tenant):
+        """Approving a creative assigned to an active buy calls push_creative_to_existing_buy."""
+        _auth_session(client, test_tenant)
+        creative_id = _create_creative(test_tenant, status="pending_review")
+        media_buy_id, package_id = _create_active_media_buy(test_tenant, status="active")
+        _create_assignment(test_tenant, creative_id, media_buy_id, package_id)
+
+        with (
+            patch(_SIDE_EFFECTS_PATCH),
+            patch(_PUSH_PATCH, return_value=(True, None)) as mock_push,
+        ):
+            response = client.post(
+                f"/tenant/{test_tenant}/creatives/review/{creative_id}/approve",
+                content_type="application/json",
+                json={"approved_by": "test@example.com"},
+            )
+
+        assert response.status_code == 200
+        mock_push.assert_called_once_with(
+            creative_id=creative_id,
+            media_buy_id=media_buy_id,
+            tenant_id=test_tenant,
+        )
+
+    def test_pending_creatives_buy_not_retroactively_pushed(self, client, test_tenant):
+        """Buys in pending_creatives status are handled by the existing loop, not the retroactive one."""
+        _auth_session(client, test_tenant)
+        creative_id = _create_creative(test_tenant, status="pending_review")
+        media_buy_id, package_id = _create_active_media_buy(test_tenant, status="pending_creatives")
+        _create_assignment(test_tenant, creative_id, media_buy_id, package_id)
+
+        with (
+            patch(_SIDE_EFFECTS_PATCH),
+            patch(_PUSH_PATCH, return_value=(True, None)) as mock_push,
+        ):
+            response = client.post(
+                f"/tenant/{test_tenant}/creatives/review/{creative_id}/approve",
+                content_type="application/json",
+                json={},
+            )
+
+        assert response.status_code == 200
+        mock_push.assert_not_called()
+
+    def test_push_failure_returns_200_with_warnings(self, client, test_tenant):
+        """Push failure is non-fatal: response is 200 with a warnings field."""
+        _auth_session(client, test_tenant)
+        creative_id = _create_creative(test_tenant, status="pending_review")
+        media_buy_id, package_id = _create_active_media_buy(test_tenant, status="active")
+        _create_assignment(test_tenant, creative_id, media_buy_id, package_id)
+
+        with (
+            patch(_SIDE_EFFECTS_PATCH),
+            patch(_PUSH_PATCH, return_value=(False, "GAM rejected the creative")),
+        ):
+            response = client.post(
+                f"/tenant/{test_tenant}/creatives/review/{creative_id}/approve",
+                content_type="application/json",
+                json={},
+            )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["success"] is True
+        assert any("GAM rejected" in w for w in data.get("warnings", []))
+
+    def test_no_active_buy_no_push_called(self, client, test_tenant):
+        """Approving a creative with no buy assignments does not call push."""
+        _auth_session(client, test_tenant)
+        creative_id = _create_creative(test_tenant, status="pending_review")
+
+        with (
+            patch(_SIDE_EFFECTS_PATCH),
+            patch(_PUSH_PATCH, return_value=(True, None)) as mock_push,
+        ):
+            response = client.post(
+                f"/tenant/{test_tenant}/creatives/review/{creative_id}/approve",
+                content_type="application/json",
+                json={},
+            )
+
+        assert response.status_code == 200
+        mock_push.assert_not_called()
+
+    def test_scheduled_buy_triggers_retroactive_push(self, client, test_tenant):
+        """Buys in 'scheduled' status (approved, not yet started) also get the push."""
+        _auth_session(client, test_tenant)
+        creative_id = _create_creative(test_tenant, status="pending_review")
+        media_buy_id, package_id = _create_active_media_buy(test_tenant, status="scheduled")
+        _create_assignment(test_tenant, creative_id, media_buy_id, package_id)
+
+        with (
+            patch(_SIDE_EFFECTS_PATCH),
+            patch(_PUSH_PATCH, return_value=(True, None)) as mock_push,
+        ):
+            response = client.post(
+                f"/tenant/{test_tenant}/creatives/review/{creative_id}/approve",
+                content_type="application/json",
+                json={},
+            )
+
+        assert response.status_code == 200
+        mock_push.assert_called_once_with(
+            creative_id=creative_id,
+            media_buy_id=media_buy_id,
+            tenant_id=test_tenant,
+        )
+
+    def test_paused_buy_triggers_retroactive_push(self, client, test_tenant):
+        """Buys in 'paused' status are live in the ad server and also get the push."""
+        _auth_session(client, test_tenant)
+        creative_id = _create_creative(test_tenant, status="pending_review")
+        media_buy_id, package_id = _create_active_media_buy(test_tenant, status="paused")
+        _create_assignment(test_tenant, creative_id, media_buy_id, package_id)
+
+        with (
+            patch(_SIDE_EFFECTS_PATCH),
+            patch(_PUSH_PATCH, return_value=(True, None)) as mock_push,
+        ):
+            response = client.post(
+                f"/tenant/{test_tenant}/creatives/review/{creative_id}/approve",
+                content_type="application/json",
+                json={},
+            )
+
+        assert response.status_code == 200
+        mock_push.assert_called_once_with(
+            creative_id=creative_id,
+            media_buy_id=media_buy_id,
+            tenant_id=test_tenant,
+        )
+
+    def test_pending_approval_buy_not_pushed(self, client, test_tenant):
+        """Buys in pending_approval (not yet sent to GAM) must not trigger push."""
+        _auth_session(client, test_tenant)
+        creative_id = _create_creative(test_tenant, status="pending_review")
+        media_buy_id, package_id = _create_active_media_buy(test_tenant, status="pending_approval")
+        _create_assignment(test_tenant, creative_id, media_buy_id, package_id)
+
+        with (
+            patch(_SIDE_EFFECTS_PATCH),
+            patch(_PUSH_PATCH, return_value=(True, None)) as mock_push,
+        ):
+            response = client.post(
+                f"/tenant/{test_tenant}/creatives/review/{creative_id}/approve",
+                content_type="application/json",
+                json={},
+            )
+
+        assert response.status_code == 200
+        mock_push.assert_not_called()
+
+
 class TestCreativeRejection:
     """Test creative rejection endpoint."""
 

--- a/tests/admin/test_creatives_blueprint.py
+++ b/tests/admin/test_creatives_blueprint.py
@@ -193,55 +193,66 @@ class TestCreativeApproval:
         assert response.status_code == 404
 
 
-def _create_active_media_buy(tenant_id: str, status: str = "active") -> tuple[str, str]:
-    """Create a media buy + package with a platform_order_id. Returns (media_buy_id, package_id)."""
+def _lookup_tenant_principal(session, tenant_id: str):
+    """Load tenant + principal created by the test_tenant fixture."""
     from sqlalchemy import select as sa_select
 
     from src.core.database.models import Principal as PrincipalModel
     from src.core.database.models import Tenant as TenantModel
+
+    tenant = session.scalars(sa_select(TenantModel).filter_by(tenant_id=tenant_id)).first()
+    principal = session.scalars(
+        sa_select(PrincipalModel).filter_by(tenant_id=tenant_id, principal_id=_PRINCIPAL_ID)
+    ).first()
+    return tenant, principal
+
+
+def _create_creative_for_retro_push(session, tenant_id: str, status: str = "pending_review") -> str:
+    """Create a creative via factories (requires factory_session fixture)."""
+    from tests.factories import CreativeFactory
+
+    tenant, principal = _lookup_tenant_principal(session, tenant_id)
+    creative = CreativeFactory(
+        tenant=tenant,
+        principal=principal,
+        status=status,
+        creative_id=f"cre_{uuid.uuid4().hex[:12]}",
+        name="Test Creative",
+        agent_url="https://creatives.example.com",
+        format="display_300x250_image",
+    )
+    return creative.creative_id
+
+
+def _create_active_media_buy(session, tenant_id: str, status: str = "active") -> tuple[str, str]:
+    """Create a media buy + package with a platform_order_id (requires factory_session)."""
     from tests.factories import MediaBuyFactory, MediaPackageFactory
 
-    with get_db_session() as session:
-        MediaBuyFactory._meta.sqlalchemy_session = session
-        MediaPackageFactory._meta.sqlalchemy_session = session
-
-        tenant = session.scalars(sa_select(TenantModel).filter_by(tenant_id=tenant_id)).first()
-        principal = session.scalars(
-            sa_select(PrincipalModel).filter_by(tenant_id=tenant_id, principal_id=_PRINCIPAL_ID)
-        ).first()
-
-        mb = MediaBuyFactory(tenant=tenant, principal=principal, status=status)
-        pkg = MediaPackageFactory(
-            media_buy=mb,
-            package_config={"platform_order_id": "gam_order_test", "platform_line_item_id": "gam_li_test"},
-        )
-        return mb.media_buy_id, pkg.package_id
+    tenant, principal = _lookup_tenant_principal(session, tenant_id)
+    mb = MediaBuyFactory(tenant=tenant, principal=principal, status=status)
+    pkg = MediaPackageFactory(
+        media_buy=mb,
+        package_config={"platform_order_id": "gam_order_test", "platform_line_item_id": "gam_li_test"},
+    )
+    return mb.media_buy_id, pkg.package_id
 
 
-def _create_assignment(tenant_id: str, creative_id: str, media_buy_id: str, package_id: str) -> str:
-    """Create a CreativeAssignment linking creative to media buy. Returns assignment_id."""
+def _create_assignment(session, tenant_id: str, creative_id: str, media_buy_id: str, package_id: str) -> str:
+    """Create a CreativeAssignment linking creative to media buy (requires factory_session)."""
     from sqlalchemy import select as sa_select
 
     from src.core.database.models import Creative as CreativeModel
     from src.core.database.models import MediaBuy as MediaBuyModel
     from tests.factories import CreativeAssignmentFactory
 
-    with get_db_session() as session:
-        CreativeAssignmentFactory._meta.sqlalchemy_session = session
-
-        creative = session.scalars(
-            sa_select(CreativeModel).filter_by(tenant_id=tenant_id, creative_id=creative_id)
-        ).first()
-        media_buy = session.scalars(
-            sa_select(MediaBuyModel).filter_by(tenant_id=tenant_id, media_buy_id=media_buy_id)
-        ).first()
-
-        asgn = CreativeAssignmentFactory(
-            creative=creative,
-            media_buy=media_buy,
-            package_id=package_id,
-        )
-        return asgn.assignment_id
+    creative = session.scalars(
+        sa_select(CreativeModel).filter_by(tenant_id=tenant_id, creative_id=creative_id)
+    ).first()
+    media_buy = session.scalars(
+        sa_select(MediaBuyModel).filter_by(tenant_id=tenant_id, media_buy_id=media_buy_id)
+    ).first()
+    asgn = CreativeAssignmentFactory(creative=creative, media_buy=media_buy, package_id=package_id)
+    return asgn.assignment_id
 
 
 _PUSH_PATCH = "src.core.tools.media_buy_create.push_creative_to_existing_buy"
@@ -250,12 +261,12 @@ _PUSH_PATCH = "src.core.tools.media_buy_create.push_creative_to_existing_buy"
 class TestCreativeApprovalRetroactivePush:
     """approve_creative triggers retroactive push for already-active media buys (#1038)."""
 
-    def test_active_buy_triggers_retroactive_push(self, client, test_tenant):
+    def test_active_buy_triggers_retroactive_push(self, client, test_tenant, factory_session):
         """Approving a creative assigned to an active buy calls push_creative_to_existing_buy."""
         _auth_session(client, test_tenant)
-        creative_id = _create_creative(test_tenant, status="pending_review")
-        media_buy_id, package_id = _create_active_media_buy(test_tenant, status="active")
-        _create_assignment(test_tenant, creative_id, media_buy_id, package_id)
+        creative_id = _create_creative_for_retro_push(factory_session, test_tenant, status="pending_review")
+        media_buy_id, package_id = _create_active_media_buy(factory_session, test_tenant, status="active")
+        _create_assignment(factory_session, test_tenant, creative_id, media_buy_id, package_id)
 
         with (
             patch(_SIDE_EFFECTS_PATCH),
@@ -274,12 +285,12 @@ class TestCreativeApprovalRetroactivePush:
             tenant_id=test_tenant,
         )
 
-    def test_pending_creatives_buy_not_retroactively_pushed(self, client, test_tenant):
+    def test_pending_creatives_buy_not_retroactively_pushed(self, client, test_tenant, factory_session):
         """Buys in pending_creatives status are handled by the existing loop, not the retroactive one."""
         _auth_session(client, test_tenant)
-        creative_id = _create_creative(test_tenant, status="pending_review")
-        media_buy_id, package_id = _create_active_media_buy(test_tenant, status="pending_creatives")
-        _create_assignment(test_tenant, creative_id, media_buy_id, package_id)
+        creative_id = _create_creative_for_retro_push(factory_session, test_tenant, status="pending_review")
+        media_buy_id, package_id = _create_active_media_buy(factory_session, test_tenant, status="pending_creatives")
+        _create_assignment(factory_session, test_tenant, creative_id, media_buy_id, package_id)
 
         with (
             patch(_SIDE_EFFECTS_PATCH),
@@ -294,12 +305,12 @@ class TestCreativeApprovalRetroactivePush:
         assert response.status_code == 200
         mock_push.assert_not_called()
 
-    def test_push_failure_returns_200_with_warnings(self, client, test_tenant):
+    def test_push_failure_returns_200_with_warnings(self, client, test_tenant, factory_session):
         """Push failure is non-fatal: response is 200 with a warnings field."""
         _auth_session(client, test_tenant)
-        creative_id = _create_creative(test_tenant, status="pending_review")
-        media_buy_id, package_id = _create_active_media_buy(test_tenant, status="active")
-        _create_assignment(test_tenant, creative_id, media_buy_id, package_id)
+        creative_id = _create_creative_for_retro_push(factory_session, test_tenant, status="pending_review")
+        media_buy_id, package_id = _create_active_media_buy(factory_session, test_tenant, status="active")
+        _create_assignment(factory_session, test_tenant, creative_id, media_buy_id, package_id)
 
         with (
             patch(_SIDE_EFFECTS_PATCH),
@@ -314,12 +325,13 @@ class TestCreativeApprovalRetroactivePush:
         assert response.status_code == 200
         data = response.get_json()
         assert data["success"] is True
-        assert any("GAM rejected" in w for w in data.get("warnings", []))
+        assert any("see server logs" in w for w in data.get("warnings", []))
+        assert not any("GAM rejected" in w for w in data.get("warnings", []))
 
-    def test_no_active_buy_no_push_called(self, client, test_tenant):
+    def test_no_active_buy_no_push_called(self, client, test_tenant, factory_session):
         """Approving a creative with no buy assignments does not call push."""
         _auth_session(client, test_tenant)
-        creative_id = _create_creative(test_tenant, status="pending_review")
+        creative_id = _create_creative_for_retro_push(factory_session, test_tenant, status="pending_review")
 
         with (
             patch(_SIDE_EFFECTS_PATCH),
@@ -334,12 +346,12 @@ class TestCreativeApprovalRetroactivePush:
         assert response.status_code == 200
         mock_push.assert_not_called()
 
-    def test_scheduled_buy_triggers_retroactive_push(self, client, test_tenant):
+    def test_scheduled_buy_triggers_retroactive_push(self, client, test_tenant, factory_session):
         """Buys in 'scheduled' status (approved, not yet started) also get the push."""
         _auth_session(client, test_tenant)
-        creative_id = _create_creative(test_tenant, status="pending_review")
-        media_buy_id, package_id = _create_active_media_buy(test_tenant, status="scheduled")
-        _create_assignment(test_tenant, creative_id, media_buy_id, package_id)
+        creative_id = _create_creative_for_retro_push(factory_session, test_tenant, status="pending_review")
+        media_buy_id, package_id = _create_active_media_buy(factory_session, test_tenant, status="scheduled")
+        _create_assignment(factory_session, test_tenant, creative_id, media_buy_id, package_id)
 
         with (
             patch(_SIDE_EFFECTS_PATCH),
@@ -358,12 +370,12 @@ class TestCreativeApprovalRetroactivePush:
             tenant_id=test_tenant,
         )
 
-    def test_paused_buy_triggers_retroactive_push(self, client, test_tenant):
+    def test_paused_buy_triggers_retroactive_push(self, client, test_tenant, factory_session):
         """Buys in 'paused' status are live in the ad server and also get the push."""
         _auth_session(client, test_tenant)
-        creative_id = _create_creative(test_tenant, status="pending_review")
-        media_buy_id, package_id = _create_active_media_buy(test_tenant, status="paused")
-        _create_assignment(test_tenant, creative_id, media_buy_id, package_id)
+        creative_id = _create_creative_for_retro_push(factory_session, test_tenant, status="pending_review")
+        media_buy_id, package_id = _create_active_media_buy(factory_session, test_tenant, status="paused")
+        _create_assignment(factory_session, test_tenant, creative_id, media_buy_id, package_id)
 
         with (
             patch(_SIDE_EFFECTS_PATCH),
@@ -382,12 +394,12 @@ class TestCreativeApprovalRetroactivePush:
             tenant_id=test_tenant,
         )
 
-    def test_pending_approval_buy_not_pushed(self, client, test_tenant):
+    def test_pending_approval_buy_not_pushed(self, client, test_tenant, factory_session):
         """Buys in pending_approval (not yet sent to GAM) must not trigger push."""
         _auth_session(client, test_tenant)
-        creative_id = _create_creative(test_tenant, status="pending_review")
-        media_buy_id, package_id = _create_active_media_buy(test_tenant, status="pending_approval")
-        _create_assignment(test_tenant, creative_id, media_buy_id, package_id)
+        creative_id = _create_creative_for_retro_push(factory_session, test_tenant, status="pending_review")
+        media_buy_id, package_id = _create_active_media_buy(factory_session, test_tenant, status="pending_approval")
+        _create_assignment(factory_session, test_tenant, creative_id, media_buy_id, package_id)
 
         with (
             patch(_SIDE_EFFECTS_PATCH),

--- a/tests/unit/test_architecture_no_raw_media_package_select.py
+++ b/tests/unit/test_architecture_no_raw_media_package_select.py
@@ -24,9 +24,8 @@ MEDIA_PACKAGE_MODELS = {"MediaPackage", "DBMediaPackage", "MediaPackageModel"}
 # These existed before the guard was created. Allowlist shrinks as they're fixed.
 # FIXME(salesagent-rva2): these should be migrated to repository calls
 ALLOWLIST = {
-    # media_buy_create.py — 2 raw selects missed by UoW migration (salesagent-0w1w)
+    # media_buy_create.py — raw select missed by UoW migration (salesagent-0w1w)
     ("src/core/tools/media_buy_create.py", "execute_approved_media_buy"),
-    ("src/core/tools/media_buy_create.py", "_create_media_buy_impl"),
 }
 
 EXPECTED_VIOLATION_COUNT = len(ALLOWLIST)

--- a/tests/unit/test_create_media_buy_behavioral.py
+++ b/tests/unit/test_create_media_buy_behavioral.py
@@ -210,6 +210,7 @@ class _PatchContext:
         mock_uow.session = self.db_session
         mock_media_buys = MagicMock()
         mock_media_buys.get_by_principal.return_value = []  # no duplicate buyer_refs
+        mock_media_buys.get_packages.return_value = []
         mock_uow.media_buys = mock_media_buys
 
         self._p_uow = patch("src.core.database.repositories.MediaBuyUoW", return_value=mock_uow)
@@ -576,10 +577,10 @@ class TestCreativeUploadFailure:
 
         with _PatchContext(products=[product]) as pc:
             # Override the scalars chain to handle multiple .all() and .first() calls.
-            # .all() call 1 (products query at line 1464) -> [product]
-            # .all() call 2 (creatives query at line 2954) -> [mock_creative]
-            # .first() calls: currency_limit (1554), adapter_config=None (1569),
-            #   package_record=None (2919), product_format_check=None (2986)
+            # .all() call 1 (products query) -> [product]
+            # .all() call 2 (creatives query) -> [mock_creative]
+            # platform_order_id persistence uses media_buys.get_packages() (not scalars)
+            # .first() calls: currency_limit, adapter_config=None, package_record=None, etc.
             all_results = iter([[product], [mock_creative]])
             first_results = iter([_mock_currency_limit(), None, None, None, None, None])
             scalars_mock = MagicMock()
@@ -888,8 +889,9 @@ class TestCreativeIdsNotFound:
 
         with _PatchContext(products=[product]) as pc:
             # Override the scalars chain to handle multiple .all() and .first() calls.
-            # .all() call 1 (products query at line 1464) -> [product]
-            # .all() call 2 (creatives query at line 2954) -> [mock_creative] (only 1 of 3)
+            # .all() call 1 (products query) -> [product]
+            # .all() call 2 (creatives query) -> [mock_creative] (only 1 of 3)
+            # platform_order_id persistence uses media_buys.get_packages() (not scalars)
             # .first() returns currency_limit then None for subsequent calls
             all_results = iter([[product], [mock_creative]])
             first_results = iter([_mock_currency_limit(), None, None, None, None, None])

--- a/tests/unit/test_execute_approved_pending_review_filter.py
+++ b/tests/unit/test_execute_approved_pending_review_filter.py
@@ -1,0 +1,115 @@
+"""Unit test: execute_approved_media_buy must skip pending_review creatives.
+
+Creatives in pending_review status at buy-approval time are held back from the
+ad server upload. They are pushed retroactively when the operator approves them
+via approve_creative (prebid#1038).
+"""
+
+from unittest.mock import MagicMock, patch
+
+_MODULE = "src.core.tools.media_buy_create"
+
+
+class TestExecuteApprovedPendingReviewFilter:
+    """execute_approved_media_buy skips pending_review creatives."""
+
+    def test_pending_review_creative_not_uploaded(self):
+        """A pending_review creative is excluded from the adapter asset list."""
+        from src.core.tools.media_buy_create import execute_approved_media_buy
+
+        # UoW chain: first UoW loads data, second updates status
+        uow1 = MagicMock()
+        uow1.__enter__ = MagicMock(return_value=uow1)
+        uow1.__exit__ = MagicMock(return_value=False)
+        uow1.session = MagicMock()
+        uow1.media_buys = MagicMock()
+
+        uow2 = MagicMock()
+        uow2.__enter__ = MagicMock(return_value=uow2)
+        uow2.__exit__ = MagicMock(return_value=False)
+        uow2.media_buys = MagicMock()
+
+        uow3 = MagicMock()
+        uow3.__enter__ = MagicMock(return_value=uow3)
+        uow3.__exit__ = MagicMock(return_value=False)
+        uow3.media_buys = MagicMock()
+
+        uow_iter = iter([uow1, uow2, uow3])
+
+        # Tenant
+        tenant = MagicMock()
+        tenant.tenant_id = "t1"
+        tenant.ad_server = "mock"
+
+        # Media buy
+        from datetime import UTC, datetime, timedelta
+        from decimal import Decimal
+
+        mb = MagicMock()
+        mb.media_buy_id = "mb_1"
+        mb.tenant_id = "t1"
+        mb.principal_id = "p1"
+        mb.status = "pending_approval"
+        mb.order_name = "Test"
+        mb.advertiser_name = "Advertiser"
+        mb.start_date = datetime.now(UTC).date()
+        mb.end_date = (datetime.now(UTC) + timedelta(days=7)).date()
+        mb.start_time = None
+        mb.end_time = None
+        mb.budget = Decimal("1000.00")
+        mb.currency = "USD"
+        mb.raw_request = {
+            "brand": {"domain": "test.com"},
+            "start_time": (datetime.now(UTC) + timedelta(days=1)).isoformat(),
+            "end_time": (datetime.now(UTC) + timedelta(days=8)).isoformat(),
+            "packages": [{"product_id": "prod_1", "pricing_option_id": "po_1", "budget": 1000.0}],
+        }
+
+        # Package
+        pkg = MagicMock()
+        pkg.package_id = "pkg_1"
+        pkg.package_config = {"product_id": "prod_1", "name": "Pkg", "budget": 1000.0, "pricing_model": "CPM"}
+
+        # Creative assignment — status is pending_review
+        assignment = MagicMock()
+        assignment.creative_id = "cre_pending"
+        assignment.package_id = "pkg_1"
+        assignment.weight = 100
+
+        pending_creative = MagicMock()
+        pending_creative.creative_id = "cre_pending"
+        pending_creative.status = "pending_review"
+
+        session = uow1.session
+        session.scalars.return_value.first.side_effect = [tenant, mb]
+        session.scalars.return_value.all.side_effect = [
+            [pkg],  # db_packages
+            [assignment],  # assignments
+            [pending_creative],  # creatives
+        ]
+
+        from src.core.schemas import CreateMediaBuySuccess, Principal
+
+        principal = Principal(principal_id="p1", name="Test", platform_mappings={})
+        adapter_response = CreateMediaBuySuccess(
+            media_buy_id="gam_order_1",
+            packages=[],
+        )
+
+        mock_adapter = MagicMock()
+        mock_adapter.creatives_manager = MagicMock()
+        mock_adapter.orders_manager.approve_order.return_value = True
+
+        with (
+            patch("src.core.database.repositories.MediaBuyUoW", side_effect=lambda _: next(uow_iter)),
+            patch("src.core.config_loader.set_current_tenant"),
+            patch("src.core.config_loader.get_tenant_by_id", return_value={"tenant_id": "t1"}),
+            patch(f"{_MODULE}.get_principal_object", return_value=principal),
+            patch(f"{_MODULE}._execute_adapter_media_buy_creation", return_value=adapter_response),
+            patch(f"{_MODULE}._validate_creatives_before_adapter_call"),
+            patch(f"{_MODULE}.get_adapter", return_value=mock_adapter),
+        ):
+            success, error = execute_approved_media_buy("mb_1", "t1")
+
+        # The pending_review creative must NOT have been uploaded
+        mock_adapter.creatives_manager.add_creative_assets.assert_not_called()

--- a/tests/unit/test_execute_approved_pending_review_filter.py
+++ b/tests/unit/test_execute_approved_pending_review_filter.py
@@ -113,3 +113,63 @@ class TestExecuteApprovedPendingReviewFilter:
 
         # The pending_review creative must NOT have been uploaded
         mock_adapter.creatives_manager.add_creative_assets.assert_not_called()
+
+
+class TestPersistAdapterPackageIds:
+    """_persist_adapter_package_ids must not overwrite mismatched platform_order_id."""
+
+    def test_refuses_to_overwrite_mismatched_platform_order_id(self):
+        from src.core.tools.media_buy_create import _persist_adapter_package_ids
+
+        pkg = MagicMock()
+        pkg.package_id = "pkg_1"
+        pkg.package_config = {"platform_order_id": "existing_gam_order"}
+
+        repo = MagicMock()
+        repo.get_packages.return_value = [pkg]
+
+        _persist_adapter_package_ids(
+            repo,
+            media_buy_id="mb_1",
+            platform_order_id="new_gam_order",
+            log_label="TEST",
+        )
+
+        assert pkg.package_config["platform_order_id"] == "existing_gam_order"
+
+    def test_writes_platform_order_id_when_unset(self):
+        from src.core.tools.media_buy_create import _persist_adapter_package_ids
+
+        pkg = MagicMock()
+        pkg.package_id = "pkg_1"
+        pkg.package_config = {}
+
+        repo = MagicMock()
+        repo.get_packages.return_value = [pkg]
+
+        _persist_adapter_package_ids(
+            repo,
+            media_buy_id="mb_1",
+            platform_order_id="gam_order_1",
+        )
+
+        assert pkg.package_config["platform_order_id"] == "gam_order_1"
+
+    def test_refuses_to_overwrite_mismatched_platform_line_item_id(self):
+        from src.core.tools.media_buy_create import _persist_adapter_package_ids
+
+        pkg = MagicMock()
+        pkg.package_id = "pkg_1"
+        pkg.package_config = {"platform_line_item_id": "existing_li"}
+
+        repo = MagicMock()
+        repo.get_packages.return_value = [pkg]
+
+        _persist_adapter_package_ids(
+            repo,
+            media_buy_id="mb_1",
+            platform_order_id="gam_order_1",
+            platform_line_item_ids={"pkg_1": "new_li"},
+        )
+
+        assert pkg.package_config["platform_line_item_id"] == "existing_li"

--- a/tests/unit/test_execute_approved_status_update.py
+++ b/tests/unit/test_execute_approved_status_update.py
@@ -106,10 +106,11 @@ class TestExecuteApprovedStatusUpdate:
         mock_adapter = MagicMock()
         mock_adapter.orders_manager = None
 
-        # Set up three UoW instances the function opens:
+        # Set up four UoW instances the function opens:
         # 1. Load tenant, media_buy, packages, products
-        # 2. Handle creative uploads
-        # 3. Update media buy status to 'active' (the fix)
+        # 2. Persist platform_order_id after adapter success
+        # 3. Handle creative uploads
+        # 4. Update media buy status to 'active' (the fix)
         mock_session_1 = MagicMock()
         mock_session_2 = MagicMock()
         mock_session_3 = MagicMock()
@@ -133,13 +134,20 @@ class TestExecuteApprovedStatusUpdate:
         mock_uow_1.session = mock_session_1
         mock_uow_1.media_buys = MagicMock()
 
+        mock_repo_plids = MagicMock()
+        mock_repo_plids.get_packages.return_value = [db_package]
+        mock_uow_plids = MagicMock()
+        mock_uow_plids.__enter__ = MagicMock(return_value=mock_uow_plids)
+        mock_uow_plids.__exit__ = MagicMock(return_value=None)
+        mock_uow_plids.media_buys = mock_repo_plids
+
         mock_uow_2 = MagicMock()
         mock_uow_2.__enter__ = MagicMock(return_value=mock_uow_2)
         mock_uow_2.__exit__ = MagicMock(return_value=None)
         mock_uow_2.session = mock_session_2
         mock_uow_2.media_buys = MagicMock()
 
-        # UoW 3 uses update_status on the repository — track it was called
+        # UoW 4 uses update_status on the repository — track it was called
         mock_repo_3 = MagicMock()
         mock_uow_3 = MagicMock()
         mock_uow_3.__enter__ = MagicMock(return_value=mock_uow_3)
@@ -147,7 +155,7 @@ class TestExecuteApprovedStatusUpdate:
         mock_uow_3.session = mock_session_3
         mock_uow_3.media_buys = mock_repo_3
 
-        uow_iter = iter([mock_uow_1, mock_uow_2, mock_uow_3])
+        uow_iter = iter([mock_uow_1, mock_uow_plids, mock_uow_2, mock_uow_3])
 
         with (
             patch("src.core.database.repositories.MediaBuyUoW", side_effect=lambda _: next(uow_iter)),

--- a/tests/unit/test_push_creative_to_existing_buy.py
+++ b/tests/unit/test_push_creative_to_existing_buy.py
@@ -1,0 +1,423 @@
+"""Unit tests: push_creative_to_existing_buy.
+
+Verifies the retroactive-push function that sends a single approved creative
+to an already-active ad server line item when it was held back at buy-approval
+time due to pending_review status (prebid#1038).
+"""
+
+from unittest.mock import ANY, MagicMock, patch
+
+# Patch targets
+_MODULE = "src.core.tools.media_buy_create"
+_UOW_PATCH = "src.core.database.repositories.uow.AdminCreativeUoW"
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _make_uow(*, tenant=None, creative=None, assignments=None, package=None):
+    """AdminCreativeUoW context manager with configurable repository returns."""
+    uow = MagicMock()
+    uow.tenant_config.get_tenant.return_value = tenant
+    uow.creatives.admin_get_by_id.return_value = creative
+    uow.assignments.get_by_creative.return_value = assignments if assignments is not None else []
+    uow.media_buys.get_package.return_value = package
+    uow.__enter__ = MagicMock(return_value=uow)
+    uow.__exit__ = MagicMock(return_value=False)
+    return uow
+
+
+def _make_tenant(tenant_id: str = "t1") -> MagicMock:
+    t = MagicMock()
+    t.tenant_id = tenant_id
+    t.ad_server = "mock"
+    return t
+
+
+def _make_creative(
+    creative_id: str = "cre_1",
+    principal_id: str = "p1",
+) -> MagicMock:
+    c = MagicMock()
+    c.creative_id = creative_id
+    c.principal_id = principal_id
+    c.format = "display_300x250_image"
+    c.agent_url = None
+    c.data = {}
+    c.name = "Test Creative"
+    return c
+
+
+def _make_assignment(
+    creative_id: str = "cre_1",
+    media_buy_id: str = "mb_1",
+    package_id: str = "pkg_1",
+) -> MagicMock:
+    a = MagicMock()
+    a.creative_id = creative_id
+    a.media_buy_id = media_buy_id
+    a.package_id = package_id
+    a.weight = 100
+    return a
+
+
+def _make_package(
+    package_id: str = "pkg_1",
+    platform_order_id: str = "gam_order_99",
+    platform_line_item_id: str = "gam_li_99",
+) -> MagicMock:
+    p = MagicMock()
+    p.package_id = package_id
+    p.package_config = {
+        "platform_order_id": platform_order_id,
+        "platform_line_item_id": platform_line_item_id,
+    }
+    return p
+
+
+def _make_adapter(*, status: str = "success") -> MagicMock:
+    asset_status = MagicMock()
+    asset_status.creative_id = "cre_1"
+    asset_status.status = status
+    asset_status.message = "Adapter error" if status == "failed" else None
+
+    adapter = MagicMock()
+    adapter.creatives_manager.add_creative_assets.return_value = [asset_status]
+    return adapter
+
+
+def _call(creative_id: str = "cre_1", media_buy_id: str = "mb_1", tenant_id: str = "t1"):
+    from src.core.tools.media_buy_create import push_creative_to_existing_buy
+
+    return push_creative_to_existing_buy(
+        creative_id=creative_id,
+        media_buy_id=media_buy_id,
+        tenant_id=tenant_id,
+    )
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+class TestPushCreativeToExistingBuy:
+    """push_creative_to_existing_buy sends an approved creative to a live buy."""
+
+    def test_happy_path_calls_adapter_returns_success(self):
+        """Adapter is called once with the GAM order ID; returns (True, None)."""
+        creative = _make_creative()
+        uow = _make_uow(
+            tenant=_make_tenant(),
+            creative=creative,
+            assignments=[_make_assignment()],
+            package=_make_package(),
+        )
+        mock_adapter = _make_adapter()
+
+        with (
+            patch(_UOW_PATCH, return_value=uow),
+            patch("src.core.config_loader.get_tenant_by_id", return_value=None),
+            patch("src.core.config_loader.set_current_tenant"),
+            patch(f"{_MODULE}.get_principal_object", return_value=MagicMock()),
+            patch(f"{_MODULE}.get_adapter", return_value=mock_adapter),
+            patch(
+                f"{_MODULE}.extract_media_url_and_dimensions", return_value=("https://ad.example.com/ad.jpg", 300, 250)
+            ),
+            patch(f"{_MODULE}.extract_click_url", return_value=None),
+            patch(f"{_MODULE}.extract_impression_tracker_url", return_value=None),
+        ):
+            success, err = _call()
+
+        assert success is True
+        assert err is None
+        mock_adapter.creatives_manager.add_creative_assets.assert_called_once_with(
+            "gam_order_99",  # GAM order ID from package_config["platform_order_id"]
+            ANY,  # assets list
+            ANY,  # datetime
+        )
+        uow.creatives.update_data.assert_called_once_with(
+            creative,
+            {"platform_creative_id": "cre_1"},
+        )
+
+    def test_happy_path_skips_platform_creative_id_when_already_set(self):
+        """Does not overwrite an existing platform_creative_id on the creative."""
+        creative = _make_creative()
+        creative.data = {"platform_creative_id": "existing_gam_id"}
+        uow = _make_uow(
+            tenant=_make_tenant(),
+            creative=creative,
+            assignments=[_make_assignment()],
+            package=_make_package(),
+        )
+        mock_adapter = _make_adapter()
+
+        with (
+            patch(_UOW_PATCH, return_value=uow),
+            patch("src.core.config_loader.get_tenant_by_id", return_value=None),
+            patch("src.core.config_loader.set_current_tenant"),
+            patch(f"{_MODULE}.get_principal_object", return_value=MagicMock()),
+            patch(f"{_MODULE}.get_adapter", return_value=mock_adapter),
+            patch(
+                f"{_MODULE}.extract_media_url_and_dimensions", return_value=("https://ad.example.com/ad.jpg", 300, 250)
+            ),
+            patch(f"{_MODULE}.extract_click_url", return_value=None),
+            patch(f"{_MODULE}.extract_impression_tracker_url", return_value=None),
+        ):
+            success, err = _call()
+
+        assert success is True
+        assert err is None
+        uow.creatives.update_data.assert_not_called()
+
+    def test_tenant_not_found_returns_failure(self):
+        """Returns (False, ...) when tenant lookup returns None."""
+        uow = _make_uow(tenant=None)
+        with patch(_UOW_PATCH, return_value=uow):
+            success, err = _call()
+
+        assert success is False
+        assert "Tenant" in err
+
+    def test_creative_not_found_returns_failure(self):
+        """Returns (False, ...) when creative does not exist for the tenant."""
+        uow = _make_uow(tenant=_make_tenant(), creative=None)
+        with (
+            patch(_UOW_PATCH, return_value=uow),
+            patch("src.core.config_loader.get_tenant_by_id", return_value=None),
+            patch("src.core.config_loader.set_current_tenant"),
+        ):
+            success, err = _call()
+
+        assert success is False
+        assert "Creative" in err
+
+    def test_assignment_not_found_returns_failure(self):
+        """Returns (False, ...) when no assignment links creative to the buy."""
+        uow = _make_uow(
+            tenant=_make_tenant(),
+            creative=_make_creative(),
+            assignments=[],  # no matching assignment
+        )
+        with (
+            patch(_UOW_PATCH, return_value=uow),
+            patch("src.core.config_loader.get_tenant_by_id", return_value=None),
+            patch("src.core.config_loader.set_current_tenant"),
+        ):
+            success, err = _call()
+
+        assert success is False
+        assert "assignment" in err.lower()
+
+    def test_package_not_found_returns_failure(self):
+        """Returns (False, ...) when no MediaPackage row exists for the buy."""
+        uow = _make_uow(
+            tenant=_make_tenant(),
+            creative=_make_creative(),
+            assignments=[_make_assignment()],
+            package=None,
+        )
+        with (
+            patch(_UOW_PATCH, return_value=uow),
+            patch("src.core.config_loader.get_tenant_by_id", return_value=None),
+            patch("src.core.config_loader.set_current_tenant"),
+            patch(f"{_MODULE}.get_principal_object", return_value=MagicMock()),
+            patch(f"{_MODULE}.get_adapter", return_value=_make_adapter()),
+        ):
+            success, err = _call()
+
+        assert success is False
+        assert "package" in err.lower()
+
+    def test_missing_platform_order_id_returns_failure(self):
+        """Returns (False, ...) when package_config has no platform_order_id.
+
+        Happens when the buy was never successfully pushed to the ad server.
+        """
+        pkg = MagicMock()
+        pkg.package_id = "pkg_1"
+        pkg.package_config = {}
+
+        uow = _make_uow(
+            tenant=_make_tenant(),
+            creative=_make_creative(),
+            assignments=[_make_assignment()],
+            package=pkg,
+        )
+        with (
+            patch(_UOW_PATCH, return_value=uow),
+            patch("src.core.config_loader.get_tenant_by_id", return_value=None),
+            patch("src.core.config_loader.set_current_tenant"),
+            patch(f"{_MODULE}.get_principal_object", return_value=MagicMock()),
+            patch(f"{_MODULE}.get_adapter", return_value=_make_adapter()),
+        ):
+            success, err = _call()
+
+        assert success is False
+        assert "platform_order_id" in err
+
+    def test_adapter_without_creatives_manager_returns_failure(self):
+        """Returns (False, ...) when adapter does not support creative upload."""
+        adapter = MagicMock(spec=[])  # no creatives_manager attribute
+
+        uow = _make_uow(
+            tenant=_make_tenant(),
+            creative=_make_creative(),
+            assignments=[_make_assignment()],
+            package=_make_package(),
+        )
+        with (
+            patch(_UOW_PATCH, return_value=uow),
+            patch("src.core.config_loader.get_tenant_by_id", return_value=None),
+            patch("src.core.config_loader.set_current_tenant"),
+            patch(f"{_MODULE}.get_principal_object", return_value=MagicMock()),
+            patch(f"{_MODULE}.get_adapter", return_value=adapter),
+        ):
+            success, err = _call()
+
+        assert success is False
+        assert "does not support" in err
+
+    def test_adapter_raises_returns_failure(self):
+        """Returns (False, error_str) when add_creative_assets raises."""
+        adapter = MagicMock()
+        adapter.creatives_manager.add_creative_assets.side_effect = RuntimeError("GAM timeout")
+
+        uow = _make_uow(
+            tenant=_make_tenant(),
+            creative=_make_creative(),
+            assignments=[_make_assignment()],
+            package=_make_package(),
+        )
+        with (
+            patch(_UOW_PATCH, return_value=uow),
+            patch("src.core.config_loader.get_tenant_by_id", return_value=None),
+            patch("src.core.config_loader.set_current_tenant"),
+            patch(f"{_MODULE}.get_principal_object", return_value=MagicMock()),
+            patch(f"{_MODULE}.get_adapter", return_value=adapter),
+            patch(
+                f"{_MODULE}.extract_media_url_and_dimensions", return_value=("https://ad.example.com/ad.jpg", 300, 250)
+            ),
+            patch(f"{_MODULE}.extract_click_url", return_value=None),
+            patch(f"{_MODULE}.extract_impression_tracker_url", return_value=None),
+        ):
+            success, err = _call()
+
+        assert success is False
+        assert "GAM timeout" in err
+
+    def test_adapter_returns_failed_status(self):
+        """Returns (False, message) when adapter reports a failed AssetStatus."""
+        adapter = _make_adapter(status="failed")
+
+        uow = _make_uow(
+            tenant=_make_tenant(),
+            creative=_make_creative(),
+            assignments=[_make_assignment()],
+            package=_make_package(),
+        )
+        with (
+            patch(_UOW_PATCH, return_value=uow),
+            patch("src.core.config_loader.get_tenant_by_id", return_value=None),
+            patch("src.core.config_loader.set_current_tenant"),
+            patch(f"{_MODULE}.get_principal_object", return_value=MagicMock()),
+            patch(f"{_MODULE}.get_adapter", return_value=adapter),
+            patch(
+                f"{_MODULE}.extract_media_url_and_dimensions", return_value=("https://ad.example.com/ad.jpg", 300, 250)
+            ),
+            patch(f"{_MODULE}.extract_click_url", return_value=None),
+            patch(f"{_MODULE}.extract_impression_tracker_url", return_value=None),
+        ):
+            success, err = _call()
+
+        assert success is False
+        assert err is not None
+
+    def test_missing_creative_dimensions_returns_failure(self):
+        """Returns (False, ...) when url/width/height cannot be extracted."""
+        uow = _make_uow(
+            tenant=_make_tenant(),
+            creative=_make_creative(),
+            assignments=[_make_assignment()],
+            package=_make_package(),
+        )
+        with (
+            patch(_UOW_PATCH, return_value=uow),
+            patch("src.core.config_loader.get_tenant_by_id", return_value=None),
+            patch("src.core.config_loader.set_current_tenant"),
+            patch(f"{_MODULE}.get_principal_object", return_value=MagicMock()),
+            patch(f"{_MODULE}.get_adapter", return_value=_make_adapter()),
+            patch(f"{_MODULE}.extract_media_url_and_dimensions", return_value=(None, None, None)),
+            patch(f"{_MODULE}.extract_click_url", return_value=None),
+            patch(f"{_MODULE}.extract_impression_tracker_url", return_value=None),
+        ):
+            success, err = _call()
+
+        assert success is False
+        assert "missing" in err.lower()
+
+    def test_adapter_no_status_for_creative_returns_failure(self):
+        """Returns (False, ...) when adapter returns no status entry for our creative."""
+        adapter = MagicMock()
+        adapter.creatives_manager.add_creative_assets.return_value = []  # empty — no status
+
+        uow = _make_uow(
+            tenant=_make_tenant(),
+            creative=_make_creative(),
+            assignments=[_make_assignment()],
+            package=_make_package(),
+        )
+        with (
+            patch(_UOW_PATCH, return_value=uow),
+            patch("src.core.config_loader.get_tenant_by_id", return_value=None),
+            patch("src.core.config_loader.set_current_tenant"),
+            patch(f"{_MODULE}.get_principal_object", return_value=MagicMock()),
+            patch(f"{_MODULE}.get_adapter", return_value=adapter),
+            patch(
+                f"{_MODULE}.extract_media_url_and_dimensions", return_value=("https://ad.example.com/ad.jpg", 300, 250)
+            ),
+            patch(f"{_MODULE}.extract_click_url", return_value=None),
+            patch(f"{_MODULE}.extract_impression_tracker_url", return_value=None),
+        ):
+            success, err = _call()
+
+        assert success is False
+        assert "did not report status" in err
+
+    def test_multi_package_all_assignments_included(self):
+        """All package assignments for the creative+buy are included in the asset dict."""
+        asgn1 = _make_assignment(package_id="pkg_1")
+        asgn2 = _make_assignment(package_id="pkg_2")
+
+        pkg1 = _make_package(package_id="pkg_1")
+        pkg2 = _make_package(package_id="pkg_2")
+
+        uow = _make_uow(
+            tenant=_make_tenant(),
+            creative=_make_creative(),
+            assignments=[asgn1, asgn2],
+        )
+        # get_package returns different packages per package_id
+        uow.media_buys.get_package.side_effect = lambda _buy, pkg_id: pkg1 if pkg_id == "pkg_1" else pkg2
+
+        mock_adapter = _make_adapter()
+
+        with (
+            patch(_UOW_PATCH, return_value=uow),
+            patch("src.core.config_loader.get_tenant_by_id", return_value=None),
+            patch("src.core.config_loader.set_current_tenant"),
+            patch(f"{_MODULE}.get_principal_object", return_value=MagicMock()),
+            patch(f"{_MODULE}.get_adapter", return_value=mock_adapter),
+            patch(
+                f"{_MODULE}.extract_media_url_and_dimensions", return_value=("https://ad.example.com/ad.jpg", 300, 250)
+            ),
+            patch(f"{_MODULE}.extract_click_url", return_value=None),
+            patch(f"{_MODULE}.extract_impression_tracker_url", return_value=None),
+        ):
+            success, err = _call()
+
+        assert success is True
+        call_args = mock_adapter.creatives_manager.add_creative_assets.call_args
+        assert call_args is not None, "add_creative_assets was not called"
+        _, assets_arg, *_ = call_args.args
+        package_ids = {pa["package_id"] for pa in assets_arg[0]["package_assignments"]}
+        assert package_ids == {"pkg_1", "pkg_2"}

--- a/tests/unit/test_push_creative_to_existing_buy.py
+++ b/tests/unit/test_push_creative_to_existing_buy.py
@@ -41,6 +41,7 @@ def _make_creative(
     c = MagicMock()
     c.creative_id = creative_id
     c.principal_id = principal_id
+    c.status = "approved"
     c.format = "display_300x250_image"
     c.agent_url = None
     c.data = {}
@@ -139,8 +140,8 @@ class TestPushCreativeToExistingBuy:
             {"platform_creative_id": "cre_1"},
         )
 
-    def test_happy_path_skips_platform_creative_id_when_already_set(self):
-        """Does not overwrite an existing platform_creative_id on the creative."""
+    def test_happy_path_skips_adapter_when_platform_creative_id_already_set(self):
+        """Does not call the adapter when platform_creative_id is already persisted."""
         creative = _make_creative()
         creative.data = {"platform_creative_id": "existing_gam_id"}
         uow = _make_uow(
@@ -155,18 +156,16 @@ class TestPushCreativeToExistingBuy:
             patch(_UOW_PATCH, return_value=uow),
             patch("src.core.config_loader.get_tenant_by_id", return_value=None),
             patch("src.core.config_loader.set_current_tenant"),
-            patch(f"{_MODULE}.get_principal_object", return_value=MagicMock()),
-            patch(f"{_MODULE}.get_adapter", return_value=mock_adapter),
-            patch(
-                f"{_MODULE}.extract_media_url_and_dimensions", return_value=("https://ad.example.com/ad.jpg", 300, 250)
-            ),
-            patch(f"{_MODULE}.extract_click_url", return_value=None),
-            patch(f"{_MODULE}.extract_impression_tracker_url", return_value=None),
+            patch(f"{_MODULE}.get_principal_object", return_value=MagicMock()) as mock_principal,
+            patch(f"{_MODULE}.get_adapter", return_value=mock_adapter) as mock_get_adapter,
         ):
             success, err = _call()
 
         assert success is True
         assert err is None
+        mock_principal.assert_not_called()
+        mock_get_adapter.assert_not_called()
+        mock_adapter.creatives_manager.add_creative_assets.assert_not_called()
         uow.creatives.update_data.assert_not_called()
 
     def test_tenant_not_found_returns_failure(self):
@@ -190,6 +189,26 @@ class TestPushCreativeToExistingBuy:
 
         assert success is False
         assert "Creative" in err
+
+    def test_pending_review_creative_returns_failure(self):
+        """Returns (False, ...) when creative is not yet approved."""
+        creative = _make_creative()
+        creative.status = "pending_review"
+        uow = _make_uow(
+            tenant=_make_tenant(),
+            creative=creative,
+            assignments=[_make_assignment()],
+            package=_make_package(),
+        )
+        with (
+            patch(_UOW_PATCH, return_value=uow),
+            patch("src.core.config_loader.get_tenant_by_id", return_value=None),
+            patch("src.core.config_loader.set_current_tenant"),
+        ):
+            success, err = _call()
+
+        assert success is False
+        assert "not approved" in err.lower()
 
     def test_assignment_not_found_returns_failure(self):
         """Returns (False, ...) when no assignment links creative to the buy."""


### PR DESCRIPTION
## Summary

- Hold back `pending_review` creatives from the initial ad-server upload when a media buy is approved; push them retroactively when the operator later approves the creative (`approve_creative` path).
- Add `push_creative_to_existing_buy()` plus shared helpers `_build_adapter_asset_from_creative()` and `_persist_adapter_package_ids()` so live buys can receive creatives after creative approval and packages retain `platform_order_id` for lookup.
- Hardening: skip adapter when `platform_creative_id` is already set (safe re-approve), mismatch guards on persisted adapter IDs, sanitized push-failure warnings, creative status guard, and admin tests via `factory_session`.

Related to #1038 — does not cover the `update_media_buy` creative_ids path.

## Test plan

- [x] `uv run pytest tests/unit/test_push_creative_to_existing_buy.py tests/unit/test_execute_approved_pending_review_filter.py tests/unit/test_execute_approved_status_update.py -q`
- [ ] `tox -e admin -- tests/admin/test_creatives_blueprint.py::TestCreativeApprovalRetroactivePush -q` (requires Docker/Postgres)
- [x] Manual: approve media buy with a `pending_review` creative → approve creative → confirm creative appears on live GAM line item

## Notes

- Legacy media buys missing `platform_order_id` in package config may need a one-time backfill before retroactive push works (follow-up, not in this PR).

Made with [Cursor](https://cursor.com)