### PR TITLE
fix(ci): bump uv 0.11.6 -> 0.11.15 for GHSA-4gg8-gxpx-9rph

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 env:
   PYTHON_VERSION: '3.12'
-  UV_VERSION: '0.11.6'
+  UV_VERSION: '0.11.15'
 
 jobs:
   security-audit:


### PR DESCRIPTION
## Summary
The CI `security-audit` job (`.github/workflows/test.yml`) installs uv via the `UV_VERSION` env and runs `uv-secure`, which flags the **global uv tool at 0.11.6** for **GHSA-4gg8-gxpx-9rph**. This fails the `Security Audit` check — and the dependent `Test Summary` gate — on every PR run today, independent of the PR's contents (older PR runs passed because the advisory was published after them).

## Fix
Bump `UV_VERSION` `0.11.6` → `0.11.15` (the advisory's fix version). This single env drives all `setup-uv` steps in the workflow.

## Scope
- Project dependencies (`uv.lock`) are unaffected and already clean (audit reports "261 dependencies, all safe"). Only the CI uv *tool* version changes.
- No action SHA pins change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)