### PR TITLE
chore(adcp): pin SDK exactly + document spec version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,15 @@ AST-scanning tests enforce architecture invariants on every `make quality` run. 
 
 ---
 
+## AdCP Spec Version
+
+This project targets AdCP spec **3.0.1** via the `adcp==4.3.0` Python SDK. See
+[docs/adcp-spec-version.md](docs/adcp-spec-version.md) for the version mapping
+and bump procedure. The CI guard at `tests/unit/test_adcp_spec_version.py`
+fails on pin drift.
+
+---
+
 ## 🚨 Critical Architecture Patterns
 
 ### 1. AdCP Schema: Extend Library Schemas

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ The Prebid Sales Agent is a server that:
 - **Provides an admin interface** for managing inventory and campaigns
 - **Handles the full campaign lifecycle** from discovery to reporting
 
+## AdCP Compatibility
+
+This implementation targets **AdCP spec version 3.0.1** via the `adcp==4.3.0`
+Python SDK. See [docs/adcp-spec-version.md](docs/adcp-spec-version.md) for the
+SDK-to-spec mapping and bump procedure.
+
 ## Choose Your Path
 
 | I want to... | Start here |

--- a/docs/adcp-spec-version.md
+++ b/docs/adcp-spec-version.md
@@ -1,0 +1,66 @@
+# AdCP Spec Version
+
+Prebid Sales Agent targets **AdCP spec version 3.0.1**.
+
+## Verifying the current target
+
+```python
+import adcp
+adcp.get_adcp_spec_version()  # "3.0.1"
+adcp.get_adcp_sdk_version()   # "4.3.0"
+```
+
+## Why this version
+
+The `adcp` Python SDK is pinned in `pyproject.toml` to `==4.3.0`. SDK 4.3.0
+is code-generated from AdCP spec 3.0.1 and ships Pydantic models that encode
+that spec version's request/response shapes.
+
+The SDK-to-spec mapping (verified via each wheel's bundled `ADCP_VERSION`
+file):
+
+| adcp SDK release | AdCP spec |
+|---|---|
+| 4.3.x | 3.0.1 |
+| 4.4.x | 3.0.5 |
+| 4.5.x – 4.6.x | 3.0.5 |
+| 5.x.x | 3.0.7 |
+| 6.x (beta) | 3.1.0-beta |
+
+To check what spec version any installed SDK release targets:
+
+```bash
+uv run python -c "import adcp; print(adcp.get_adcp_spec_version())"
+```
+
+## CI guard
+
+`tests/unit/test_adcp_spec_version.py` asserts the installed SDK targets
+`3.0.1`. A pin shift will fail this test, forcing a deliberate update
+across `pyproject.toml`, the test's `EXPECTED_SPEC_VERSION` constant, and
+this document.
+
+## Wire negotiation
+
+AdCP wire values for `adcp_version` are release-precision (`"3.0"`,
+`"3.1"`). The SDK accepts patch-precision input for backwards
+compatibility but normalizes to release-precision on the wire.
+
+## Bumping the spec version
+
+A spec version bump is a deliberate change with downstream impact:
+
+1. Read the AdCP spec changelog for the target version.
+2. Update `pyproject.toml` SDK pin to a release that targets the new spec
+   version (see mapping above).
+3. Run `uv lock --upgrade-package adcp`.
+4. Update `EXPECTED_SPEC_VERSION` in `tests/unit/test_adcp_spec_version.py`.
+5. Update this document.
+6. Run `make quality` and address Pydantic field/type changes.
+7. Re-verify integration and BDD test coverage.
+
+## Related files
+
+- `pyproject.toml` — SDK pin
+- `tests/unit/test_adcp_spec_version.py` — CI guard
+- `docs/adcp-spec-version.md` — this document

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 
 dependencies = [
     "a2wsgi>=1.10.0",
-    "adcp>=4.3.0",
+    "adcp==4.3.0",  # exact pin — 4.3.0 targets AdCP spec 3.0.1; see docs/adcp-spec-version.md
     "fastmcp>=3.2.0", # v3.2 fixes GHSA-m8x7-r2rg-vh5g, GHSA-rww4-4w9c-7733
     "google-cloud-iam>=2.19.1",
     "rich>=13.7.1",

--- a/tests/unit/test_adcp_spec_version.py
+++ b/tests/unit/test_adcp_spec_version.py
@@ -1,0 +1,21 @@
+"""CI guard: assert the adcp SDK pin targets the expected AdCP spec version."""
+
+import adcp
+
+EXPECTED_SPEC_VERSION = "3.0.1"
+
+
+def test_adcp_spec_version_matches_pin() -> None:
+    """Verify SDK pin targets the spec version this codebase expects.
+
+    Failure here means the adcp Python SDK pin in pyproject.toml has shifted
+    to a version that targets a different AdCP spec version. Either revert
+    the pin or follow docs/adcp-spec-version.md to update
+    EXPECTED_SPEC_VERSION and the related references it lists.
+    """
+    actual = adcp.get_adcp_spec_version()
+    assert actual == EXPECTED_SPEC_VERSION, (
+        f"adcp SDK targets spec {actual}, but this codebase expects "
+        f"{EXPECTED_SPEC_VERSION}. See docs/adcp-spec-version.md for "
+        f"reconciliation steps."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -206,7 +206,7 @@ requires-dist = [
     { name = "a2a-cli", specifier = ">=0.2.0" },
     { name = "a2a-sdk", extras = ["http-server"], specifier = ">=1.0.1" },
     { name = "a2wsgi", specifier = ">=1.10.0" },
-    { name = "adcp", specifier = ">=4.3.0" },
+    { name = "adcp", specifier = "==4.3.0" },
     { name = "aiohttp", specifier = ">=3.9.0" },
     { name = "alembic", specifier = ">=1.13.0" },
     { name = "allure-pytest", marker = "extra == 'ui-tests'", specifier = "==2.13.5" },


### PR DESCRIPTION
Pins adcp Python SDK to exact version 4.3.0 (was >=4.3.0) and adds infrastructure to make the targeted AdCP spec version explicit.

- pyproject.toml: adcp>=4.3.0 → adcp==4.3.0
- New tests/unit/test_adcp_spec_version.py: CI guard asserting adcp.get_adcp_spec_version() == "3.0.1"
- New docs/adcp-spec-version.md: SDK-to-spec mapping + bump procedure
- README.md: adds AdCP Compatibility section
- CLAUDE.md: adds reference to the doc

adcp 4.3.0 ships Pydantic models code-generated from AdCP spec 3.0.1 (per adcp.get_adcp_spec_version()). The previous open-upper-bound pin allowed silent dependency-resolution shifts to a 4.x release targeting a different spec version. The exact pin + CI guard prevents accidental drift; the doc makes the current target discoverable.