### PR TITLE
fix(ci): pass GITHUB_TOKEN to pinact to avoid anonymous rate limit

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -71,6 +71,8 @@ jobs:
           grep "  ${PINACT_TARBALL}$" pinact_checksums.txt | sha256sum -c -
           tar -xzf "${PINACT_TARBALL}" -C /usr/local/bin/ pinact
           pinact run --check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   actionlint:
     name: actionlint (workflow expression lint)


### PR DESCRIPTION
Closes #1234.

Follow-up to #1338.

`pinact run --check` resolves action tag SHAs via the GitHub API. Without authentication it hits the 60 req/h anonymous limit (403 rate limit exceeded). Pass `GITHUB_TOKEN` so requests are authenticated (5000 req/h).

The `actions/checkout` version bump is handled separately by Dependabot PR #1342.