### PR TITLE
feat: add composition API product authoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,14 @@ RUN echo 'path-exclude /usr/share/doc/*' > /etc/dpkg/dpkg.cfg.d/01_nodoc && \
     echo 'path-exclude /usr/share/groff/*' >> /etc/dpkg/dpkg.cfg.d/01_nodoc && \
     echo 'path-exclude /usr/share/info/*' >> /etc/dpkg/dpkg.cfg.d/01_nodoc && \
     echo 'path-exclude /usr/share/lintian/*' >> /etc/dpkg/dpkg.cfg.d/01_nodoc && \
-    echo 'path-exclude /usr/share/linda/*' >> /etc/dpkg/dpkg.cfg.d/01_nodoc
+    echo 'path-exclude /usr/share/linda/*' >> /etc/dpkg/dpkg.cfg.d/01_nodoc && \
+    sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list.d/debian.sources
 
 # Install build dependencies in one layer
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update --error-on=any && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     gcc \
     libpq-dev \
     git
@@ -57,12 +59,14 @@ RUN echo 'path-exclude /usr/share/doc/*' > /etc/dpkg/dpkg.cfg.d/01_nodoc && \
     echo 'path-exclude /usr/share/groff/*' >> /etc/dpkg/dpkg.cfg.d/01_nodoc && \
     echo 'path-exclude /usr/share/info/*' >> /etc/dpkg/dpkg.cfg.d/01_nodoc && \
     echo 'path-exclude /usr/share/lintian/*' >> /etc/dpkg/dpkg.cfg.d/01_nodoc && \
-    echo 'path-exclude /usr/share/linda/*' >> /etc/dpkg/dpkg.cfg.d/01_nodoc
+    echo 'path-exclude /usr/share/linda/*' >> /etc/dpkg/dpkg.cfg.d/01_nodoc && \
+    sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list.d/debian.sources
 
 # Install runtime dependencies including nginx (no gcc/libpq-dev/git — build deps stay in builder)
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update --error-on=any && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     libpq5 \
     curl \
     nginx

--- a/alembic/versions/caf4f13c6f42_add_composition_inventory_signal_fields.py
+++ b/alembic/versions/caf4f13c6f42_add_composition_inventory_signal_fields.py
@@ -1,0 +1,56 @@
+"""add composition inventory and signal fields
+
+Revision ID: caf4f13c6f42
+Revises: b4e2bffdd4f8
+Create Date: 2026-05-22
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+from src.core.database.json_type import JSONType
+
+revision: str = "caf4f13c6f42"
+down_revision: str | Sequence[str] | None = "b4e2bffdd4f8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("inventory_profiles", sa.Column("constraints", JSONType, nullable=True))
+    op.add_column("inventory_profiles", sa.Column("etag", sa.String(length=64), nullable=True))
+
+    op.create_table(
+        "tenant_signals",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("tenant_id", sa.String(length=50), nullable=False),
+        sa.Column("signal_id", sa.String(length=200), nullable=False),
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("value_type", sa.String(length=32), nullable=False),
+        sa.Column("categories", JSONType, nullable=False, server_default=sa.text("'[]'::jsonb")),
+        sa.Column("tags", JSONType, nullable=False, server_default=sa.text("'[]'::jsonb")),
+        sa.Column("range_min", sa.DECIMAL(20, 6), nullable=True),
+        sa.Column("range_max", sa.DECIMAL(20, 6), nullable=True),
+        sa.Column("adapter_config", JSONType, nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("data_provider", sa.String(length=200), nullable=True),
+        sa.Column("targeting_dimension", sa.String(length=64), nullable=True),
+        sa.Column("etag", sa.String(length=64), nullable=True),
+        sa.Column("created_by", sa.String(length=255), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.tenant_id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("tenant_id", "signal_id", name="uq_tenant_signal"),
+    )
+    op.create_index("idx_tenant_signals_tenant", "tenant_signals", ["tenant_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_tenant_signals_tenant", table_name="tenant_signals")
+    op.drop_table("tenant_signals")
+    op.drop_column("inventory_profiles", "etag")
+    op.drop_column("inventory_profiles", "constraints")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "python-multipart>=0.0.27",  # GHSA-wp53-j4wj-2cfg + GHSA-mj87-hwqh-73pj + GHSA-pp6c-gr5w-3c5g
     "pyasn1>=0.6.3",  # GHSA-jr27-m4p2-rc6r
     "mako>=1.3.12",  # GHSA-2h4p-vjrc-8xpq (transitive via alembic)
+    "spectree>=2.0.1",
 ]
 
 

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -54,6 +54,24 @@ collect_reports() {
     return 0
 }
 
+needs_creative_agent() {
+    # Full local runs execute the creative suite, so they need the pinned
+    # reference creative agent. Targeted non-creative slices should not pay
+    # the Docker/memory cost for that unrelated sidecar.
+    [ -z "$PYTEST_TARGET" ] && return 0
+
+    local targeted_scope="${PYTEST_TARGET} ${PYTEST_ARGS}"
+    [[ "$targeted_scope" == *creative* ]]
+}
+
+CREATIVE_AGENT_STARTED=false
+cleanup_ci() {
+    if [ "$CREATIVE_AGENT_STARTED" = true ]; then
+        ./scripts/creative-agent-stack.sh down 2>/dev/null || true
+    fi
+    ./scripts/test-stack.sh down 2>/dev/null || true
+}
+
 # --- Quick mode (no Docker) ---
 if [ "$MODE" = "quick" ]; then
     validate_imports
@@ -81,15 +99,18 @@ elif [ "$MODE" = "ci" ]; then
     # Start Docker stack (writes .test-stack.env)
     ./scripts/test-stack.sh up
     source .test-stack.env
+    trap cleanup_ci EXIT
 
     # Pinned reference creative agent (salesagent-kczg): the authoritative run
     # must NOT silently hit the live public agent (its catalog drifts). This
     # mirrors the CI `creative` matrix group exactly — the commit pin is
     # single-sourced in scripts/creative-agent-stack.sh. Idempotent (reuses a
     # healthy stack across runs); torn down with the Docker stack on EXIT.
-    ./scripts/creative-agent-stack.sh up
-    export CREATIVE_AGENT_URL="$(./scripts/creative-agent-stack.sh url)"
-    trap './scripts/creative-agent-stack.sh down 2>/dev/null || true; ./scripts/test-stack.sh down 2>/dev/null || true' EXIT
+    if needs_creative_agent; then
+        ./scripts/creative-agent-stack.sh up
+        CREATIVE_AGENT_STARTED=true
+        export CREATIVE_AGENT_URL="$(./scripts/creative-agent-stack.sh url)"
+    fi
 
     if [ -n "$PYTEST_TARGET" ]; then
         # Targeted test run — see "set +eo pipefail / PIPESTATUS[0]" rationale in quick mode.

--- a/src/admin/api_schemas/__init__.py
+++ b/src/admin/api_schemas/__init__.py
@@ -1,0 +1,1 @@
+"""Pydantic schemas for admin REST APIs."""

--- a/src/admin/api_schemas/composition.py
+++ b/src/admin/api_schemas/composition.py
@@ -1,0 +1,439 @@
+"""Pydantic schemas for the Embedded Composition API (``/api/v1/...``).
+
+Server-to-server REST surface for operator-side authoring of:
+- Inventory profiles (operator declares the inventory that backs wholesale
+  Products in their catalog).
+- Tenant signals (operator declares adapter targeting capabilities; surface
+  through the AdCP ``get_signals`` tool).
+- Advertiser mappings (``AccountReference`` → adapter advertiser routing).
+
+Storefront discovery + composition itself runs through standard AdCP tools
+(``get_products``, ``get_signals``, ``create_media_buy``) — there is no
+separate "compose product" write on this surface. See
+``.context/embedded-composition-design.md``.
+
+Adapter-agnostic at the boundary:
+- ``InventoryProfileRead`` exposes only AdCP-vocab metadata to the
+  storefront. Adapter-specific ``inventory_config`` is operator-authored
+  on Create/Update.
+- ``TenantSignalRead`` mirrors AdCP's existing ``Signal`` shape
+  (``value_type``, ``categories``, ``range``). The opaque
+  ``adapter_config`` resolution map is operator-authored on Create/Update
+  only.
+- Advertiser-mapping bodies use ``AccountPattern`` — same field names as
+  AdCP ``AccountReference``, with ``brand`` optional for wildcards.
+
+All schemas follow the project ``get_pydantic_extra_mode()`` convention:
+forbid unknown fields in dev/CI, ignore them in production.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from src.core.config import get_pydantic_extra_mode
+
+_EXTRA_MODE = get_pydantic_extra_mode()
+
+
+def _config() -> ConfigDict:
+    return ConfigDict(extra=_EXTRA_MODE)
+
+
+# ---------------------------------------------------------------------------
+# Capability narrowings (AdCP-vocab; storefront-visible)
+# ---------------------------------------------------------------------------
+
+
+class ProfileConstraints(BaseModel):
+    """Typed AdCP capability narrowings on an inventory profile.
+
+    Vocabulary references the agent's declared ``DecisioningCapabilities``;
+    profiles express narrowings, never redeclarations. Lets the storefront
+    pre-validate ``(inventory ∩ signal_selections ∩ buyer_targeting)``
+    client-side.
+    """
+
+    model_config = _config()
+
+    formats: list[str] = Field(default_factory=list, description="Allowed AdCP format ids")
+    channels: list[str] = Field(default_factory=list, description="Allowed AdCP channel names")
+    targeting_dimensions: list[str] = Field(
+        default_factory=list,
+        description="AdCP-standard targeting-dimension names usable on this inventory",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Inventory profiles
+# ---------------------------------------------------------------------------
+
+
+class InventoryProfileCreate(BaseModel):
+    """Operator-authored. Includes the adapter-shaped ``inventory_config``
+    blob (GAM placements, FW sites, Broadstreet zones, …) and the
+    AdCP-vocab ``constraints`` narrowings."""
+
+    model_config = _config()
+
+    profile_id: str = Field(..., min_length=1, max_length=100)
+    name: str = Field(..., min_length=1, max_length=200)
+    description: str | None = None
+    inventory_config: dict = Field(
+        default_factory=dict,
+        description=(
+            "Adapter-specific inventory selection. Operator-authored, opaque to the "
+            "storefront. Shape depends on tenant.ad_server (GAM: {ad_units, placements, "
+            "include_descendants}; Freewheel: {site_ids, video_group_ids, ...}; "
+            "Broadstreet: {zone_ids}; etc.)."
+        ),
+    )
+    format_ids: list[dict] = Field(default_factory=list)
+    publisher_properties: list[dict] = Field(default_factory=list)
+    targeting_template: dict | None = None
+    constraints: ProfileConstraints | None = None
+
+
+class InventoryProfileUpdate(BaseModel):
+    model_config = _config()
+
+    name: str | None = Field(default=None, min_length=1, max_length=200)
+    description: str | None = None
+    inventory_config: dict | None = None
+    format_ids: list[dict] | None = None
+    publisher_properties: list[dict] | None = None
+    targeting_template: dict | None = None
+    constraints: ProfileConstraints | None = None
+
+
+class InventoryProfileRead(BaseModel):
+    """Storefront-facing read. AdCP-vocab metadata only — no adapter-shaped
+    fields. Operators that need to inspect the underlying ``inventory_config``
+    can use the admin UI; this surface is for storefront discovery and
+    composition."""
+
+    model_config = _config()
+
+    profile_id: str
+    name: str
+    description: str | None
+    constraints: ProfileConstraints | None
+    etag: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class InventoryProfileListResponse(BaseModel):
+    model_config = _config()
+    inventory_profiles: list[InventoryProfileRead]
+
+
+# ---------------------------------------------------------------------------
+# Products — profile-backed wholesale catalog entries
+# ---------------------------------------------------------------------------
+
+
+_DELIVERY_TYPE = Literal["guaranteed", "non_guaranteed"]
+_PRICING_MODEL = Literal["cpm"]
+
+
+class ProductPricingOptionWrite(BaseModel):
+    """Pricing option persisted with a profile-backed product."""
+
+    model_config = _config()
+
+    pricing_model: _PRICING_MODEL = "cpm"
+    currency: str = Field(default="USD", min_length=3, max_length=3)
+    is_fixed: bool = False
+    rate: Decimal | None = Field(
+        default=None,
+        description="Fixed price for fixed options. Optional for auction CPM/VCPM/CPC with price_guidance.",
+    )
+    price_guidance: dict | None = Field(
+        default=None,
+        description="Auction guidance; CPM/VCPM/CPC auction options require this, e.g. {floor, p50, p75}.",
+    )
+    parameters: dict | None = None
+    min_spend_per_package: Decimal | None = None
+
+    @model_validator(mode="after")
+    def _validate_price_shape(self) -> ProductPricingOptionWrite:
+        if self.is_fixed and self.rate is None:
+            raise ValueError("fixed pricing options require rate")
+        if not self.is_fixed and self.pricing_model == "cpm" and not self.price_guidance:
+            raise ValueError("auction cpm pricing options require price_guidance")
+        return self
+
+
+class ProductCreate(BaseModel):
+    """Create a profile-backed wholesale product.
+
+    The product points at an existing ``InventoryProfile.profile_id``. The
+    profile owns inventory, formats, and publisher properties; this payload owns
+    the sellable catalog metadata and pricing.
+    """
+
+    model_config = _config()
+
+    product_id: str = Field(..., min_length=1, max_length=100)
+    name: str = Field(..., min_length=1, max_length=200)
+    description: str | None = None
+    inventory_profile_id: str = Field(..., min_length=1, max_length=100)
+    delivery_type: _DELIVERY_TYPE = "non_guaranteed"
+    pricing_options: list[ProductPricingOptionWrite] = Field(..., min_length=1)
+    countries: list[str] | None = None
+    channels: list[str] | None = None
+    property_targeting_allowed: bool = False
+    signal_targeting_allowed: bool = True
+    allowed_principal_ids: list[str] | None = None
+    catalog_match: dict | None = None
+    catalog_types: list[str] | None = None
+    data_provider_signals: list[dict] | None = None
+    forecast: dict | None = None
+
+
+class ProductUpdate(BaseModel):
+    model_config = _config()
+
+    name: str | None = Field(default=None, min_length=1, max_length=200)
+    description: str | None = None
+    inventory_profile_id: str | None = Field(default=None, min_length=1, max_length=100)
+    delivery_type: _DELIVERY_TYPE | None = None
+    pricing_options: list[ProductPricingOptionWrite] | None = Field(default=None, min_length=1)
+    countries: list[str] | None = None
+    channels: list[str] | None = None
+    property_targeting_allowed: bool | None = None
+    signal_targeting_allowed: bool | None = None
+    allowed_principal_ids: list[str] | None = None
+    catalog_match: dict | None = None
+    catalog_types: list[str] | None = None
+    data_provider_signals: list[dict] | None = None
+    forecast: dict | None = None
+
+
+class ProductPricingOptionRead(BaseModel):
+    model_config = _config()
+
+    pricing_option_id: str
+    pricing_model: str
+    currency: str
+    is_fixed: bool
+    rate: Decimal | None
+    price_guidance: dict | None
+    parameters: dict | None
+    min_spend_per_package: Decimal | None
+
+
+class ProductRead(BaseModel):
+    model_config = _config()
+
+    product_id: str
+    name: str
+    description: str | None
+    inventory_profile_id: str | None
+    delivery_type: str
+    pricing_options: list[ProductPricingOptionRead]
+    countries: list[str] | None
+    channels: list[str] | None
+    property_targeting_allowed: bool
+    signal_targeting_allowed: bool | None
+    allowed_principal_ids: list[str] | None
+    catalog_match: dict | None
+    catalog_types: list[str] | None
+    data_provider_signals: list[dict] | None
+    forecast: dict | None
+
+
+class ProductListResponse(BaseModel):
+    model_config = _config()
+    products: list[ProductRead]
+
+
+# ---------------------------------------------------------------------------
+# Tenant signals — operator's map of adapter targeting capabilities
+# ---------------------------------------------------------------------------
+
+
+_SIGNAL_VALUE_TYPE = Literal["binary", "categorical", "numeric"]
+
+
+class SignalRange(BaseModel):
+    """Numeric bounds for a ``value_type='numeric'`` signal."""
+
+    model_config = _config()
+
+    min: Decimal | None = None
+    max: Decimal | None = None
+
+
+class TenantSignalCreate(BaseModel):
+    """Operator-authored. ``adapter_config`` is the opaque resolution map
+    consumed by the per-adapter materializer at compose time."""
+
+    model_config = _config()
+
+    signal_id: str = Field(..., min_length=1, max_length=200)
+    name: str = Field(..., min_length=1, max_length=200)
+    description: str | None = None
+    value_type: _SIGNAL_VALUE_TYPE
+    categories: list[str] = Field(default_factory=list, description="Taxonomy when value_type='categorical'")
+    range: SignalRange | None = Field(default=None, description="Bounds when value_type='numeric'")
+    adapter_config: dict = Field(
+        default_factory=dict,
+        description=(
+            "Adapter-specific resolution map. Operator-authored, opaque to storefront. "
+            "Examples: GAM custom KV → {kind: 'custom_key_value', key_id: '...', value_ids: {...}}; "
+            "GAM audience → {kind: 'audience_segment', segment_id: '...'}; "
+            "Freewheel → {kind: 'audience_item', audience_item_id: '...'}."
+        ),
+    )
+    data_provider: str | None = None
+    targeting_dimension: str | None = Field(
+        default=None,
+        description="AdCP-standard dimension this signal narrows (audience, contextual, weather, ...)",
+    )
+
+
+class TenantSignalUpdate(BaseModel):
+    model_config = _config()
+
+    name: str | None = Field(default=None, min_length=1, max_length=200)
+    description: str | None = None
+    value_type: _SIGNAL_VALUE_TYPE | None = None
+    categories: list[str] | None = None
+    range: SignalRange | None = None
+    adapter_config: dict | None = None
+    data_provider: str | None = None
+    targeting_dimension: str | None = None
+
+
+class TenantSignalRead(BaseModel):
+    """Storefront-facing read. Mirrors AdCP ``Signal`` vocabulary — no
+    ``adapter_config`` echo. Storefront uses ``value_type`` + ``categories`` /
+    ``range`` to render UI."""
+
+    model_config = _config()
+
+    signal_id: str
+    name: str
+    description: str | None
+    value_type: _SIGNAL_VALUE_TYPE
+    categories: list[str]
+    range: SignalRange | None
+    data_provider: str | None
+    targeting_dimension: str | None
+    etag: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class TenantSignalListResponse(BaseModel):
+    model_config = _config()
+    signals: list[TenantSignalRead]
+
+
+# ---------------------------------------------------------------------------
+# Advertiser mappings (operator + brand → adapter advertiser routing)
+# ---------------------------------------------------------------------------
+
+
+class AccountBrandPattern(BaseModel):
+    """Brand component of an :class:`AccountPattern`. Same field names as AdCP
+    ``BrandReference`` (``domain``, ``brand_id``) but both are optional so a
+    routing rule can wildcard the brand house, the brand id, or both."""
+
+    model_config = _config()
+
+    domain: str | None = Field(default=None, max_length=255)
+    brand_id: str | None = Field(default=None, max_length=255)
+
+
+class AccountPattern(BaseModel):
+    """Routing-rule pattern over an AdCP account.
+
+    Structurally mirrors ``AccountReference`` (operator + brand + sandbox)
+    so the storefront can paste the same shape it uses on
+    ``create_media_buy`` — but ``brand`` is optional here, and components
+    inside ``brand`` are individually optional, because routing rules
+    treat NULL columns as wildcards per the existing resolution chain
+    (exact → house wildcard → operator wildcard → tenant default).
+
+    Strict AccountReference targeting one account uses every field; routing
+    patterns may leave some absent.
+    """
+
+    model_config = _config()
+
+    operator: str = Field(..., min_length=1, max_length=255)
+    brand: AccountBrandPattern | None = None
+    sandbox: bool = False
+
+
+class AdvertiserMappingCreate(BaseModel):
+    """Route buys carrying ``account: AccountReference`` to a specific adapter
+    advertiser. The natural key is ``account`` (operator + brand + sandbox);
+    NULL components on ``brand`` act as wildcards.
+    """
+
+    model_config = _config()
+
+    account: AccountPattern
+    adapter_advertiser_id: str = Field(..., min_length=1, max_length=64)
+
+
+class AdvertiserMappingUpdate(BaseModel):
+    model_config = _config()
+
+    adapter_advertiser_id: str | None = Field(default=None, min_length=1, max_length=64)
+
+
+class AdvertiserMappingRead(BaseModel):
+    model_config = _config()
+
+    mapping_id: str
+    account: AccountPattern
+    adapter_advertiser_id: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class AdvertiserMappingListResponse(BaseModel):
+    model_config = _config()
+    advertiser_mappings: list[AdvertiserMappingRead]
+
+
+class AdvertiserSummary(BaseModel):
+    """Entry in the synced adapter-advertiser cache. Read-only mirror of the
+    operator's GAM (or other adapter) advertiser list."""
+
+    model_config = _config()
+
+    adapter_advertiser_id: str
+    name: str
+    status: str
+    currency_code: str | None = None
+    synced_at: datetime
+
+
+class AdvertiserListResponse(BaseModel):
+    model_config = _config()
+    advertisers: list[AdvertiserSummary]
+
+
+# ---------------------------------------------------------------------------
+# Generic error envelope
+# ---------------------------------------------------------------------------
+
+
+class ApiError(BaseModel):
+    """Generic error envelope mirroring ``tenant_management.ApiError``."""
+
+    model_config = _config()
+
+    error: str
+    message: str
+    details: dict | None = None

--- a/src/admin/app.py
+++ b/src/admin/app.py
@@ -38,6 +38,7 @@ from src.admin.blueprints.signals_agents import signals_agents_bp
 from src.admin.blueprints.tenants import tenants_bp
 from src.admin.blueprints.users import users_bp
 from src.admin.blueprints.workflows import workflows_bp
+from src.admin.composition_api import composition_api
 from src.core.config_loader import is_single_tenant_mode
 from src.core.domain_config import (
     get_session_cookie_domain,
@@ -368,6 +369,8 @@ def create_app(config=None):
         app.register_blueprint(tenant_management_api)
     except ImportError:
         logger.warning("tenant_management_api blueprint not found")
+
+    app.register_blueprint(composition_api)
 
     try:
         from src.admin.sync_api import sync_api

--- a/src/admin/auth_helpers.py
+++ b/src/admin/auth_helpers.py
@@ -72,3 +72,15 @@ def require_api_key_auth(*, env_var: str, config_key: str, header: str) -> Any:
         return decorated_function
 
     return decorator
+
+
+def protect_docs_with_api_key(auth_decorator: Any) -> Any | None:
+    """Apply an API-key decorator to Spectree docs routes only."""
+    if "/docs/" not in request.path:
+        return None
+
+    @auth_decorator
+    def _authorized() -> None:
+        return None
+
+    return _authorized()

--- a/src/admin/composition_api.py
+++ b/src/admin/composition_api.py
@@ -1,0 +1,736 @@
+"""Embedded Composition API — REST blueprint at ``/api/v1/tenants/<tenant_id>/...``.
+
+Server-to-server surface for an embedding storefront (e.g. Scope3) to author
+the primitives an AdCP buyer composes against: inventory profiles, tenant
+signals (operator's map of adapter targeting capabilities), and advertiser
+mappings.
+
+Auth: same operator/wrapper API key as the Tenant Management API
+(``X-Tenant-Management-API-Key``). No new MCP tools — REST only.
+
+AdCP-pure composition: discovery and composition happen through the
+standard AdCP tools (``get_products``, ``get_signals``, ``create_media_buy``)
+— not through a parallel "compose product" surface. The storefront treats
+us like any other AdCP agent:
+
+- Operator authors a non-guaranteed ``Product`` with a floor-priced
+  ``PricingOption`` and an ``InventoryProfile`` — this is the wholesale /
+  composable product. It shows up in ``get_products`` like any other
+  catalog entry.
+- Operator authors ``TenantSignal`` rows declaring adapter capabilities
+  (custom KVs, audiences, …). These surface through the AdCP
+  ``get_signals`` tool — same wire shape as third-party signals agents.
+- Storefront composes by building a ``CreateMediaBuyRequest``: picks a
+  wholesale product, layers signals in ``PackageRequest.targeting_overlay``,
+  layers optimization in ``optimization_goals`` / ``performance_standards``
+  / ``pacing`` / ``bid_price``, sets the agreed price in ``budget`` /
+  ``bid_price`` against the product's ``PricingOption``.
+- This blueprint is OPERATOR-AUTHORING ONLY. Storefront discovery flows
+  through AdCP tools; storefront purchase flows through
+  ``create_media_buy``. No separate compose write.
+
+In embedded mode the host (storefront) is the only agent. The sales
+agent never receives requests directly from a buyer.
+
+See ``.context/embedded-composition-design.md``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+from flask import Blueprint, jsonify, request
+from spectree import Response, SpecTree
+from sqlalchemy.exc import IntegrityError
+
+from src.admin.api_schemas.composition import (
+    ApiError,
+    InventoryProfileCreate,
+    InventoryProfileListResponse,
+    InventoryProfileRead,
+    InventoryProfileUpdate,
+    ProductCreate,
+    ProductListResponse,
+    ProductPricingOptionWrite,
+    ProductRead,
+    ProductUpdate,
+    SignalRange,
+    TenantSignalCreate,
+    TenantSignalListResponse,
+    TenantSignalRead,
+    TenantSignalUpdate,
+)
+from src.admin.auth_helpers import protect_docs_with_api_key, require_api_key_auth
+from src.core.database.database_session import get_db_session
+from src.core.database.models import (
+    InventoryProfile,
+    PricingOption,
+    Product,
+    Tenant,
+    TenantSignal,
+)
+from src.core.database.repositories.inventory_profile import InventoryProfileRepository
+from src.core.database.repositories.product import ProductRepository
+from src.core.database.repositories.tenant_signal import TenantSignalRepository
+
+logger = logging.getLogger(__name__)
+
+composition_api = Blueprint(
+    "composition_api",
+    __name__,
+    url_prefix="/api/v1",
+)
+
+spec = SpecTree(
+    "flask",
+    title="Sales Agent - Composition API",
+    version="v1",
+    path="docs",
+    openapi_url_prefix="",
+)
+
+COMPOSITION_API_ROUTE_CONTRACT: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("GET", "/api/v1/tenants/<tenant_id>/inventory-profiles"),
+        ("POST", "/api/v1/tenants/<tenant_id>/inventory-profiles"),
+        ("GET", "/api/v1/tenants/<tenant_id>/inventory-profiles/<profile_id>"),
+        ("PUT", "/api/v1/tenants/<tenant_id>/inventory-profiles/<profile_id>"),
+        ("DELETE", "/api/v1/tenants/<tenant_id>/inventory-profiles/<profile_id>"),
+        ("GET", "/api/v1/tenants/<tenant_id>/products"),
+        ("POST", "/api/v1/tenants/<tenant_id>/products"),
+        ("GET", "/api/v1/tenants/<tenant_id>/products/<product_id>"),
+        ("PUT", "/api/v1/tenants/<tenant_id>/products/<product_id>"),
+        ("DELETE", "/api/v1/tenants/<tenant_id>/products/<product_id>"),
+        ("GET", "/api/v1/tenants/<tenant_id>/signals"),
+        ("POST", "/api/v1/tenants/<tenant_id>/signals"),
+        ("GET", "/api/v1/tenants/<tenant_id>/signals/<signal_id>"),
+        ("PUT", "/api/v1/tenants/<tenant_id>/signals/<signal_id>"),
+        ("DELETE", "/api/v1/tenants/<tenant_id>/signals/<signal_id>"),
+    }
+)
+
+require_composition_api_key = require_api_key_auth(
+    env_var="TENANT_MANAGEMENT_API_KEY",
+    config_key="tenant_management_api_key",
+    header="X-Tenant-Management-API-Key",
+)
+
+
+@composition_api.before_request
+def protect_composition_docs():
+    """Apply management API-key auth to Spectree docs mounted on this blueprint."""
+    return protect_docs_with_api_key(require_composition_api_key)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _api_error(code: str, message: str, status: int, details: dict | None = None):
+    body = ApiError(error=code, message=message, details=details).model_dump(exclude_none=True)
+    return jsonify(body), status
+
+
+def _parse_updated_since() -> datetime | None:
+    raw = request.args.get("updated_since")
+    if raw is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _compute_etag(payload: Any) -> str:
+    raw = json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()[:32]
+
+
+def _maybe_304(etag: str):
+    inm = request.headers.get("If-None-Match")
+    if inm and inm.strip('"') == etag:
+        return ("", 304, {"ETag": f'"{etag}"'})
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Inventory profiles (operator authoring)
+# ---------------------------------------------------------------------------
+
+
+def _inventory_profile_to_read(profile: InventoryProfile) -> dict:
+    """Storefront-facing read. Adapter-shaped fields (``inventory_config``,
+    ``format_ids``, ``publisher_properties``, ``targeting_template``) are
+    intentionally omitted — operators manage them, storefront composes
+    against the AdCP-vocab metadata only."""
+    return InventoryProfileRead(
+        profile_id=profile.profile_id,
+        name=profile.name,
+        description=profile.description,
+        constraints=profile.constraints,
+        etag=profile.etag,
+        created_at=profile.created_at,
+        updated_at=profile.updated_at,
+    ).model_dump(mode="json")
+
+
+def _refresh_inventory_profile_etag(profile: InventoryProfile) -> None:
+    profile.etag = _compute_etag(_inventory_profile_to_read(profile))
+
+
+@composition_api.route("/tenants/<tenant_id>/inventory-profiles", methods=["GET"])
+@require_composition_api_key
+@spec.validate(resp=Response(HTTP_200=InventoryProfileListResponse, HTTP_304=None, HTTP_404=ApiError))
+def list_inventory_profiles(tenant_id: str):
+    with get_db_session() as session:
+        if session.get(Tenant, tenant_id) is None:
+            return _api_error("tenant_not_found", f"Tenant {tenant_id!r} not found.", 404)
+        repo = InventoryProfileRepository(session, tenant_id)
+        profiles = repo.list_all(updated_since=_parse_updated_since())
+        items = [_inventory_profile_to_read(p) for p in profiles]
+        body = InventoryProfileListResponse(inventory_profiles=items).model_dump(mode="json")
+        etag = _compute_etag(body)
+        not_modified = _maybe_304(etag)
+        if not_modified:
+            return not_modified
+        return jsonify(body), 200, {"ETag": f'"{etag}"'}
+
+
+@composition_api.route("/tenants/<tenant_id>/inventory-profiles/<profile_id>", methods=["GET"])
+@require_composition_api_key
+@spec.validate(resp=Response(HTTP_200=InventoryProfileRead, HTTP_304=None, HTTP_404=ApiError))
+def get_inventory_profile(tenant_id: str, profile_id: str):
+    with get_db_session() as session:
+        if session.get(Tenant, tenant_id) is None:
+            return _api_error("tenant_not_found", f"Tenant {tenant_id!r} not found.", 404)
+        repo = InventoryProfileRepository(session, tenant_id)
+        profile = repo.get_by_id(profile_id)
+        if profile is None:
+            return _api_error(
+                "inventory_profile_not_found",
+                f"Inventory profile {profile_id!r} not found.",
+                404,
+            )
+        body = _inventory_profile_to_read(profile)
+        etag = profile.etag or _compute_etag(body)
+        not_modified = _maybe_304(etag)
+        if not_modified:
+            return not_modified
+        return jsonify(body), 200, {"ETag": f'"{etag}"'}
+
+
+@composition_api.route("/tenants/<tenant_id>/inventory-profiles", methods=["POST"])
+@require_composition_api_key
+@spec.validate(
+    json=InventoryProfileCreate,
+    resp=Response(
+        HTTP_201=InventoryProfileRead,
+        HTTP_400=ApiError,
+        HTTP_404=ApiError,
+        HTTP_409=ApiError,
+        HTTP_422=None,
+    ),
+)
+def create_inventory_profile(tenant_id: str):
+    try:
+        payload = InventoryProfileCreate.model_validate(request.get_json() or {})
+    except Exception as exc:
+        return _api_error("invalid_request", str(exc), 400)
+
+    with get_db_session() as session:
+        if session.get(Tenant, tenant_id) is None:
+            return _api_error("tenant_not_found", f"Tenant {tenant_id!r} not found.", 404)
+        repo = InventoryProfileRepository(session, tenant_id)
+        if repo.get_by_id(payload.profile_id) is not None:
+            return _api_error(
+                "conflict",
+                f"Inventory profile {payload.profile_id!r} already exists.",
+                409,
+            )
+        profile = InventoryProfile(
+            tenant_id=tenant_id,
+            profile_id=payload.profile_id,
+            name=payload.name,
+            description=payload.description,
+            inventory_config=payload.inventory_config,
+            format_ids=payload.format_ids,
+            publisher_properties=payload.publisher_properties,
+            targeting_template=payload.targeting_template,
+            constraints=payload.constraints.model_dump() if payload.constraints else None,
+        )
+        repo.add(profile)
+        session.flush()
+        _refresh_inventory_profile_etag(profile)
+        session.commit()
+        body = _inventory_profile_to_read(profile)
+        return jsonify(body), 201, {"ETag": f'"{profile.etag}"'}
+
+
+@composition_api.route("/tenants/<tenant_id>/inventory-profiles/<profile_id>", methods=["PUT"])
+@require_composition_api_key
+@spec.validate(
+    json=InventoryProfileUpdate,
+    resp=Response(HTTP_200=InventoryProfileRead, HTTP_400=ApiError, HTTP_404=ApiError, HTTP_422=None),
+)
+def update_inventory_profile(tenant_id: str, profile_id: str):
+    try:
+        payload = InventoryProfileUpdate.model_validate(request.get_json() or {})
+    except Exception as exc:
+        return _api_error("invalid_request", str(exc), 400)
+
+    with get_db_session() as session:
+        if session.get(Tenant, tenant_id) is None:
+            return _api_error("tenant_not_found", f"Tenant {tenant_id!r} not found.", 404)
+        repo = InventoryProfileRepository(session, tenant_id)
+        profile = repo.get_by_id(profile_id)
+        if profile is None:
+            return _api_error(
+                "inventory_profile_not_found",
+                f"Inventory profile {profile_id!r} not found.",
+                404,
+            )
+        for field in (
+            "name",
+            "description",
+            "inventory_config",
+            "format_ids",
+            "publisher_properties",
+            "targeting_template",
+        ):
+            value = getattr(payload, field)
+            if value is not None:
+                setattr(profile, field, value)
+        if payload.constraints is not None:
+            profile.constraints = payload.constraints.model_dump()
+        _refresh_inventory_profile_etag(profile)
+        session.commit()
+        return jsonify(_inventory_profile_to_read(profile)), 200, {"ETag": f'"{profile.etag}"'}
+
+
+@composition_api.route("/tenants/<tenant_id>/inventory-profiles/<profile_id>", methods=["DELETE"])
+@require_composition_api_key
+@spec.validate(resp=Response(HTTP_204=None, HTTP_404=ApiError))
+def delete_inventory_profile(tenant_id: str, profile_id: str):
+    with get_db_session() as session:
+        if session.get(Tenant, tenant_id) is None:
+            return _api_error("tenant_not_found", f"Tenant {tenant_id!r} not found.", 404)
+        repo = InventoryProfileRepository(session, tenant_id)
+        profile = repo.get_by_id(profile_id)
+        if profile is None:
+            return _api_error(
+                "inventory_profile_not_found",
+                f"Inventory profile {profile_id!r} not found.",
+                404,
+            )
+        repo.delete(profile)
+        session.commit()
+        return "", 204
+
+
+# ---------------------------------------------------------------------------
+# Products (profile-backed wholesale catalog entries)
+# ---------------------------------------------------------------------------
+
+
+def _pricing_option_id(option: PricingOption) -> str:
+    fixed_suffix = "fixed" if option.is_fixed else "auction"
+    return f"{option.pricing_model.lower()}_{option.currency.lower()}_{fixed_suffix}"
+
+
+def _pricing_option_to_read(option: PricingOption) -> dict:
+    return {
+        "pricing_option_id": _pricing_option_id(option),
+        "pricing_model": option.pricing_model,
+        "currency": option.currency,
+        "is_fixed": option.is_fixed,
+        "rate": option.rate,
+        "price_guidance": option.price_guidance,
+        "parameters": option.parameters,
+        "min_spend_per_package": option.min_spend_per_package,
+    }
+
+
+def _product_to_read(product: Product) -> dict:
+    profile = product.inventory_profile
+    return ProductRead(
+        product_id=product.product_id,
+        name=product.name,
+        description=product.description,
+        inventory_profile_id=profile.profile_id if profile else None,
+        delivery_type=product.delivery_type,
+        pricing_options=[_pricing_option_to_read(po) for po in product.pricing_options],
+        countries=product.countries,
+        channels=product.channels,
+        property_targeting_allowed=product.property_targeting_allowed,
+        signal_targeting_allowed=product.signal_targeting_allowed,
+        allowed_principal_ids=product.allowed_principal_ids,
+        catalog_match=product.catalog_match,
+        catalog_types=product.catalog_types,
+        data_provider_signals=product.data_provider_signals,
+        forecast=product.forecast,
+    ).model_dump(mode="json")
+
+
+def _pricing_options_from_payload(
+    tenant_id: str, product_id: str, payload_options: list[ProductPricingOptionWrite]
+) -> list[PricingOption]:
+    return [
+        PricingOption(
+            tenant_id=tenant_id,
+            product_id=product_id,
+            pricing_model=option.pricing_model,
+            rate=Decimal(option.rate) if option.rate is not None else None,
+            currency=option.currency.upper(),
+            is_fixed=option.is_fixed,
+            price_guidance=option.price_guidance,
+            parameters=option.parameters,
+            min_spend_per_package=(
+                Decimal(option.min_spend_per_package) if option.min_spend_per_package is not None else None
+            ),
+        )
+        for option in payload_options
+    ]
+
+
+def _get_required_inventory_profile(session, tenant_id: str, profile_id: str):
+    profile = InventoryProfileRepository(session, tenant_id).get_by_id(profile_id)
+    if profile is None:
+        return None, _api_error(
+            "inventory_profile_not_found",
+            f"Inventory profile {profile_id!r} not found.",
+            404,
+        )
+    return profile, None
+
+
+@composition_api.route("/tenants/<tenant_id>/products", methods=["GET"])
+@require_composition_api_key
+@spec.validate(resp=Response(HTTP_200=ProductListResponse, HTTP_404=ApiError))
+def list_products(tenant_id: str):
+    with get_db_session() as session:
+        if session.get(Tenant, tenant_id) is None:
+            return _api_error("tenant_not_found", f"Tenant {tenant_id!r} not found.", 404)
+        products = ProductRepository(session, tenant_id).list_all()
+        return jsonify(
+            ProductListResponse(products=[_product_to_read(p) for p in products]).model_dump(mode="json")
+        ), 200
+
+
+@composition_api.route("/tenants/<tenant_id>/products/<product_id>", methods=["GET"])
+@require_composition_api_key
+@spec.validate(resp=Response(HTTP_200=ProductRead, HTTP_404=ApiError))
+def get_product(tenant_id: str, product_id: str):
+    with get_db_session() as session:
+        if session.get(Tenant, tenant_id) is None:
+            return _api_error("tenant_not_found", f"Tenant {tenant_id!r} not found.", 404)
+        product = ProductRepository(session, tenant_id).get_by_id_with_pricing(product_id)
+        if product is None:
+            return _api_error("product_not_found", f"Product {product_id!r} not found.", 404)
+        return jsonify(_product_to_read(product)), 200
+
+
+@composition_api.route("/tenants/<tenant_id>/products", methods=["POST"])
+@require_composition_api_key
+@spec.validate(
+    json=ProductCreate,
+    resp=Response(HTTP_201=ProductRead, HTTP_400=ApiError, HTTP_404=ApiError, HTTP_409=ApiError, HTTP_422=None),
+)
+def create_product(tenant_id: str):
+    payload: ProductCreate = request.context.json  # type: ignore[attr-defined]
+
+    with get_db_session() as session:
+        if session.get(Tenant, tenant_id) is None:
+            return _api_error("tenant_not_found", f"Tenant {tenant_id!r} not found.", 404)
+        repo = ProductRepository(session, tenant_id)
+        if repo.get_by_id(payload.product_id) is not None:
+            return _api_error("conflict", f"Product {payload.product_id!r} already exists.", 409)
+        profile, error = _get_required_inventory_profile(session, tenant_id, payload.inventory_profile_id)
+        if error is not None:
+            return error
+        assert profile is not None
+
+        product = Product(
+            tenant_id=tenant_id,
+            product_id=payload.product_id,
+            name=payload.name,
+            description=payload.description,
+            format_ids=[],
+            targeting_template={},
+            delivery_type=payload.delivery_type,
+            property_tags=["all_inventory"],
+            inventory_profile_id=profile.id,
+            delivery_measurement={"provider": "publisher"},
+            property_targeting_allowed=payload.property_targeting_allowed,
+            signal_targeting_allowed=payload.signal_targeting_allowed,
+            countries=payload.countries,
+            channels=payload.channels,
+            allowed_principal_ids=payload.allowed_principal_ids,
+            catalog_match=payload.catalog_match,
+            catalog_types=payload.catalog_types,
+            data_provider_signals=payload.data_provider_signals,
+            forecast=payload.forecast,
+        )
+        repo.create(product)
+        repo.replace_pricing_options(
+            product,
+            _pricing_options_from_payload(tenant_id, payload.product_id, payload.pricing_options),
+        )
+        try:
+            session.commit()
+        except IntegrityError as exc:
+            session.rollback()
+            return _api_error("conflict", str(exc), 409)
+        return jsonify(_product_to_read(product)), 201
+
+
+@composition_api.route("/tenants/<tenant_id>/products/<product_id>", methods=["PUT"])
+@require_composition_api_key
+@spec.validate(
+    json=ProductUpdate, resp=Response(HTTP_200=ProductRead, HTTP_400=ApiError, HTTP_404=ApiError, HTTP_422=None)
+)
+def update_product(tenant_id: str, product_id: str):
+    payload: ProductUpdate = request.context.json  # type: ignore[attr-defined]
+
+    with get_db_session() as session:
+        if session.get(Tenant, tenant_id) is None:
+            return _api_error("tenant_not_found", f"Tenant {tenant_id!r} not found.", 404)
+        repo = ProductRepository(session, tenant_id)
+        product = repo.get_by_id_with_pricing(product_id)
+        if product is None:
+            return _api_error("product_not_found", f"Product {product_id!r} not found.", 404)
+
+        fields_set = payload.model_fields_set
+        for field in (
+            "name",
+            "description",
+            "delivery_type",
+            "countries",
+            "channels",
+            "property_targeting_allowed",
+            "signal_targeting_allowed",
+            "allowed_principal_ids",
+            "catalog_match",
+            "catalog_types",
+            "data_provider_signals",
+            "forecast",
+        ):
+            if field in fields_set:
+                setattr(product, field, getattr(payload, field))
+        if "inventory_profile_id" in fields_set:
+            if payload.inventory_profile_id is None:
+                return _api_error(
+                    "invalid_request",
+                    "inventory_profile_id cannot be null for profile-backed products.",
+                    400,
+                )
+            profile, error = _get_required_inventory_profile(session, tenant_id, payload.inventory_profile_id)
+            if error is not None:
+                return error
+            assert profile is not None
+            product.inventory_profile_id = profile.id
+        if payload.pricing_options is not None:
+            repo.replace_pricing_options(
+                product,
+                _pricing_options_from_payload(tenant_id, product.product_id, payload.pricing_options),
+            )
+        session.commit()
+        return jsonify(_product_to_read(product)), 200
+
+
+@composition_api.route("/tenants/<tenant_id>/products/<product_id>", methods=["DELETE"])
+@require_composition_api_key
+@spec.validate(resp=Response(HTTP_204=None, HTTP_404=ApiError))
+def delete_product(tenant_id: str, product_id: str):
+    with get_db_session() as session:
+        if session.get(Tenant, tenant_id) is None:
+            return _api_error("tenant_not_found", f"Tenant {tenant_id!r} not found.", 404)
+        repo = ProductRepository(session, tenant_id)
+        product = repo.get_by_id(product_id)
+        if product is None:
+            return _api_error("product_not_found", f"Product {product_id!r} not found.", 404)
+        repo.delete(product)
+        session.commit()
+        return "", 204
+
+
+# ---------------------------------------------------------------------------
+# Tenant signals (operator-authored capability map)
+#
+# Storefront DISCOVERY flows through the AdCP ``get_signals`` tool (wired
+# elsewhere to read ``tenant_signals`` + any registered external
+# ``SignalsAgent`` rows). The endpoints below are operator-authoring —
+# they include ``adapter_config`` (opaque to storefront) on Create/Update.
+# GET surfaces here are storefront-friendly (no adapter_config echo) but
+# operators may use them for inspection.
+# ---------------------------------------------------------------------------
+
+
+def _signal_range(signal: TenantSignal) -> SignalRange | None:
+    if signal.range_min is None and signal.range_max is None:
+        return None
+    return SignalRange(min=signal.range_min, max=signal.range_max)
+
+
+def _signal_to_read(signal: TenantSignal) -> dict:
+    return TenantSignalRead(
+        signal_id=signal.signal_id,
+        name=signal.name,
+        description=signal.description,
+        value_type=signal.value_type,
+        categories=list(signal.categories or []),
+        range=_signal_range(signal),
+        data_provider=signal.data_provider,
+        targeting_dimension=signal.targeting_dimension,
+        etag=signal.etag,
+        created_at=signal.created_at,
+        updated_at=signal.updated_at,
+    ).model_dump(mode="json")
+
+
+def _refresh_signal_etag(signal: TenantSignal) -> None:
+    signal.etag = _compute_etag(_signal_to_read(signal))
+
+
+@composition_api.route("/tenants/<tenant_id>/signals", methods=["GET"])
+@require_composition_api_key
+@spec.validate(resp=Response(HTTP_200=TenantSignalListResponse, HTTP_304=None, HTTP_404=ApiError))
+def list_signals(tenant_id: str):
+    with get_db_session() as session:
+        if session.get(Tenant, tenant_id) is None:
+            return _api_error("tenant_not_found", f"Tenant {tenant_id!r} not found.", 404)
+        repo = TenantSignalRepository(session, tenant_id)
+        rows = repo.list_all(updated_since=_parse_updated_since())
+        items = [_signal_to_read(s) for s in rows]
+        body = TenantSignalListResponse(signals=items).model_dump(mode="json")
+        etag = _compute_etag(body)
+        not_modified = _maybe_304(etag)
+        if not_modified:
+            return not_modified
+        return jsonify(body), 200, {"ETag": f'"{etag}"'}
+
+
+@composition_api.route("/tenants/<tenant_id>/signals/<signal_id>", methods=["GET"])
+@require_composition_api_key
+@spec.validate(resp=Response(HTTP_200=TenantSignalRead, HTTP_304=None, HTTP_404=ApiError))
+def get_signal(tenant_id: str, signal_id: str):
+    with get_db_session() as session:
+        if session.get(Tenant, tenant_id) is None:
+            return _api_error("tenant_not_found", f"Tenant {tenant_id!r} not found.", 404)
+        signal = TenantSignalRepository(session, tenant_id).get_by_id(signal_id)
+        if signal is None:
+            return _api_error("signal_not_found", f"Signal {signal_id!r} not found.", 404)
+        body = _signal_to_read(signal)
+        etag = signal.etag or _compute_etag(body)
+        not_modified = _maybe_304(etag)
+        if not_modified:
+            return not_modified
+        return jsonify(body), 200, {"ETag": f'"{etag}"'}
+
+
+@composition_api.route("/tenants/<tenant_id>/signals", methods=["POST"])
+@require_composition_api_key
+@spec.validate(
+    json=TenantSignalCreate,
+    resp=Response(HTTP_201=TenantSignalRead, HTTP_400=ApiError, HTTP_404=ApiError, HTTP_409=ApiError, HTTP_422=None),
+)
+def create_signal(tenant_id: str):
+    try:
+        payload = TenantSignalCreate.model_validate(request.get_json() or {})
+    except Exception as exc:
+        return _api_error("invalid_request", str(exc), 400)
+
+    with get_db_session() as session:
+        if session.get(Tenant, tenant_id) is None:
+            return _api_error("tenant_not_found", f"Tenant {tenant_id!r} not found.", 404)
+        repo = TenantSignalRepository(session, tenant_id)
+        if repo.get_by_id(payload.signal_id) is not None:
+            return _api_error("conflict", f"Signal {payload.signal_id!r} already exists.", 409)
+        signal = TenantSignal(
+            tenant_id=tenant_id,
+            signal_id=payload.signal_id,
+            name=payload.name,
+            description=payload.description,
+            value_type=payload.value_type,
+            categories=list(payload.categories),
+            range_min=payload.range.min if payload.range else None,
+            range_max=payload.range.max if payload.range else None,
+            adapter_config=payload.adapter_config,
+            data_provider=payload.data_provider,
+            targeting_dimension=payload.targeting_dimension,
+        )
+        repo.add(signal)
+        session.flush()
+        _refresh_signal_etag(signal)
+        session.commit()
+        return jsonify(_signal_to_read(signal)), 201, {"ETag": f'"{signal.etag}"'}
+
+
+@composition_api.route("/tenants/<tenant_id>/signals/<signal_id>", methods=["PUT"])
+@require_composition_api_key
+@spec.validate(
+    json=TenantSignalUpdate,
+    resp=Response(HTTP_200=TenantSignalRead, HTTP_400=ApiError, HTTP_404=ApiError, HTTP_422=None),
+)
+def update_signal(tenant_id: str, signal_id: str):
+    try:
+        payload = TenantSignalUpdate.model_validate(request.get_json() or {})
+    except Exception as exc:
+        return _api_error("invalid_request", str(exc), 400)
+
+    with get_db_session() as session:
+        if session.get(Tenant, tenant_id) is None:
+            return _api_error("tenant_not_found", f"Tenant {tenant_id!r} not found.", 404)
+        repo = TenantSignalRepository(session, tenant_id)
+        signal = repo.get_by_id(signal_id)
+        if signal is None:
+            return _api_error("signal_not_found", f"Signal {signal_id!r} not found.", 404)
+        if payload.name is not None:
+            signal.name = payload.name
+        if payload.description is not None:
+            signal.description = payload.description
+        if payload.value_type is not None:
+            signal.value_type = payload.value_type
+        if payload.categories is not None:
+            signal.categories = list(payload.categories)
+        if payload.range is not None:
+            signal.range_min = payload.range.min
+            signal.range_max = payload.range.max
+        if payload.adapter_config is not None:
+            signal.adapter_config = payload.adapter_config
+        if payload.data_provider is not None:
+            signal.data_provider = payload.data_provider
+        if payload.targeting_dimension is not None:
+            signal.targeting_dimension = payload.targeting_dimension
+        _refresh_signal_etag(signal)
+        session.commit()
+        return jsonify(_signal_to_read(signal)), 200, {"ETag": f'"{signal.etag}"'}
+
+
+@composition_api.route("/tenants/<tenant_id>/signals/<signal_id>", methods=["DELETE"])
+@require_composition_api_key
+@spec.validate(resp=Response(HTTP_204=None, HTTP_404=ApiError))
+def delete_signal(tenant_id: str, signal_id: str):
+    with get_db_session() as session:
+        if session.get(Tenant, tenant_id) is None:
+            return _api_error("tenant_not_found", f"Tenant {tenant_id!r} not found.", 404)
+        repo = TenantSignalRepository(session, tenant_id)
+        signal = repo.get_by_id(signal_id)
+        if signal is None:
+            return _api_error("signal_not_found", f"Signal {signal_id!r} not found.", 404)
+        repo.delete(signal)
+        session.commit()
+        return "", 204
+
+
+# Register all spectree-validated composition routes with the shared OpenAPI
+# generator used by the tenant-management API docs.
+spec.register(composition_api)

--- a/src/core/database/models.py
+++ b/src/core/database/models.py
@@ -1373,6 +1373,10 @@ class InventoryProfile(Base, JSONValidatorMixin):
     # Structure: AdCP targeting object
     targeting_template: Mapped[dict | None] = mapped_column(JSONType, nullable=True)
 
+    # Typed AdCP capability narrowings used by the embedded composition API.
+    constraints: Mapped[dict | None] = mapped_column(JSONType, nullable=True)
+    etag: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
     # Optional GAM integration
     gam_preset_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
     gam_preset_sync_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
@@ -1390,6 +1394,43 @@ class InventoryProfile(Base, JSONValidatorMixin):
     __table_args__ = (
         UniqueConstraint("tenant_id", "profile_id", name="uq_inventory_profile"),
         Index("idx_inventory_profiles_tenant", "tenant_id"),
+    )
+
+
+class TenantSignal(Base, JSONValidatorMixin):
+    """Operator-authored map of one adapter targeting capability."""
+
+    __tablename__ = "tenant_signals"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    tenant_id: Mapped[str] = mapped_column(
+        String(50),
+        ForeignKey("tenants.tenant_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    signal_id: Mapped[str] = mapped_column(String(200), nullable=False)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    value_type: Mapped[str] = mapped_column(String(32), nullable=False)
+    categories: Mapped[list[str]] = mapped_column(JSONType, nullable=False, default=list)
+    tags: Mapped[list[str]] = mapped_column(JSONType, nullable=False, default=list)
+    range_min: Mapped[Decimal | None] = mapped_column(DECIMAL(20, 6), nullable=True)
+    range_max: Mapped[Decimal | None] = mapped_column(DECIMAL(20, 6), nullable=True)
+    adapter_config: Mapped[dict] = mapped_column(JSONType, nullable=False, default=dict)
+    data_provider: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    targeting_dimension: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    etag: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    created_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=func.now(), onupdate=func.now()
+    )
+
+    tenant = relationship("Tenant")
+
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "signal_id", name="uq_tenant_signal"),
+        Index("idx_tenant_signals_tenant", "tenant_id"),
     )
 
 

--- a/src/core/database/repositories/inventory_profile.py
+++ b/src/core/database/repositories/inventory_profile.py
@@ -1,0 +1,46 @@
+"""InventoryProfile repository -- tenant-scoped data access."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.core.database.models import InventoryProfile
+
+
+class InventoryProfileRepository:
+    """Tenant-scoped data access for InventoryProfile."""
+
+    def __init__(self, session: Session, tenant_id: str) -> None:
+        self._session = session
+        self._tenant_id = tenant_id
+
+    def get_by_id(self, profile_id: str) -> InventoryProfile | None:
+        return self._session.scalars(
+            select(InventoryProfile).where(
+                InventoryProfile.tenant_id == self._tenant_id,
+                InventoryProfile.profile_id == profile_id,
+            )
+        ).first()
+
+    def list_all(self, updated_since: datetime | None = None) -> list[InventoryProfile]:
+        stmt = select(InventoryProfile).where(InventoryProfile.tenant_id == self._tenant_id)
+        if updated_since is not None:
+            stmt = stmt.where(InventoryProfile.updated_at > updated_since)
+        return list(self._session.scalars(stmt.order_by(InventoryProfile.profile_id)).all())
+
+    def add(self, profile: InventoryProfile) -> None:
+        if profile.tenant_id != self._tenant_id:
+            raise ValueError(
+                f"tenant mismatch: profile.tenant_id={profile.tenant_id!r} != repo tenant_id={self._tenant_id!r}"
+            )
+        self._session.add(profile)
+
+    def delete(self, profile: InventoryProfile) -> None:
+        if profile.tenant_id != self._tenant_id:
+            raise ValueError(
+                f"tenant mismatch: profile.tenant_id={profile.tenant_id!r} != repo tenant_id={self._tenant_id!r}"
+            )
+        self._session.delete(profile)

--- a/src/core/database/repositories/product.py
+++ b/src/core/database/repositories/product.py
@@ -137,6 +137,62 @@ class ProductRepository:
         self._session.flush()
         return product
 
+    def delete(self, product: Product) -> None:
+        """Delete a product within this tenant."""
+        if product.tenant_id != self._tenant_id:
+            raise ValueError(
+                f"Tenant mismatch: product.tenant_id={product.tenant_id!r} != repository tenant_id={self._tenant_id!r}"
+            )
+        self._session.delete(product)
+        self._session.flush()
+
+    def replace_pricing_options(self, product: Product, pricing_options: list[PricingOption]) -> None:
+        """Replace a product's pricing options with tenant-scoped rows.
+
+        Updates existing rows before adding/removing rows so the database
+        trigger that prevents products from ever having zero pricing options
+        is not tripped during replacement.
+        """
+        if product.tenant_id != self._tenant_id:
+            raise ValueError(
+                f"Tenant mismatch: product.tenant_id={product.tenant_id!r} != repository tenant_id={self._tenant_id!r}"
+            )
+        for option in pricing_options:
+            self._validate_pricing_option(product, option)
+
+        existing_options = list(product.pricing_options or [])
+        for idx, option in enumerate(pricing_options):
+            if idx < len(existing_options):
+                self._copy_pricing_option_fields(existing_options[idx], option)
+            else:
+                self._session.add(option)
+
+        for option in existing_options[len(pricing_options) :]:
+            self._session.delete(option)
+        self._session.flush()
+
+    def _validate_pricing_option(self, product: Product, option: PricingOption) -> None:
+        if option.tenant_id != self._tenant_id:
+            raise ValueError(
+                f"Tenant mismatch: pricing_option.tenant_id={option.tenant_id!r} "
+                f"!= repository tenant_id={self._tenant_id!r}"
+            )
+        if option.product_id != product.product_id:
+            raise ValueError(
+                f"Product mismatch: pricing_option.product_id={option.product_id!r} "
+                f"!= product.product_id={product.product_id!r}"
+            )
+
+    @staticmethod
+    def _copy_pricing_option_fields(target: PricingOption, source: PricingOption) -> None:
+        target.pricing_model = source.pricing_model
+        target.rate = source.rate
+        target.currency = source.currency
+        target.is_fixed = source.is_fixed
+        target.price_guidance = source.price_guidance
+        target.parameters = source.parameters
+        target.min_spend_per_package = source.min_spend_per_package
+
     def update_fields(self, product_id: str, **kwargs: Any) -> Product | None:
         """Update arbitrary fields on a product within this tenant.
 

--- a/src/core/database/repositories/tenant_signal.py
+++ b/src/core/database/repositories/tenant_signal.py
@@ -1,0 +1,61 @@
+"""TenantSignal repository -- tenant-scoped data access."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.core.database.models import TenantSignal
+
+
+class TenantSignalRepository:
+    """Tenant-scoped data access for TenantSignal."""
+
+    def __init__(self, session: Session, tenant_id: str) -> None:
+        self._session = session
+        self._tenant_id = tenant_id
+
+    def get_by_id(self, signal_id: str) -> TenantSignal | None:
+        return self._session.scalars(
+            select(TenantSignal).where(
+                TenantSignal.tenant_id == self._tenant_id,
+                TenantSignal.signal_id == signal_id,
+            )
+        ).first()
+
+    def list_all(self, updated_since: datetime | None = None) -> list[TenantSignal]:
+        stmt = select(TenantSignal).where(TenantSignal.tenant_id == self._tenant_id)
+        if updated_since is not None:
+            stmt = stmt.where(TenantSignal.updated_at > updated_since)
+        return list(self._session.scalars(stmt.order_by(TenantSignal.signal_id)).all())
+
+    @classmethod
+    def list_for_tenant(cls, tenant_id: str, updated_since: datetime | None = None) -> list[TenantSignal]:
+        from src.core.database.database_session import get_db_session
+
+        with get_db_session() as session:
+            return cls(session, tenant_id).list_all(updated_since)
+
+    @classmethod
+    def list_signal_ids_for_tenant(cls, tenant_id: str) -> set[str]:
+        from src.core.database.database_session import get_db_session
+
+        with get_db_session() as session:
+            stmt = select(TenantSignal.signal_id).where(TenantSignal.tenant_id == tenant_id)
+            return set(session.scalars(stmt).all())
+
+    def add(self, signal: TenantSignal) -> None:
+        if signal.tenant_id != self._tenant_id:
+            raise ValueError(
+                f"tenant mismatch: signal.tenant_id={signal.tenant_id!r} != repo tenant_id={self._tenant_id!r}"
+            )
+        self._session.add(signal)
+
+    def delete(self, signal: TenantSignal) -> None:
+        if signal.tenant_id != self._tenant_id:
+            raise ValueError(
+                f"tenant mismatch: signal.tenant_id={signal.tenant_id!r} != repo tenant_id={self._tenant_id!r}"
+            )
+        self._session.delete(signal)

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -297,6 +297,7 @@ from src.core.tools.media_buy_update import update_media_buy
 from src.core.tools.performance import update_performance_index
 from src.core.tools.products import get_products
 from src.core.tools.properties import list_authorized_properties
+from src.core.tools.signals import activate_signal, get_signals
 from src.core.tools.task_management import complete_task, get_task, list_tasks
 
 _sdk_tool_defs = {td["name"]: td for td in ADCP_TOOL_DEFINITIONS}
@@ -318,6 +319,8 @@ _register_tool(list_accounts)
 _register_tool(sync_accounts)
 _register_tool(get_adcp_capabilities)
 _register_tool(get_products)
+_register_tool(get_signals)
+_register_tool(activate_signal)
 _register_tool(list_creative_formats)
 _register_tool(sync_creatives)
 _register_tool(list_creatives)

--- a/src/core/tools/__init__.py
+++ b/src/core/tools/__init__.py
@@ -21,14 +21,15 @@ from src.core.tools.media_buy_update import update_media_buy_raw
 from src.core.tools.performance import update_performance_index_raw
 from src.core.tools.products import get_products_raw
 from src.core.tools.properties import list_authorized_properties_raw
-
-# Signals tools removed - should come from dedicated signals agents, not sales agent
+from src.core.tools.signals import activate_signal_raw, get_signals_raw
 
 __all__ = [
     "list_accounts_raw",
     "sync_accounts_raw",
     "get_adcp_capabilities_raw",
     "get_products_raw",
+    "get_signals_raw",
+    "activate_signal_raw",
     "create_media_buy_raw",
     "sync_creatives_raw",
     "list_creatives_raw",

--- a/src/core/tools/capabilities.py
+++ b/src/core/tools/capabilities.py
@@ -23,6 +23,7 @@ from adcp.types.generated_poc.protocol.get_adcp_capabilities_response import (
     MediaBuy,
     Portfolio,
     PublisherDomain,
+    Signals,
     SupportedProtocol,
     Targeting,
 )
@@ -91,8 +92,13 @@ def _get_adcp_capabilities_impl(
                 major_versions=[MajorVersion(root=3)],
                 idempotency=Idempotency(supported=True, replay_ttl_seconds=86400),
             ),
-            supported_protocols=[SupportedProtocol.media_buy],
-            specialisms=[AdcpSpecialism.sales_non_guaranteed],
+            supported_protocols=[SupportedProtocol.media_buy, SupportedProtocol.signals],
+            specialisms=[
+                AdcpSpecialism.sales_non_guaranteed,
+                AdcpSpecialism.signal_marketplace,
+                AdcpSpecialism.signal_owned,
+            ],
+            signals=Signals(features={"catalog_signals": True}),
         )
 
     # If we got here, tenant is truthy, which means identity was not None on line 84
@@ -264,8 +270,13 @@ def _get_adcp_capabilities_impl(
             major_versions=[MajorVersion(root=3)],
             idempotency=Idempotency(supported=True, replay_ttl_seconds=86400),
         ),
-        supported_protocols=[SupportedProtocol.media_buy],
-        specialisms=[AdcpSpecialism.sales_non_guaranteed],
+        supported_protocols=[SupportedProtocol.media_buy, SupportedProtocol.signals],
+        specialisms=[
+            AdcpSpecialism.sales_non_guaranteed,
+            AdcpSpecialism.signal_marketplace,
+            AdcpSpecialism.signal_owned,
+        ],
+        signals=Signals(features={"catalog_signals": True}),
         media_buy=media_buy,
         last_updated=datetime.now(UTC),
     )

--- a/src/core/tools/media_buy_create.py
+++ b/src/core/tools/media_buy_create.py
@@ -2762,9 +2762,9 @@ async def _create_media_buy_impl(
                 # Merge dimensions from product's format_ids if request format_ids don't have them
                 # This handles the case where buyer specifies format_id but not dimensions
                 # Build lookup of product format dimensions by (normalized_url, id)
-                product_format_dimensions: dict[tuple[str | None, str], tuple[int | None, int | None, float | None]] = (
-                    {}
-                )
+                product_format_dimensions: dict[
+                    tuple[str | None, str], tuple[int | None, int | None, float | None]
+                ] = {}
                 if pkg_product.format_ids:
                     for fmt in pkg_product.format_ids:
                         agent_url = fmt.agent_url

--- a/src/core/tools/signals.py
+++ b/src/core/tools/signals.py
@@ -16,11 +16,19 @@ from src.core.tool_context import ToolContext
 
 logger = logging.getLogger(__name__)
 
+from adcp.types.generated_poc.core.account_ref import AccountReference
 from adcp.types.generated_poc.core.context import ContextObject
+from adcp.types.generated_poc.core.destination import Destination
+from adcp.types.generated_poc.core.ext import ExtensionObject
+from adcp.types.generated_poc.core.pagination_request import PaginationRequest
 from adcp.types.generated_poc.core.signal_id import SignalId, SignalId18
 from adcp.types.generated_poc.core.vendor_pricing_option import VendorPricingOption
+from adcp.types.generated_poc.signals.get_signals_request import Country
+from adcp.types.generated_poc.signals.get_signals_response import Range
 
 from src.core.auth import get_principal_object
+from src.core.database.models import TenantSignal
+from src.core.database.repositories.tenant_signal import TenantSignalRepository
 from src.core.resolved_identity import ResolvedIdentity
 from src.core.schemas import (
     ActivateSignalResponse,
@@ -28,8 +36,24 @@ from src.core.schemas import (
     GetSignalsResponse,
     Signal,
     SignalDeployment,
+    SignalFilters,
 )
 from src.core.testing_hooks import AdCPTestContext
+
+_SAMPLE_SIGNAL_IDS: frozenset[str] = frozenset(
+    {
+        "auto_intenders_q1_2025",
+        "luxury_travel_enthusiasts",
+        "sports_content",
+        "finance_content",
+        "urban_millennials",
+        "pet_owners",
+    }
+)
+
+
+def _canonical_signal_id(signal_id: str) -> str:
+    return signal_id.replace(".", "_")
 
 
 def _agent_signal_id(segment_id: str) -> SignalId:
@@ -44,6 +68,60 @@ def _cpm_pricing_option(cpm: float, currency: str = "USD") -> list[VendorPricing
             {"pricing_option_id": f"cpm_{currency.lower()}", "model": "cpm", "cpm": cpm, "currency": currency}
         )
     ]
+
+
+def _tenant_signal_to_adcp(
+    tenant_signal: TenantSignal,
+    *,
+    ad_server: str | None,
+    agent_url: str | None,
+) -> Signal:
+    """Translate an operator-authored TenantSignal row to AdCP Signal."""
+    range_obj: Range | None = None
+    if tenant_signal.range_min is not None or tenant_signal.range_max is not None:
+        range_obj = Range(min=tenant_signal.range_min, max=tenant_signal.range_max)
+
+    wire_id = _canonical_signal_id(tenant_signal.signal_id)
+    signal_kwargs: dict = {
+        "signal_id": {
+            "source": "agent",
+            "agent_url": agent_url or "https://salesagent.adcontextprotocol.org/signals",
+            "id": wire_id,
+        },
+        "signal_agent_segment_id": wire_id,
+        "name": tenant_signal.name,
+        "description": tenant_signal.description or "",
+        "signal_type": "owned",
+        "data_provider": tenant_signal.data_provider or "publisher",
+        "coverage_percentage": 100.0,
+        "deployments": [
+            SignalDeployment(
+                platform=ad_server or "mock",
+                is_live=True,
+                type="platform",
+            )
+        ],
+        "pricing_options": _cpm_pricing_option(0.0),
+    }
+    if tenant_signal.value_type:
+        signal_kwargs["value_type"] = tenant_signal.value_type
+    if tenant_signal.categories:
+        signal_kwargs["categories"] = list(tenant_signal.categories)
+    if range_obj is not None:
+        signal_kwargs["range"] = range_obj
+    if tenant_signal.tags:
+        signal_kwargs["tags"] = list(tenant_signal.tags)
+    return Signal.model_validate(signal_kwargs)
+
+
+def _load_tenant_signals(
+    tenant_id: str,
+    *,
+    ad_server: str | None,
+    agent_url: str | None,
+) -> list[Signal]:
+    rows = TenantSignalRepository.list_for_tenant(tenant_id)
+    return [_tenant_signal_to_adcp(row, ad_server=ad_server, agent_url=agent_url) for row in rows]
 
 
 async def _get_signals_impl(req: GetSignalsRequest, identity: ResolvedIdentity | None = None) -> GetSignalsResponse:
@@ -64,10 +142,9 @@ async def _get_signals_impl(req: GetSignalsRequest, identity: ResolvedIdentity |
     tenant = identity.tenant
     if not tenant:
         raise AdCPAuthenticationError("No tenant context available")
-
-    # Mock implementation - in production, this would query from a signal provider
-    # or the ad server's available audience segments
-    signals = []
+    tenant_id = identity.tenant_id
+    if tenant_id is None:
+        raise AdCPAuthenticationError("No tenant context available")
 
     # Sample signals for demonstration using local types (extend AdCP library types)
     sample_signals = [
@@ -138,9 +215,15 @@ async def _get_signals_impl(req: GetSignalsRequest, identity: ResolvedIdentity |
             pricing_options=_cpm_pricing_option(1.2),
         ),
     ]
+    tenant_signals = _load_tenant_signals(
+        tenant_id,
+        ad_server=tenant.get("ad_server") if isinstance(tenant, dict) else None,
+        agent_url=tenant.get("public_agent_url") if isinstance(tenant, dict) else None,
+    )
 
     # Filter based on request parameters using AdCP-compliant fields
-    for signal in sample_signals:
+    signals = []
+    for signal in [*tenant_signals, *sample_signals]:
         # Apply signal_spec filter (natural language description matching)
         if req.signal_spec:
             spec_lower = req.signal_spec.lower()
@@ -179,28 +262,62 @@ async def _get_signals_impl(req: GetSignalsRequest, identity: ResolvedIdentity |
     if req.max_results:
         signals = signals[: req.max_results]
 
-    # Signals are already constructed as local types (extending library types),
-    # so no conversion needed — pass directly to response.
     return GetSignalsResponse(signals=signals, errors=None, context=req.context)
 
 
-async def get_signals(req: GetSignalsRequest, context: Context | ToolContext | None = None):
+async def get_signals(
+    adcp_major_version: int | None = None,
+    account: AccountReference | None = None,
+    signal_spec: str | None = None,
+    signal_ids: list[SignalId] | None = None,
+    destinations: list[Destination] | None = None,
+    countries: list[Country] | None = None,
+    filters: SignalFilters | None = None,
+    max_results: int | None = None,
+    pagination: PaginationRequest | None = None,
+    context: ContextObject | None = None,
+    ext: ExtensionObject | None = None,
+    ctx: Context | ToolContext | None = None,
+):
     """Optional endpoint for discovering available signals (audiences, contextual, etc.)
 
     MCP tool wrapper that delegates to the shared implementation.
 
     Args:
-        req: Request containing query parameters for signal discovery
-        context: FastMCP context (automatically provided)
+        adcp_major_version: Requested AdCP major version.
+        account: Optional account reference.
+        signal_spec: Natural-language signal discovery request.
+        signal_ids: Optional explicit signal IDs to retrieve.
+        destinations: Optional deployment destinations.
+        countries: Optional country filters.
+        filters: Optional structured signal filters.
+        max_results: Optional maximum result count.
+        pagination: Optional pagination request.
+        context: Application level context per AdCP spec.
+        ext: Extension object per AdCP spec.
+        ctx: FastMCP context (automatically provided).
 
     Returns:
         ToolResult with GetSignalsResponse data
     """
     from src.core.transport_helpers import resolve_identity_from_context
 
-    identity = resolve_identity_from_context(context, require_valid_token=False)
+    req = GetSignalsRequest(
+        adcp_major_version=adcp_major_version,
+        account=account,
+        signal_spec=signal_spec,
+        signal_ids=signal_ids,
+        destinations=destinations,
+        countries=countries,
+        filters=filters,
+        max_results=max_results,
+        pagination=pagination,
+        context=context,
+        ext=ext,
+    )
+    identity = resolve_identity_from_context(ctx, require_valid_token=False)
     response = await _get_signals_impl(req, identity)
-    return ToolResult(content=str(response), structured_content=response)
+    return ToolResult(content=str(response), structured_content=response.model_dump(mode="json"))
 
 
 async def _activate_signal_impl(
@@ -230,11 +347,23 @@ async def _activate_signal_impl(
     # Tenant is resolved at the transport boundary (resolve_identity_from_context)
     if not identity or not identity.tenant:
         raise AdCPAuthenticationError("No tenant context available")
+    tenant_id = identity.tenant_id
+    if tenant_id is None:
+        raise AdCPAuthenticationError("No tenant context available")
 
     # Get the Principal object with ad server mappings
     if not principal_id:
         raise AdCPAuthenticationError("Authentication required for signal activation")
     principal = get_principal_object(principal_id, tenant_id=identity.tenant_id)
+
+    tenant_signal_ids = {
+        _canonical_signal_id(signal_id) for signal_id in TenantSignalRepository.list_signal_ids_for_tenant(tenant_id)
+    }
+    if signal_agent_segment_id not in tenant_signal_ids and signal_agent_segment_id not in _SAMPLE_SIGNAL_IDS:
+        raise AdCPValidationError(
+            f"Signal {signal_agent_segment_id!r} is not declared for tenant {tenant_id!r}",
+            recovery="terminal",
+        )
 
     # Apply testing hooks
     if not identity:

--- a/tests/e2e/conftest_contract_validation.py
+++ b/tests/e2e/conftest_contract_validation.py
@@ -13,11 +13,12 @@ from pathlib import Path
 import pytest
 
 # Actual tools that exist (keep this updated with src/core/main.py)
-# Note: signals tools (get_signals, activate_signal) removed - should come from dedicated signals agents
 ACTUAL_MCP_TOOLS = {
+    "activate_signal",
     "create_media_buy",
     "get_media_buy_delivery",
     "get_products",
+    "get_signals",
     "list_authorized_properties",
     "list_creative_formats",
     "list_creatives",
@@ -61,6 +62,8 @@ def extract_tool_calls_from_test_file(test_file: Path) -> dict[str, set[str]]:
             self.generic_visit(node)
             if node.name == current_test:
                 current_test = None
+
+        visit_AsyncFunctionDef = visit_FunctionDef
 
         def visit_Call(self, node):
             # Check for call_tool("tool_name") or call_mcp_tool("tool_name")

--- a/tests/e2e/test_composition_api_e2e.py
+++ b/tests/e2e/test_composition_api_e2e.py
@@ -1,0 +1,243 @@
+"""Composition API buyer-facing e2e path.
+
+Exercises the deployed HTTP stack:
+admin REST authoring -> persisted catalog/signal rows -> buyer MCP discovery.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import psycopg2
+import pytest
+import requests
+from fastmcp.client import Client
+from fastmcp.client.transports import StreamableHttpTransport
+
+from tests.e2e.adcp_request_builder import parse_tool_result
+
+TENANT_SUBDOMAIN = "ci-test"
+
+
+def _db_params(live_server: dict[str, object]) -> dict:
+    params = live_server["postgres_params"]
+    assert isinstance(params, dict)
+    return params
+
+
+@contextmanager
+def _temporary_management_api_key(live_server: dict[str, object], api_key: str) -> Iterator[None]:
+    params = _db_params(live_server)
+    previous: str | None
+    with psycopg2.connect(**params) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute("SELECT config_value FROM superadmin_config WHERE config_key = 'tenant_management_api_key'")
+            row = cursor.fetchone()
+            previous = str(row[0]) if row else None
+            cursor.execute(
+                """
+                INSERT INTO superadmin_config (config_key, config_value, description, updated_by, updated_at)
+                VALUES ('tenant_management_api_key', %s, 'Composition e2e key', 'pytest', now())
+                ON CONFLICT (config_key) DO UPDATE
+                SET config_value = EXCLUDED.config_value,
+                    updated_by = EXCLUDED.updated_by,
+                    updated_at = now()
+                """,
+                (api_key,),
+            )
+    try:
+        yield
+    finally:
+        with psycopg2.connect(**params) as conn:
+            with conn.cursor() as cursor:
+                if previous is None:
+                    cursor.execute("DELETE FROM superadmin_config WHERE config_key = 'tenant_management_api_key'")
+                else:
+                    cursor.execute(
+                        """
+                        UPDATE superadmin_config
+                        SET config_value = %s,
+                            updated_by = 'pytest-restore',
+                            updated_at = now()
+                        WHERE config_key = 'tenant_management_api_key'
+                        """,
+                        (previous,),
+                    )
+
+
+def _cleanup_composition_rows(
+    live_server: dict[str, object], tenant_id: str, product_id: str, signal_id: str, profile_id: str
+) -> None:
+    params = _db_params(live_server)
+    with psycopg2.connect(**params) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                "DELETE FROM products WHERE tenant_id = %s AND product_id = %s",
+                (tenant_id, product_id),
+            )
+            cursor.execute(
+                "DELETE FROM tenant_signals WHERE tenant_id = %s AND signal_id = %s",
+                (tenant_id, signal_id),
+            )
+            cursor.execute(
+                "DELETE FROM inventory_profiles WHERE tenant_id = %s AND profile_id = %s",
+                (tenant_id, profile_id),
+            )
+
+
+def _resolve_ci_tenant_id(live_server: dict[str, object]) -> str:
+    params = _db_params(live_server)
+    with psycopg2.connect(**params) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute("SELECT tenant_id FROM tenants WHERE subdomain = %s", (TENANT_SUBDOMAIN,))
+            row = cursor.fetchone()
+    assert row is not None, "CI seed tenant must exist before composition e2e setup"
+    return str(row[0])
+
+
+def _composition_url(live_server: dict[str, str], tenant_id: str, path: str) -> str:
+    return f"{live_server['admin']}/admin/api/v1/tenants/{tenant_id}{path}"
+
+
+def _post_json(live_server: dict[str, str], tenant_id: str, api_key: str, path: str, payload: dict) -> dict:
+    response = requests.post(
+        _composition_url(live_server, tenant_id, path),
+        json=payload,
+        headers={"X-Tenant-Management-API-Key": api_key},
+        timeout=10,
+    )
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert isinstance(body, dict)
+    return body
+
+
+def _inventory_profile_payload(profile_id: str) -> dict:
+    return {
+        "profile_id": profile_id,
+        "name": "E2E Homepage Sports Bundle",
+        "description": "Display inventory authored by the composition e2e test.",
+        "inventory_config": {
+            "ad_units": ["e2e_home", "e2e_sports"],
+            "placements": ["e2e_top"],
+            "include_descendants": True,
+        },
+        "format_ids": [{"agent_url": "https://creative.adcontextprotocol.org", "id": "display_300x250"}],
+        "publisher_properties": [
+            {
+                "publisher_domain": "publisher.example.com",
+                "property_tags": ["sports"],
+                "selection_type": "by_tag",
+            }
+        ],
+        "constraints": {
+            "formats": ["display_300x250"],
+            "channels": ["display"],
+            "targeting_dimensions": ["audience"],
+        },
+    }
+
+
+def _signal_payload(signal_id: str) -> dict:
+    return {
+        "signal_id": signal_id,
+        "name": "E2E Sports Fans",
+        "description": "Publisher-declared sports audience.",
+        "value_type": "binary",
+        "categories": [],
+        "adapter_config": {"kind": "audience_segment", "segment_id": "e2e-98765"},
+        "data_provider": "publisher_1p",
+        "targeting_dimension": "audience",
+    }
+
+
+def _product_payload(product_id: str, profile_id: str) -> dict:
+    return {
+        "product_id": product_id,
+        "name": "E2E Wholesale Sports Display",
+        "description": "Profile-backed non-guaranteed wholesale product.",
+        "inventory_profile_id": profile_id,
+        "delivery_type": "non_guaranteed",
+        "channels": ["display"],
+        "countries": ["US"],
+        "signal_targeting_allowed": True,
+        "pricing_options": [
+            {
+                "pricing_model": "cpm",
+                "currency": "USD",
+                "is_fixed": False,
+                "price_guidance": {"floor": 3.0, "p50": 4.0, "p75": 5.0},
+            }
+        ],
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_admin_authored_inventory_signal_and_product_reach_buyer_discovery(
+    docker_services_e2e,
+    live_server,
+    test_auth_token,
+):
+    suffix = uuid.uuid4().hex[:8]
+    profile_id = f"e2e_homepage_sports_{suffix}"
+    signal_id = f"e2e_sports_fans_{suffix}"
+    product_id = f"e2e_wholesale_sports_display_{suffix}"
+    api_key = f"composition-e2e-{uuid.uuid4().hex}"
+
+    tenant_id = _resolve_ci_tenant_id(live_server)
+
+    try:
+        with _temporary_management_api_key(live_server, api_key):
+            profile = _post_json(
+                live_server,
+                tenant_id,
+                api_key,
+                "/inventory-profiles",
+                _inventory_profile_payload(profile_id),
+            )
+            assert profile["profile_id"] == profile_id
+
+            signal = _post_json(live_server, tenant_id, api_key, "/signals", _signal_payload(signal_id))
+            assert signal["signal_id"] == signal_id
+            assert "adapter_config" not in signal
+
+            product = _post_json(live_server, tenant_id, api_key, "/products", _product_payload(product_id, profile_id))
+            assert product["product_id"] == product_id
+            assert product["inventory_profile_id"] == profile_id
+            assert product["pricing_options"][0]["pricing_option_id"] == "cpm_usd_auction"
+
+            transport = StreamableHttpTransport(
+                url=f"{live_server['mcp']}/mcp/",
+                headers={"x-adcp-auth": test_auth_token, "x-adcp-tenant": TENANT_SUBDOMAIN},
+            )
+            async with Client(transport=transport) as client:
+                products_result = await client.call_tool(
+                    "get_products",
+                    {
+                        "brief": "wholesale sports display inventory",
+                        "brand": {"domain": "buyer.example"},
+                    },
+                )
+                products_data = parse_tool_result(products_result)
+                discovered_products = {item["product_id"]: item for item in products_data["products"]}
+                assert product_id in discovered_products
+                discovered_product = discovered_products[product_id]
+                assert discovered_product["pricing_options"][0]["pricing_option_id"] == "cpm_usd_auction"
+                assert discovered_product["format_ids"][0]["id"] == "display_300x250"
+                assert discovered_product["publisher_properties"][0]["property_tags"] == ["sports"]
+
+                signals_result = await client.call_tool("get_signals", {})
+                signals_data = parse_tool_result(signals_result)
+                discovered_signal_ids = {item["signal_agent_segment_id"] for item in signals_data["signals"]}
+                assert signal_id in discovered_signal_ids
+    finally:
+        _cleanup_composition_rows(
+            live_server,
+            tenant_id,
+            product_id,
+            signal_id,
+            profile_id,
+        )

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -34,6 +34,7 @@ from tests.factories.targeting import (
     PropertyListReferenceFactory,
     TargetingFactory,
 )
+from tests.factories.tenant_signal import TenantSignalFactory
 from tests.factories.user import TenantAuthConfigFactory, UserFactory
 from tests.factories.webhook import PushNotificationConfigFactory
 
@@ -58,6 +59,7 @@ ALL_FACTORIES = [
     FormatPerformanceMetricsFactory,
     UserFactory,
     TenantAuthConfigFactory,
+    TenantSignalFactory,
 ]
 
 __all__ = [
@@ -87,5 +89,6 @@ __all__ = [
     "TargetingFactory",
     "TenantAuthConfigFactory",
     "TenantFactory",
+    "TenantSignalFactory",
     "UserFactory",
 ]

--- a/tests/factories/tenant_signal.py
+++ b/tests/factories/tenant_signal.py
@@ -1,0 +1,30 @@
+"""Factory_boy factory for TenantSignal model."""
+
+from __future__ import annotations
+
+import factory
+from factory import LazyAttribute, Sequence, SubFactory
+
+from src.core.database.models import TenantSignal
+from tests.factories.core import TenantFactory
+
+
+class TenantSignalFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = TenantSignal
+        sqlalchemy_session = None
+        sqlalchemy_session_persistence = "commit"
+
+    tenant = SubFactory(TenantFactory)
+    tenant_id = LazyAttribute(lambda o: o.tenant.tenant_id)
+    signal_id = Sequence(lambda n: f"audience_signal_{n:04d}")
+    name = LazyAttribute(lambda o: f"Signal {o.signal_id}")
+    description = LazyAttribute(lambda o: f"Description for {o.name}")
+    value_type = "binary"
+    categories = factory.LazyFunction(list)
+    tags = factory.LazyFunction(list)
+    range_min = None
+    range_max = None
+    adapter_config = factory.LazyFunction(lambda: {"kind": "audience_segment", "segment_id": "12345"})
+    data_provider = "publisher_1p"
+    targeting_dimension = "audience"

--- a/tests/integration/test_composition_api.py
+++ b/tests/integration/test_composition_api.py
@@ -1,0 +1,258 @@
+"""Composition API e2e setup path.
+
+These tests exercise the server-to-server authoring endpoints that let an
+embedded host seed inventory bundles, signals, and wholesale products before a
+buyer runs AdCP discovery.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from adcp import GetProductsRequest
+
+from src.core.resolved_identity import ResolvedIdentity
+from src.core.schemas import GetSignalsRequest
+from src.core.tools.products import _get_products_impl
+from src.core.tools.signals import _get_signals_impl
+from tests.utils.database_helpers import _bind_factories_to_session
+
+pytestmark = [pytest.mark.integration, pytest.mark.requires_db]
+
+
+def _headers(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    monkeypatch.setenv("TENANT_MANAGEMENT_API_KEY", "composition-api-test-key")
+    return {"X-Tenant-Management-API-Key": "composition-api-test-key"}
+
+
+def _seed_tenant(tenant_id: str) -> None:
+    from src.core.database.database_session import get_db_session
+    from tests.factories import TenantFactory
+
+    with get_db_session() as session, _bind_factories_to_session(session):
+        TenantFactory(
+            tenant_id=tenant_id,
+            subdomain=tenant_id.replace("_", "-"),
+            ad_server="mock",
+            brand_manifest_policy="public",
+        )
+
+
+def _identity(tenant_id: str) -> ResolvedIdentity:
+    return ResolvedIdentity(
+        tenant_id=tenant_id,
+        principal_id=None,
+        tenant={
+            "tenant_id": tenant_id,
+            "ad_server": "mock",
+            "public_agent_url": f"https://{tenant_id}.example.com/agent",
+            "brand_manifest_policy": "public",
+            "advertising_policy": {"enabled": False},
+        },
+        principal=None,
+        auth_method="api_key",
+        raw_credential=None,
+    )
+
+
+def _inventory_profile_payload(profile_id: str) -> dict:
+    return {
+        "profile_id": profile_id,
+        "name": "Homepage + Sports Bundle",
+        "description": "Display inventory used for wholesale discovery tests.",
+        "inventory_config": {
+            "ad_units": ["au_home", "au_sports"],
+            "placements": ["pl_top"],
+            "include_descendants": True,
+        },
+        "format_ids": [{"agent_url": "https://creative.adcontextprotocol.org", "id": "display_300x250"}],
+        "publisher_properties": [
+            {
+                "publisher_domain": "publisher.example.com",
+                "property_tags": ["sports"],
+                "selection_type": "by_tag",
+            }
+        ],
+        "constraints": {
+            "formats": ["display_300x250"],
+            "channels": ["display"],
+            "targeting_dimensions": ["audience"],
+        },
+    }
+
+
+def _signal_payload(signal_id: str) -> dict:
+    return {
+        "signal_id": signal_id,
+        "name": "Sports Fans",
+        "description": "Publisher-declared sports audience.",
+        "value_type": "binary",
+        "categories": [],
+        "adapter_config": {"kind": "audience_segment", "segment_id": "98765"},
+        "data_provider": "publisher_1p",
+        "targeting_dimension": "audience",
+    }
+
+
+def _product_payload(product_id: str, profile_id: str) -> dict:
+    return {
+        "product_id": product_id,
+        "name": "Wholesale Sports Display",
+        "description": "Profile-backed non-guaranteed wholesale product.",
+        "inventory_profile_id": profile_id,
+        "delivery_type": "non_guaranteed",
+        "channels": ["display"],
+        "countries": ["US"],
+        "signal_targeting_allowed": True,
+        "pricing_options": [
+            {
+                "pricing_model": "cpm",
+                "currency": "USD",
+                "is_fixed": False,
+                "price_guidance": {"floor": 3.0, "p50": 4.0, "p75": 5.0},
+            }
+        ],
+    }
+
+
+def test_authoring_inventory_signal_and_product_unblocks_buyer_discovery(admin_client, integration_db, monkeypatch):
+    tenant_id = "composition_api_e2e"
+    profile_id = "homepage_sports"
+    signal_id = "sports_fans"
+    product_id = "wholesale_sports_display"
+    _seed_tenant(tenant_id)
+    headers = _headers(monkeypatch)
+
+    profile_resp = admin_client.post(
+        f"/api/v1/tenants/{tenant_id}/inventory-profiles",
+        json=_inventory_profile_payload(profile_id),
+        headers=headers,
+    )
+    assert profile_resp.status_code == 201
+    assert profile_resp.get_json()["profile_id"] == profile_id
+
+    signal_resp = admin_client.post(
+        f"/api/v1/tenants/{tenant_id}/signals",
+        json=_signal_payload(signal_id),
+        headers=headers,
+    )
+    assert signal_resp.status_code == 201
+    assert signal_resp.get_json()["signal_id"] == signal_id
+    assert "adapter_config" not in signal_resp.get_json()
+
+    product_resp = admin_client.post(
+        f"/api/v1/tenants/{tenant_id}/products",
+        json=_product_payload(product_id, profile_id),
+        headers=headers,
+    )
+    assert product_resp.status_code == 201
+    product_body = product_resp.get_json()
+    assert product_body["product_id"] == product_id
+    assert product_body["inventory_profile_id"] == profile_id
+    assert product_body["pricing_options"][0]["pricing_option_id"] == "cpm_usd_auction"
+
+    products = asyncio.run(
+        _get_products_impl(
+            GetProductsRequest(buying_mode="wholesale", brand={"domain": "buyer.example"}),
+            identity=_identity(tenant_id),
+        )
+    )
+    assert [product.product_id for product in products.products] == [product_id]
+    discovered_product = products.products[0].model_dump(mode="json")
+    assert discovered_product["format_ids"][0]["id"] == "display_300x250"
+    assert discovered_product["publisher_properties"][0]["property_tags"] == ["sports"]
+
+    signals = asyncio.run(_get_signals_impl(GetSignalsRequest(), identity=_identity(tenant_id)))
+    discovered_signal_ids = {signal.signal_agent_segment_id for signal in signals.signals}
+    assert signal_id in discovered_signal_ids
+
+
+def test_product_update_replaces_pricing_without_empty_option_gap(admin_client, integration_db, monkeypatch):
+    tenant_id = "composition_api_update_pricing"
+    profile_id = "homepage_sports"
+    product_id = "wholesale_update_display"
+    _seed_tenant(tenant_id)
+    headers = _headers(monkeypatch)
+
+    profile_resp = admin_client.post(
+        f"/api/v1/tenants/{tenant_id}/inventory-profiles",
+        json=_inventory_profile_payload(profile_id),
+        headers=headers,
+    )
+    assert profile_resp.status_code == 201
+
+    create_resp = admin_client.post(
+        f"/api/v1/tenants/{tenant_id}/products",
+        json=_product_payload(product_id, profile_id),
+        headers=headers,
+    )
+    assert create_resp.status_code == 201
+
+    update_payload = {
+        "pricing_options": [
+            {
+                "pricing_model": "cpm",
+                "currency": "USD",
+                "is_fixed": True,
+                "rate": 6.25,
+            }
+        ]
+    }
+    update_resp = admin_client.put(
+        f"/api/v1/tenants/{tenant_id}/products/{product_id}",
+        json=update_payload,
+        headers=headers,
+    )
+
+    assert update_resp.status_code == 200
+    pricing = update_resp.get_json()["pricing_options"]
+    assert len(pricing) == 1
+    assert pricing[0]["pricing_option_id"] == "cpm_usd_fixed"
+    assert pricing[0]["rate"] == "6.25"
+
+
+def test_product_create_rejects_non_cpm_pricing_model(admin_client, integration_db, monkeypatch):
+    tenant_id = "composition_api_bad_pricing"
+    profile_id = "homepage_sports"
+    _seed_tenant(tenant_id)
+    headers = _headers(monkeypatch)
+
+    profile_resp = admin_client.post(
+        f"/api/v1/tenants/{tenant_id}/inventory-profiles",
+        json=_inventory_profile_payload(profile_id),
+        headers=headers,
+    )
+    assert profile_resp.status_code == 201
+
+    payload = _product_payload("bad_pricing_product", profile_id)
+    payload["pricing_options"][0]["pricing_model"] = "cpp"
+    resp = admin_client.post(
+        f"/api/v1/tenants/{tenant_id}/products",
+        json=payload,
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+
+
+def test_composition_docs_require_management_api_key(admin_client, integration_db, monkeypatch):
+    unauthenticated = admin_client.get("/api/v1/docs/openapi.json")
+    assert unauthenticated.status_code == 401
+
+    authenticated = admin_client.get("/api/v1/docs/openapi.json", headers=_headers(monkeypatch))
+    assert authenticated.status_code == 200
+
+
+def test_product_create_requires_existing_inventory_profile(admin_client, integration_db, monkeypatch):
+    tenant_id = "composition_api_missing_profile"
+    _seed_tenant(tenant_id)
+
+    resp = admin_client.post(
+        f"/api/v1/tenants/{tenant_id}/products",
+        json=_product_payload("orphan_product", "missing_profile"),
+        headers=_headers(monkeypatch),
+    )
+
+    assert resp.status_code == 404
+    assert resp.get_json()["error"] == "inventory_profile_not_found"

--- a/tests/integration/test_gam_lifecycle.py
+++ b/tests/integration/test_gam_lifecycle.py
@@ -25,12 +25,12 @@ def _assert_unsupported_feature_for_action(response, action: str) -> None:
     forces re-evaluation of that test's contract. Helper is private to
     this module — DRY per CLAUDE.md, intentionally not exported.
     """
-    assert (
-        response.errors is not None and len(response.errors) > 0
-    ), f"Expected Error response for action={action!r}; GAM currently rejects with UNSUPPORTED_FEATURE"
-    assert (
-        response.errors[0].code == "UNSUPPORTED_FEATURE"
-    ), f"Expected UNSUPPORTED_FEATURE for action={action!r}, got {response.errors[0].code}"
+    assert response.errors is not None and len(response.errors) > 0, (
+        f"Expected Error response for action={action!r}; GAM currently rejects with UNSUPPORTED_FEATURE"
+    )
+    assert response.errors[0].code == "UNSUPPORTED_FEATURE", (
+        f"Expected UNSUPPORTED_FEATURE for action={action!r}, got {response.errors[0].code}"
+    )
 
 
 class TestGAMOrderLifecycleIntegration:

--- a/tests/integration/test_property_targeting_allowed_enforcement.py
+++ b/tests/integration/test_property_targeting_allowed_enforcement.py
@@ -154,9 +154,9 @@ async def test_create_accepts_property_list_when_product_allows(property_targeti
     # checks, leaving the happy-path proof vacuous. If the response IS an
     # error variant, accept any failure cause that isn't the property_targeting
     # rule itself (test stays decoupled from unrelated downstream errors).
-    assert not isinstance(
-        response, CreateMediaBuyError
-    ), f"Expected success but got CreateMediaBuyError: {[err.message for err in (response.errors or [])]}"
+    assert not isinstance(response, CreateMediaBuyError), (
+        f"Expected success but got CreateMediaBuyError: {[err.message for err in (response.errors or [])]}"
+    )
     assert all("property_targeting_allowed" not in err.message for err in (response.errors or []))
 
 
@@ -190,9 +190,9 @@ async def test_create_accepts_collection_list_without_property_list(property_tar
     # happy-path proof vacuous. Separate ``not isinstance`` gates the success
     # branch with a real check; the follow-up ``all(...)`` ensures the
     # property_list rule still doesn't fire if an unrelated error did appear.
-    assert not isinstance(
-        response, CreateMediaBuyError
-    ), f"Expected success but got CreateMediaBuyError: {[err.message for err in (response.errors or [])]}"
+    assert not isinstance(response, CreateMediaBuyError), (
+        f"Expected success but got CreateMediaBuyError: {[err.message for err in (response.errors or [])]}"
+    )
     assert all("property_targeting_allowed" not in err.message for err in (response.errors or []))
 
 

--- a/tests/integration/test_targeting_overlay_roundtrip.py
+++ b/tests/integration/test_targeting_overlay_roundtrip.py
@@ -209,9 +209,9 @@ def test_collection_list_roundtrips_through_postgres(roundtrip_tenant):
     assert len(response.media_buys) == 1
     pkg = response.media_buys[0].packages[0]
     assert pkg.targeting_overlay is not None
-    assert (
-        pkg.targeting_overlay.collection_list is not None
-    ), "collection_list nested reference must survive JSON SerDes"
+    assert pkg.targeting_overlay.collection_list is not None, (
+        "collection_list nested reference must survive JSON SerDes"
+    )
     assert pkg.targeting_overlay.collection_list.list_id == "C_collection_v1"
 
 

--- a/tests/integration/test_tenant_signal_flow.py
+++ b/tests/integration/test_tenant_signal_flow.py
@@ -1,0 +1,108 @@
+"""Tenant-authored signal discovery and activation."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from src.core.exceptions import AdCPValidationError
+from src.core.resolved_identity import ResolvedIdentity
+from src.core.schemas import GetSignalsRequest
+from src.core.tools.signals import _activate_signal_impl, _get_signals_impl
+from tests.factories import PrincipalFactory, TenantFactory, TenantSignalFactory
+from tests.utils.database_helpers import _bind_factories_to_session
+
+pytestmark = [pytest.mark.integration, pytest.mark.requires_db]
+
+
+def _identity(tenant_id: str, principal_id: str | None = None) -> ResolvedIdentity:
+    return ResolvedIdentity(
+        tenant_id=tenant_id,
+        principal_id=principal_id,
+        tenant={
+            "tenant_id": tenant_id,
+            "ad_server": "google_ad_manager",
+            "public_agent_url": f"https://{tenant_id}.example.com/agent",
+        },
+        principal=None,
+        auth_method="api_key",
+        raw_credential=None,
+    )
+
+
+def test_tenant_signal_appears_in_get_signals(integration_db):
+    from src.core.database.database_session import get_db_session
+
+    with get_db_session() as session, _bind_factories_to_session(session):
+        tenant = TenantFactory(
+            tenant_id="sig_disc_t1",
+            ad_server="google_ad_manager",
+        )
+        TenantSignalFactory(
+            tenant=tenant,
+            signal_id="audience_sports_fans",
+            name="Sports Fans",
+            value_type="binary",
+            adapter_config={"kind": "audience_segment", "segment_id": "98765"},
+            targeting_dimension="audience",
+            data_provider="publisher_1p",
+        )
+
+    response = asyncio.run(_get_signals_impl(GetSignalsRequest(), identity=_identity("sig_disc_t1")))
+
+    target = [s for s in response.signals if s.signal_agent_segment_id == "audience_sports_fans"]
+    assert len(target) == 1
+    wire = target[0].model_dump(mode="json")
+    assert wire["value_type"] == "binary"
+    assert wire["data_provider"] == "publisher_1p"
+    assert "adapter_config" not in wire
+
+
+def test_tenant_signal_dot_id_is_canonicalized_for_wire_and_activation(integration_db):
+    from src.core.database.database_session import get_db_session
+
+    with get_db_session() as session, _bind_factories_to_session(session):
+        tenant = TenantFactory(tenant_id="sig_dot_t1", ad_server="google_ad_manager")
+        principal = PrincipalFactory(tenant=tenant)
+        TenantSignalFactory(
+            tenant=tenant,
+            signal_id="audience.sports_fans",
+            name="Sports Fans",
+            value_type="binary",
+            adapter_config={"kind": "audience_segment", "segment_id": "98765"},
+        )
+        principal_id = principal.principal_id
+
+    signals = asyncio.run(_get_signals_impl(GetSignalsRequest(), identity=_identity("sig_dot_t1")))
+    discovered_signal_ids = {signal.signal_agent_segment_id for signal in signals.signals}
+    assert "audience_sports_fans" in discovered_signal_ids
+
+    activated = asyncio.run(
+        _activate_signal_impl(
+            signal_agent_segment_id="audience_sports_fans",
+            identity=_identity("sig_dot_t1", principal_id),
+        )
+    )
+    assert activated.errors is None
+    assert activated.activation_details is not None
+    assert activated.activation_details["status"] == "processing"
+
+
+def test_activate_undeclared_signal_raises(integration_db):
+    from src.core.database.database_session import get_db_session
+
+    with get_db_session() as session, _bind_factories_to_session(session):
+        tenant = TenantFactory(tenant_id="sig_unknown_t1", ad_server="google_ad_manager")
+        principal = PrincipalFactory(tenant=tenant)
+        principal_id = principal.principal_id
+
+    with pytest.raises(AdCPValidationError) as exc_info:
+        asyncio.run(
+            _activate_signal_impl(
+                signal_agent_segment_id="unknown_signal",
+                identity=_identity("sig_unknown_t1", principal_id),
+            )
+        )
+
+    assert "unknown_signal" in str(exc_info.value)

--- a/tests/integration/test_tool_registration.py
+++ b/tests/integration/test_tool_registration.py
@@ -5,7 +5,6 @@ import pytest
 pytestmark = [pytest.mark.integration, pytest.mark.requires_db]
 
 # All MCP tools - unified mode is now enabled by default
-# Note: signals tools (get_signals, activate_signal) removed - should come from dedicated signals agents
 ALL_TOOLS = [
     # Core AdCP discovery tools
     "get_adcp_capabilities",
@@ -22,6 +21,9 @@ ALL_TOOLS = [
     "list_accounts",
     "sync_accounts",
     "update_performance_index",
+    # Signal discovery/activation tools
+    "get_signals",
+    "activate_signal",
     # Task management tools (HITL - Human-in-the-loop)
     "list_tasks",
     "get_task",

--- a/tests/unit/test_get_adcp_capabilities.py
+++ b/tests/unit/test_get_adcp_capabilities.py
@@ -194,9 +194,9 @@ class TestGetAdcpCapabilitiesImpl:
 
         assert "adcp" in data
         assert "supported_protocols" in data
-        assert data["supported_protocols"] == ["media_buy"]
+        assert data["supported_protocols"] == ["media_buy", "signals"]
         assert "specialisms" in data
-        assert data["specialisms"] == ["sales-non-guaranteed"]
+        assert data["specialisms"] == ["sales-non-guaranteed", "signal-marketplace", "signal-owned"]
 
 
 class TestGetAdcpCapabilitiesWithTenant:
@@ -685,7 +685,7 @@ class TestResponseShapeCapabilities:
         assert "adcp" in data
         assert "supported_protocols" in data
         assert "media_buy" in data
-        assert data["supported_protocols"] == ["media_buy"]
+        assert data["supported_protocols"] == ["media_buy", "signals"]
         assert "portfolio" in data["media_buy"]
         assert "features" in data["media_buy"]
         assert "execution" in data["media_buy"]

--- a/tests/unit/test_media_buy.py
+++ b/tests/unit/test_media_buy.py
@@ -918,7 +918,9 @@ class TestCreateMediaBuyCreativeValidation:
         package.creative_ids = ["c_gen"]
         package.package_id = "pkg_1"
 
-        with (patch("src.core.tools.media_buy_create._get_format_spec_sync", return_value=mock_format_spec),):
+        with (
+            patch("src.core.tools.media_buy_create._get_format_spec_sync", return_value=mock_format_spec),
+        ):
             session = MagicMock()
             session.scalars.return_value.all.return_value = [mock_creative]
 

--- a/tests/unit/test_update_media_buy_behavioral.py
+++ b/tests/unit/test_update_media_buy_behavioral.py
@@ -1826,9 +1826,9 @@ class TestUC003UpdateTargetingOverlay:
         # response_data) gets caught — that would silently lose the
         # structured payload on the webhook path.
         fail_calls = standard_mocks["ctx_mgr_instance"].fail_workflow_step_for_exception.call_args_list
-        assert (
-            len(fail_calls) == 1
-        ), f"Expected exactly one fail_workflow_step_for_exception call on raise, got {len(fail_calls)}"
+        assert len(fail_calls) == 1, (
+            f"Expected exactly one fail_workflow_step_for_exception call on raise, got {len(fail_calls)}"
+        )
         fail_call = fail_calls[0]
         # Positional args: (step_id, exception)
         assert fail_call.args[0] == standard_mocks["step"].step_id
@@ -1936,9 +1936,9 @@ class TestUC003UpdateTargetingOverlay:
             persisted_list_id = persisted_pl.list_id if persisted_pl is not None else None
         else:
             persisted_list_id = persisted["property_list"]["list_id"]
-        assert (
-            persisted_list_id == "B"
-        ), f"replacement semantic broken — persisted list_id={persisted_list_id!r}, expected 'B'"
+        assert persisted_list_id == "B", (
+            f"replacement semantic broken — persisted list_id={persisted_list_id!r}, expected 'B'"
+        )
         # The original "A" must not survive on list_id specifically (don't
         # substring-match the whole overlay repr — 'AnyUrl' contains 'A' too).
         assert persisted_list_id != "A", "original list_id was not replaced"

--- a/uv.lock
+++ b/uv.lock
@@ -139,6 +139,7 @@ dependencies = [
     { name = "requests-oauthlib" },
     { name = "rich" },
     { name = "simple-websocket" },
+    { name = "spectree" },
     { name = "sqlalchemy" },
     { name = "types-markdown" },
     { name = "types-pytz" },
@@ -258,6 +259,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.7.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
     { name = "simple-websocket", specifier = ">=1.1.0" },
+    { name = "spectree", specifier = ">=2.0.1" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "types-markdown", specifier = ">=3.4.2.10" },
     { name = "types-psycopg2", marker = "extra == 'dev'", specifier = ">=2.9.21.20251012" },
@@ -4307,6 +4309,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/89/23/adf3796d740536d63a6fbda113d07e60c734b6ed5d3058d1e47fc0495e47/soupsieve-2.8.1.tar.gz", hash = "sha256:4cf733bc50fa805f5df4b8ef4740fc0e0fa6218cf3006269afd3f9d6d80fd350", size = 117856, upload-time = "2025-12-18T13:50:34.655Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/f3/b67d6ea49ca9154453b6d70b34ea22f3996b9fa55da105a79d8732227adc/soupsieve-2.8.1-py3-none-any.whl", hash = "sha256:a11fe2a6f3d76ab3cf2de04eb339c1be5b506a8a47f2ceb6d139803177f85434", size = 36710, upload-time = "2025-12-18T13:50:33.267Z" },
+]
+
+[[package]]
+name = "spectree"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/3d/1380581a90b714a56cb1669982e5889557b6edcda85e9ee3d538804f4726/spectree-2.0.1.tar.gz", hash = "sha256:280dd6beb10a9c5f023254650d3d8f4494077d556f7de92c1fbebd1203efe39c", size = 58970, upload-time = "2025-12-16T01:38:52.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/9c/889999a8e8c1c9c56b55f20038e807e234199887b3ba706bd708b57ce9d8/spectree-2.0.1-py3-none-any.whl", hash = "sha256:fd30dadca93afdd82573d886365ae27f0b3eea4ed43a9daf6f6616483520b673", size = 44438, upload-time = "2025-12-16T01:38:51.011Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds admin composition API endpoints for profile-backed wholesale product authoring, alongside existing inventory profile and signal authoring.
- Wires tenant-authored signals into live buyer discovery/activation and advertises signals capabilities on the platform surfaces.
- Adds OpenAPI export/contract coverage so composition routes stay registered and docs remain management-key protected.

## Expert review
- Ran code review and security review; addressed docs exposure, signal activation validation, pricing replacement safety, async tool contract detection, and CPM-only authoring drift.

## Tests
- `make quality`
- `scripts/run-test.sh tests/integration/test_composition_api.py tests/integration/test_tenant_signal_flow.py -q`
- `uv run pytest tests/unit/test_openapi_export_in_sync.py tests/unit/test_architecture_no_raw_select.py tests/unit/test_architecture_repository_pattern.py -q`
- Pre-push hook: unit + integration + `uv-secure` (`test-results/220526_1921/`)
- Local served-app e2e against real HTTP admin API and MCP: created inventory profile, signal, and product; verified buyer `get_products` and `get_signals` discover them.

Note: I also attempted the Docker e2e harness (`./run_all_tests.sh ci tests/e2e/test_composition_api_e2e.py -q`), but it blocked before app tests on global Docker buildx contention resolving `docker/dockerfile:1.4`. The same e2e path passed against a locally served app with the agent Postgres DB.
