### PR TITLE
feat(rules): add review-derived code and test pattern rules

### DIFF
--- a/.claude/rules/patterns/review-code-patterns.md
+++ b/.claude/rules/patterns/review-code-patterns.md
@@ -1,7 +1,7 @@
-# Review-Derived Code Patterns
+# Code Review Patterns
 
-Patterns consistently flagged by ChrisHuie and KonstantinMirin across 102
-review comments on 14 merged PRs. Follow these when writing or modifying code.
+Recurring patterns extracted from code review history. Follow these when
+writing or modifying code.
 
 ## Hoisting — No Inline Imports Without Circular-Dep Justification
 

--- a/.claude/rules/patterns/review-code-patterns.md
+++ b/.claude/rules/patterns/review-code-patterns.md
@@ -148,7 +148,9 @@ with an inline code string. The structural guard tests cap these sites.
 
 ## Project Conventions
 
-- No issue/PR numbers in code comments — reference in commit messages only
+- FIXME comments must carry a GitHub issue reference — `FIXME(#1234)`, not
+  bare `FIXME` and not internal tool IDs (e.g. beads). Reviewers ask for the
+  issue-tagged form so the revisit condition is trackable.
 - No `# noqa: F401` on imports that are actually used
 - No `--link` in Docker commands — use named networks
 - Check `subprocess.run()` result `returncode` when the result drives a gate

--- a/.claude/rules/patterns/review-code-patterns.md
+++ b/.claude/rules/patterns/review-code-patterns.md
@@ -1,0 +1,154 @@
+# Review-Derived Code Patterns
+
+Patterns consistently flagged by ChrisHuie and KonstantinMirin across 102
+review comments on 14 merged PRs. Follow these when writing or modifying code.
+
+## Hoisting — No Inline Imports Without Circular-Dep Justification
+
+Move imports to module level unless a circular dependency requires deferral.
+
+```python
+# WRONG — inline import without circular dep
+def process_order(order_id: str) -> None:
+    from src.core.schemas import Order  # no circular dep exists
+    ...
+
+# CORRECT — module-level import
+from src.core.schemas import Order
+
+def process_order(order_id: str) -> None:
+    ...
+
+# ACCEPTABLE — circular dep requires deferral
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.core.schemas import Order
+```
+
+## Type Refinement — No `Any` Where a Concrete Type Is Known
+
+If a function only ever receives or returns one specific type, annotate it.
+
+```python
+# WRONG — Any hides the real type
+def get_errors(result: Any) -> list[Any]:
+    return result.errors
+
+# CORRECT — concrete types
+def get_errors(result: CreateMediaBuyResult) -> list[Error]:
+    return result.errors
+```
+
+Common violations:
+- `product: Any` that only accesses `.product_id` → `Product | None`
+- `list[Any]` that only contains `Error` objects → `list[Error]`
+- `-> Any` on a function that always returns a `BaseModel` subclass → type it
+- Use `TYPE_CHECKING` guard if the concrete type would cause a circular import
+
+## Create/Update Path Parity
+
+If a validator runs in `_create_*_impl`, it must also run in `_update_*_impl`
+(and vice versa) unless the asymmetry is intentional and documented.
+
+Asymmetric validation lets buyers bypass checks via the update path.
+
+```python
+# WRONG — create validates budget, update doesn't
+async def _create_media_buy_impl(req, identity):
+    validate_budget(req.budget, identity)
+    validate_targeting(req.targeting)
+    ...
+
+async def _update_media_buy_impl(req, identity):
+    validate_targeting(req.targeting)
+    # Missing: validate_budget — buyer can bypass via update
+    ...
+
+# CORRECT — both paths validate
+async def _update_media_buy_impl(req, identity):
+    validate_budget(req.budget, identity)
+    validate_targeting(req.targeting)
+    ...
+```
+
+Also check: if the create path guards on `identity.principal_id` and
+`identity.tenant_id`, the update/list/sync paths must do the same.
+
+## Raw Dicts → Typed Constructors
+
+When a model field is typed (e.g., `list[Error]`), pass typed instances,
+not raw dicts.
+
+```python
+# WRONG — raw dict to a typed field
+errors=[{"code": "FOO", "message": "bar"}]
+
+# CORRECT — typed constructor
+errors=[Error(code="FOO", message="bar")]
+```
+
+Also: both sides of a comparison must use the same representation.
+DB-hydrated Pydantic models vs serialized dicts will always be `!=`.
+Use `.model_dump(mode="json")` on both sides, or compare model-to-model.
+
+## Dead / Unreachable Code
+
+Remove code that can never execute:
+
+1. **Unreachable exception branch**: `except SomeError` where `SomeError`
+   cannot be raised by anything in the `try` block. Common: catching
+   `ToolError` around TypeAdapter calls (which raise `ValidationError`).
+
+2. **No-op transformation**: `json.loads(json.dumps(x))` where `x` is
+   already plain JSON types — the round-trip changes nothing.
+
+3. **Import of renamed/deleted symbol**: `from module import name` where
+   `name` no longer exists in `module`.
+
+## Redundant DB Queries
+
+Don't query the same data twice on hot paths:
+
+```python
+# WRONG — two queries with same WHERE clause
+count = repo.count_by_tenant(tenant_id)
+items = repo.get_by_tenant(tenant_id)
+
+# CORRECT — single query
+items = repo.get_by_tenant(tenant_id, limit=expected + 1)
+count = len(items)
+```
+
+Watch for `get_adapter()` and similar factory methods where a called
+helper re-queries what the caller already loaded.
+
+## `_impl` Functions — Raise Typed Exceptions, Don't Build Wire Shape
+
+`_impl` functions raise typed `AdCPError` subclasses. Boundary translators
+build the wire envelope via `build_two_layer_error_envelope()`.
+
+```python
+# WRONG — _impl building wire shape
+def _create_impl(req):
+    return {"errors": [{"code": "VALIDATION_ERROR", "message": msg}]}
+
+# WRONG — raw ValueError where a typed subclass exists
+def _create_impl(req):
+    raise ValueError("budget must be positive")
+
+# CORRECT — typed subclass with correct metadata
+def _create_impl(req):
+    raise AdCPBudgetTooLowError("budget must be positive")
+```
+
+Use the semantic subclass instead of `AdCPError(message, error_code="...")`
+with an inline code string. The structural guard tests cap these sites.
+
+## Project Conventions
+
+- No issue/PR numbers in code comments — reference in commit messages only
+- No `# noqa: F401` on imports that are actually used
+- No `--link` in Docker commands — use named networks
+- Check `subprocess.run()` result `returncode` when the result drives a gate

--- a/.claude/rules/patterns/review-code-patterns.md
+++ b/.claude/rules/patterns/review-code-patterns.md
@@ -3,9 +3,17 @@
 Recurring patterns extracted from code review history. Follow these when
 writing or modifying code.
 
-## Hoisting — No Inline Imports Without Circular-Dep Justification
+## Hoisting — No Inline Imports Without Justification
 
-Move imports to module level unless a circular dependency requires deferral.
+Move imports to module level unless a sanctioned exception applies:
+
+1. A circular dependency requires deferral
+2. `TYPE_CHECKING` guards
+3. Test files — fixture/function-scoped imports are repo convention
+4. A documented lazy import (e.g. an explicit comment explaining
+   test-patching or startup-cost rationale)
+
+Production code with an inline import and none of the above — flag it.
 
 ```python
 # WRONG — inline import without circular dep

--- a/.claude/rules/patterns/review-test-patterns.md
+++ b/.claude/rules/patterns/review-test-patterns.md
@@ -1,7 +1,7 @@
-# Review-Derived Test Patterns
+# Test Review Patterns
 
-Patterns consistently flagged by ChrisHuie and KonstantinMirin in test code
-across 102 review comments on 14 merged PRs. Follow these when writing tests.
+Recurring patterns extracted from test code review history. Follow these
+when writing or modifying tests.
 
 ## Vacuous / Tautological Assertions
 

--- a/.claude/rules/patterns/review-test-patterns.md
+++ b/.claude/rules/patterns/review-test-patterns.md
@@ -1,0 +1,117 @@
+# Review-Derived Test Patterns
+
+Patterns consistently flagged by ChrisHuie and KonstantinMirin in test code
+across 102 review comments on 14 merged PRs. Follow these when writing tests.
+
+## Vacuous / Tautological Assertions
+
+Every assertion must be capable of failing when the code is wrong.
+
+### OR Short-Circuit
+```python
+# WRONG — when X is True, Y never evaluates
+assert not isinstance(response, CreateMediaBuyError) or all(
+    pkg.status == "active" for pkg in response.packages
+)
+
+# CORRECT — split into two asserts
+assert not isinstance(response, CreateMediaBuyError)
+assert all(pkg.status == "active" for pkg in response.packages)
+```
+
+### hasattr on Concrete Object
+```python
+# WRONG — always True; method exists unconditionally on the class
+assert hasattr(adapter, "get_products")
+
+# CORRECT — assert something meaningful about behavior
+result = adapter.get_products(brief="test")
+assert result is not None
+```
+
+### Happy Path With Zero Assertions
+```python
+# WRONG — no assertion on the response
+def test_create_media_buy():
+    result = create_media_buy_impl(req)
+    # ... nothing checked
+
+# CORRECT — at minimum assert success
+def test_create_media_buy():
+    result = create_media_buy_impl(req)
+    assert not isinstance(result, CreateMediaBuyError)
+    assert result.media_buy_id is not None
+```
+
+### Always-True Inequality
+```python
+# WRONG — Pydantic model != dict is always True in Python
+assert response != {"status": "active"}
+
+# CORRECT — compare same representations
+assert response.model_dump(mode="json") == {"status": "active"}
+# or
+assert response == ExpectedModel(status="active")
+```
+
+## Test DRY — Use Shared Helpers
+
+When a helper exists in `tests/utils/` or `tests/helpers/`, use it.
+Don't re-implement the same logic inline.
+
+```python
+# WRONG — hand-rolling setup that a factory already provides
+tenant = Tenant(id="t1", name="test", ...)
+principal = Principal(id="p1", tenant_id="t1", ...)
+
+# CORRECT — use the shared factory
+from tests.factories import TenantFactory, PrincipalFactory
+tenant = TenantFactory()
+principal = PrincipalFactory(tenant=tenant)
+```
+
+When adding a new test factory or fixture, check that existing tests in
+the same file aren't still hand-rolling the same setup.
+
+## BDD / Integration Assertion Strength
+
+Don't weaken assertions when modifying BDD steps.
+
+```python
+# WRONG — OR where Gherkin implies AND
+# Gherkin: "Then response contains error message AND field reference"
+assert "error" in response or "field" in response  # OR lets one slide
+
+# CORRECT — both conditions
+assert "error" in response
+assert "field" in response
+```
+
+- Don't replace field-identity checks (`response_names == registered_names`)
+  with count checks (`len(response_names) == len(registered_names)`)
+- Don't remove guards (`len(x) > 0`) before asserting on contents
+
+## Error Tests — Assert on Wire Envelope, Not Reconstructed Exceptions
+
+The test harness reconstructs `AdCPError` from wire responses, but this
+reconstruction is lossy. Assert on the wire envelope as the primary authority.
+
+```python
+# WRONG — tests reconstruction, not the buyer-facing wire contract
+assert isinstance(result.error, AdCPValidationError)
+assert result.error.error_code == "VALIDATION_ERROR"
+
+# CORRECT — tests actual wire shape
+assert result.is_error
+assert_envelope_shape(
+    result.wire_error_envelope,
+    "VALIDATION_ERROR",
+    recovery="correctable",
+)
+```
+
+Always verify the `recovery` field (`transient`, `correctable`, `terminal`)
+— it drives buyer-agent retry semantics.
+
+**Exception:** `_impl`-level unit tests (no wire involved) may use
+`isinstance()` and `.error_code` since they test the raise site directly.


### PR DESCRIPTION
## Summary

- Adds two rule files to `.claude/rules/patterns/` so agents internalize review patterns upfront rather than catching them in a post-hoc review pass
- **review-code-patterns.md**: hoisting, type refinement, create/update parity, raw dicts → typed constructors, dead code, redundant DB queries, typed exceptions in `_impl`, project conventions
- **review-test-patterns.md**: vacuous assertions, test DRY, BDD assertion strength, wire envelope assertions over reconstructed exceptions

## Context

Reworked from PRs #1364 and #1365 (which used a skill/command approach) into rule files per review feedback. These load into agent context at session start so the patterns are followed one-shot.

Derived from recurring patterns in code review history, plus error-emission architecture conventions from PR #1306.

Follows the existing format in `.claude/rules/patterns/` (`code-patterns.md`, `testing-patterns.md`, `mcp-patterns.md`).

Supersedes #1364 and #1365.

## Test plan

- [ ] Start a new Claude session in the salesagent repo and verify the rules load
- [ ] Write code that violates a pattern (e.g., inline import) and confirm the agent avoids or self-corrects it
- [ ] Confirm no overlap/contradiction with existing pattern files