### PR TITLE
fix(delivery): resolve account references in shared path

### DIFF
--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -1986,7 +1986,7 @@ class AdCPRequestHandler(RequestHandler):
                 reporting_dimensions=req.reporting_dimensions,
                 attribution_window=req.attribution_window,
                 include_package_daily_breakdown=req.include_package_daily_breakdown,
-                account=params.get("account"),
+                account=req.account,
                 context=params.get("context"),
                 identity=identity,
             )

--- a/src/core/tools/media_buy_delivery.py
+++ b/src/core/tools/media_buy_delivery.py
@@ -650,7 +650,7 @@ def get_media_buy_delivery_raw(
     reporting_dimensions: ReportingDimensions | None = None,
     attribution_window: AttributionWindow | None = None,
     include_package_daily_breakdown: bool | None = None,
-    account: LibraryAccountReference | dict[str, Any] | None = None,
+    account: LibraryAccountReference | None = None,
     context: ContextObject | None = None,
     ctx: Context | ToolContext | None = None,
     identity: ResolvedIdentity | None = None,

--- a/src/core/tools/media_buy_delivery.py
+++ b/src/core/tools/media_buy_delivery.py
@@ -93,6 +93,12 @@ def _get_media_buy_delivery_impl(
     if identity is None:
         raise AdCPValidationError("Context is required", recovery="correctable")
 
+    if isinstance(req, GetMediaBuyDeliveryRequest) and req.account is not None:
+        from src.core.transport_helpers import enrich_identity_with_account
+
+        identity = enrich_identity_with_account(identity, req.account)
+        assert identity is not None
+
     # Extract testing context for time simulation and event jumping
     testing_ctx = identity.testing_context or AdCPTestContext()
 
@@ -615,12 +621,6 @@ async def get_media_buy_delivery(
     """
     identity = (await ctx.get_state("identity")) if isinstance(ctx, Context) else None
 
-    # Handle account resolution at boundary (same as sync_creatives pattern)
-    if account is not None and identity is not None:
-        from src.core.transport_helpers import enrich_identity_with_account
-
-        identity = enrich_identity_with_account(identity, account)
-
     # Create AdCP-compliant request object
     try:
         req = GetMediaBuyDeliveryRequest(
@@ -631,6 +631,7 @@ async def get_media_buy_delivery(
             reporting_dimensions=reporting_dimensions,
             attribution_window=attribution_window,
             include_package_daily_breakdown=include_package_daily_breakdown,
+            account=account,
             context=cast(ContextObject | None, context),
         )
 
@@ -649,7 +650,7 @@ def get_media_buy_delivery_raw(
     reporting_dimensions: ReportingDimensions | None = None,
     attribution_window: AttributionWindow | None = None,
     include_package_daily_breakdown: bool | None = None,
-    account: LibraryAccountReference | None = None,
+    account: LibraryAccountReference | dict[str, Any] | None = None,
     context: ContextObject | None = None,
     ctx: Context | ToolContext | None = None,
     identity: ResolvedIdentity | None = None,
@@ -677,12 +678,6 @@ def get_media_buy_delivery_raw(
 
         identity = resolve_identity_from_context(ctx)
 
-    # Handle account resolution at boundary (same as sync_creatives pattern)
-    if account is not None and identity is not None:
-        from src.core.transport_helpers import enrich_identity_with_account
-
-        identity = enrich_identity_with_account(identity, account)
-
     # Create request object
     req = GetMediaBuyDeliveryRequest(
         media_buy_ids=media_buy_ids,
@@ -692,6 +687,7 @@ def get_media_buy_delivery_raw(
         reporting_dimensions=reporting_dimensions,
         attribution_window=attribution_window,
         include_package_daily_breakdown=include_package_daily_breakdown,
+        account=account,
         context=cast(ContextObject | None, context),
     )
 

--- a/src/routes/api_v1.py
+++ b/src/routes/api_v1.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from src.core.resolved_identity import ResolvedIdentity
 
+from adcp.types import AccountReference as LibraryAccountReference
 from adcp.types.generated_poc.core.brand_ref import BrandReference
 from adcp.types.generated_poc.media_buy.get_media_buy_delivery_request import (
     AttributionWindow,
@@ -266,6 +267,8 @@ async def update_media_buy(media_buy_id: str, body: UpdateMediaBuyBody, identity
 async def get_media_buy_delivery(body: GetMediaBuyDeliveryBody, identity: ResolvedIdentity = require_auth):
     """Get delivery metrics for media buys (auth required)."""
     try:
+        account_ref = LibraryAccountReference.model_validate(body.account) if body.account is not None else None
+
         response = media_buy_delivery_module.get_media_buy_delivery_raw(
             media_buy_ids=body.media_buy_ids,
             status_filter=body.status_filter,
@@ -274,7 +277,7 @@ async def get_media_buy_delivery(body: GetMediaBuyDeliveryBody, identity: Resolv
             reporting_dimensions=body.reporting_dimensions,
             attribution_window=body.attribution_window,
             include_package_daily_breakdown=body.include_package_daily_breakdown,
-            account=body.account,
+            account=account_ref,
             identity=identity,
         )
     except ToolError as e:

--- a/src/routes/api_v1.py
+++ b/src/routes/api_v1.py
@@ -266,17 +266,6 @@ async def update_media_buy(media_buy_id: str, body: UpdateMediaBuyBody, identity
 async def get_media_buy_delivery(body: GetMediaBuyDeliveryBody, identity: ResolvedIdentity = require_auth):
     """Get delivery metrics for media buys (auth required)."""
     try:
-        # Handle account resolution at boundary
-        if body.account is not None:
-            from adcp.types import AccountReference as LibraryAccountReference
-
-            from src.core.transport_helpers import enrich_identity_with_account
-
-            account_ref = LibraryAccountReference(**body.account)
-            enriched = enrich_identity_with_account(identity, account_ref)
-            assert enriched is not None  # identity is non-None (from require_auth)
-            identity = enriched
-
         response = media_buy_delivery_module.get_media_buy_delivery_raw(
             media_buy_ids=body.media_buy_ids,
             status_filter=body.status_filter,
@@ -285,6 +274,7 @@ async def get_media_buy_delivery(body: GetMediaBuyDeliveryBody, identity: Resolv
             reporting_dimensions=body.reporting_dimensions,
             attribution_window=body.attribution_window,
             include_package_daily_breakdown=body.include_package_daily_breakdown,
+            account=body.account,
             identity=identity,
         )
     except ToolError as e:

--- a/tests/unit/test_delivery_account_resolution_flow.py
+++ b/tests/unit/test_delivery_account_resolution_flow.py
@@ -30,7 +30,7 @@ def test_delivery_raw_preserves_account_for_shared_impl(monkeypatch: pytest.Monk
 
     result = media_buy_delivery.get_media_buy_delivery_raw(
         media_buy_ids=["mb-001"],
-        account={"account_id": "acc_001"},
+        account=AccountReference(AccountReference1(account_id="acc_001")),
         identity=identity,
     )
 
@@ -131,5 +131,5 @@ async def test_rest_delivery_route_passes_account_to_raw_path(monkeypatch: pytes
     result = await api_v1.get_media_buy_delivery(body, identity)
 
     assert result == {"ok": True}
-    assert captured["account"] == {"account_id": "acc_001"}
+    assert _account_id(captured["account"]) == "acc_001"
     assert captured["identity"] is identity

--- a/tests/unit/test_delivery_account_resolution_flow.py
+++ b/tests/unit/test_delivery_account_resolution_flow.py
@@ -1,0 +1,135 @@
+"""Unit regressions for delivery AccountReference propagation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from adcp.types.generated_poc.core.account_ref import AccountReference, AccountReference1
+
+from src.core.resolved_identity import ResolvedIdentity
+from src.core.schemas import GetMediaBuyDeliveryRequest
+
+
+def _account_id(account: Any) -> str:
+    return account.root.account_id
+
+
+def test_delivery_raw_preserves_account_for_shared_impl(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.core.tools import media_buy_delivery
+
+    captured: dict[str, Any] = {}
+    identity = ResolvedIdentity(principal_id="buyer-001", tenant_id="tenant-001")
+
+    def fake_impl(req: GetMediaBuyDeliveryRequest, got_identity: ResolvedIdentity | None) -> str:
+        captured["account"] = req.account
+        captured["identity"] = got_identity
+        return "ok"
+
+    monkeypatch.setattr(media_buy_delivery, "_get_media_buy_delivery_impl", fake_impl)
+
+    result = media_buy_delivery.get_media_buy_delivery_raw(
+        media_buy_ids=["mb-001"],
+        account={"account_id": "acc_001"},
+        identity=identity,
+    )
+
+    assert result == "ok"
+    assert _account_id(captured["account"]) == "acc_001"
+    assert captured["identity"] is identity
+
+
+def test_delivery_impl_resolves_account_before_principal_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.core.tools import media_buy_delivery
+
+    calls: dict[str, Any] = {}
+    account = AccountReference(AccountReference1(account_id="acc_001"))
+    identity = ResolvedIdentity(
+        principal_id="buyer-001",
+        tenant_id="tenant-001",
+        tenant={"tenant_id": "tenant-001"},
+    )
+    enriched = identity.model_copy(update={"account_id": "acc_001"})
+
+    def fake_enrich_identity(got_identity: ResolvedIdentity | None, got_account: Any) -> ResolvedIdentity:
+        calls["identity"] = got_identity
+        calls["account"] = got_account
+        return enriched
+
+    def stop_after_account_resolution(principal_id: str, tenant_id: str | None = None) -> None:
+        calls["principal_lookup"] = (principal_id, tenant_id)
+        raise RuntimeError("stop before database access")
+
+    monkeypatch.setattr("src.core.transport_helpers.enrich_identity_with_account", fake_enrich_identity)
+    monkeypatch.setattr(media_buy_delivery, "get_principal_object", stop_after_account_resolution)
+
+    req = GetMediaBuyDeliveryRequest(media_buy_ids=["mb-001"], account=account)
+    with pytest.raises(RuntimeError, match="stop before database access"):
+        media_buy_delivery._get_media_buy_delivery_impl(req, identity)
+
+    assert calls["identity"] is identity
+    assert _account_id(calls["account"]) == "acc_001"
+    assert calls["principal_lookup"] == ("buyer-001", "tenant-001")
+
+
+@pytest.mark.asyncio
+async def test_a2a_delivery_handler_forwards_validated_account_to_raw(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.a2a_server import adcp_a2a_server
+
+    captured: dict[str, Any] = {}
+
+    def fake_raw(**kwargs: Any) -> dict[str, bool]:
+        captured.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(adcp_a2a_server, "core_get_media_buy_delivery_tool", fake_raw)
+
+    handler = adcp_a2a_server.AdCPRequestHandler()
+    identity = ResolvedIdentity(
+        principal_id="buyer-001",
+        tenant_id="tenant-001",
+        tenant={"tenant_id": "tenant-001"},
+        protocol="a2a",
+    )
+
+    result = await handler._handle_get_media_buy_delivery_skill(
+        {"media_buy_ids": ["mb-001"], "account": {"account_id": "acc_001"}},
+        identity,
+    )
+
+    assert result == {"ok": True}
+    assert _account_id(captured["account"]) == "acc_001"
+    assert captured["identity"] is identity
+
+
+@pytest.mark.asyncio
+async def test_rest_delivery_route_passes_account_to_raw_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.routes import api_v1
+
+    captured: dict[str, Any] = {}
+    identity = ResolvedIdentity(
+        principal_id="buyer-001",
+        tenant_id="tenant-001",
+        tenant={"tenant_id": "tenant-001"},
+        protocol="rest",
+    )
+
+    class FakeResponse:
+        def model_dump(self, mode: str = "python") -> dict[str, bool]:
+            return {"ok": mode == "json"}
+
+    def fake_raw(**kwargs: Any) -> FakeResponse:
+        captured.update(kwargs)
+        return FakeResponse()
+
+    monkeypatch.setattr(api_v1.media_buy_delivery_module, "get_media_buy_delivery_raw", fake_raw)
+
+    body = api_v1.GetMediaBuyDeliveryBody(
+        media_buy_ids=["mb-001"],
+        account={"account_id": "acc_001"},
+    )
+    result = await api_v1.get_media_buy_delivery(body, identity)
+
+    assert result == {"ok": True}
+    assert captured["account"] == {"account_id": "acc_001"}
+    assert captured["identity"] is identity


### PR DESCRIPTION
## Summary

Refs #1316 and #1317.

This is the smaller current-main replacement for the stale #1321 draft after #1334 changed the delivery/A2A/BDD surfaces. It focuses on AccountReference propagation and shared resolution for get_media_buy_delivery; it does not claim #1318 or media-buy ownership filtering.

## What changed

- A2A now passes the validated `req.account` value to the raw delivery call instead of the original raw params dict.
- MCP/raw and REST pass account into `GetMediaBuyDeliveryRequest` instead of resolving account at each wrapper boundary.
- REST validates `body.account` into a typed `AccountReference` before passing it to the raw path.
- `_get_media_buy_delivery_impl` resolves `req.account` once through `enrich_identity_with_account` before principal lookup.
- Added unit regression coverage for raw forwarding, shared impl resolution, A2A forwarding, and REST forwarding.

## Out of scope

This does not claim #1318. Cross-principal media-buy ownership remains separate.

## Testing

- `uv run pytest tests/unit/test_delivery_account_resolution_flow.py tests/unit/test_auth_consistency.py::TestMissingTokenConsistency::test_get_media_buy_delivery_missing_auth_returns_error_response -q --tb=short`
- `uv run pytest tests/unit/test_delivery.py tests/unit/test_rest_api_endpoints.py tests/unit/test_delivery_account_resolution_flow.py -q --tb=short`
- `uv run pytest tests/unit/test_pydantic_schema_alignment.py::TestPydanticSchemaAlignment::test_model_accepts_all_schema_fields[/schemas/latest/media-buy/get-media-buy-delivery-request.json-GetMediaBuyDeliveryRequest] -q --tb=short`
- `uv run ruff check src/core/tools/media_buy_delivery.py src/a2a_server/adcp_a2a_server.py src/routes/api_v1.py tests/unit/test_delivery_account_resolution_flow.py`
- `uv run mypy src/core/tools/media_buy_delivery.py src/a2a_server/adcp_a2a_server.py src/routes/api_v1.py`
- `git diff --check`

Keeping this draft until the full GitHub Actions matrix runs or maintainers signal that this smaller current-main split is wanted.
