### PR TITLE
feat(ci): parallel BDD CI shards with merged coverage (stacked on PR3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,8 +316,12 @@ jobs:
           paths: tests/admin/
           extra_args: -m "not requires_server and not slow"
 
-  bdd-tests:
-    name: BDD Tests
+  bdd-tests-shard:
+    name: BDD Tests (Shard ${{ matrix.shard }}/2)
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -347,30 +351,53 @@ jobs:
       - uses: ./.github/actions/_postgres
         with:
           database-url: ${{ env.DATABASE_URL }}
+      - name: Resolve BDD shard paths
+        id: bdd_shard
+        run: |
+          mapfile -t TEST_FILES < <(uv run python scripts/ci/shard_paths.py bdd ${{ matrix.shard }})
+          joined="${TEST_FILES[*]}"
+          echo "paths=${joined}" >> "$GITHUB_OUTPUT"
       - uses: ./.github/actions/_pytest
         env:
-          # Separate data file so the artifact cannot collide with unit's .coverage.
-          COVERAGE_FILE: .coverage.bdd
+          # Separate data file per shard so artifacts cannot collide with unit's .coverage.
+          COVERAGE_FILE: .coverage.bdd-${{ matrix.shard }}
         with:
-          paths: tests/bdd/
-          coverage_xml: coverage-bdd.xml
+          paths: ${{ steps.bdd_shard.outputs.paths }}
+          coverage_xml: coverage-bdd-${{ matrix.shard }}.xml
           extra_args: -n auto --dist=loadfile --timeout=60
       - name: Combine xdist coverage fragments
         run: |
           shopt -s nullglob
-          fragments=(.coverage.bdd.*)
+          fragments=(.coverage.bdd-${{ matrix.shard }}.*)
           if [ "${#fragments[@]}" -gt 0 ]; then
-            uv run coverage combine --data-file=.coverage.bdd .coverage.bdd "${fragments[@]}"
+            uv run coverage combine --data-file=.coverage.bdd-${{ matrix.shard }} \
+              .coverage.bdd-${{ matrix.shard }} "${fragments[@]}"
           fi
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
-          name: bdd-coverage
+          name: bdd-shard-${{ matrix.shard }}-coverage
           path: |
-            .coverage.bdd
-            coverage-bdd.xml
+            .coverage.bdd-${{ matrix.shard }}
+            coverage-bdd-${{ matrix.shard }}.xml
           include-hidden-files: true
           if-no-files-found: error
+
+  bdd-tests:
+    name: BDD Tests
+    runs-on: ubuntu-latest
+    needs: [bdd-tests-shard]
+    if: always()
+    permissions:
+      contents: read
+    steps:
+      - name: Aggregate BDD shards
+        run: |
+          if [ "${{ needs.bdd-tests-shard.result }}" != "success" ]; then
+            echo "One or more BDD shards failed."
+            exit 1
+          fi
+          echo "BDD shards passed."
 
   migration-roundtrip:
     name: Migration Roundtrip
@@ -409,8 +436,8 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
-    needs: [unit-tests, bdd-tests]
-    if: ${{ needs.unit-tests.result == 'success' && needs.bdd-tests.result == 'success' }}
+    needs: [unit-tests, bdd-tests-shard]
+    if: ${{ needs.unit-tests.result == 'success' && needs.bdd-tests-shard.result == 'success' }}
     permissions:
       contents: read
     timeout-minutes: 10
@@ -427,18 +454,22 @@ jobs:
           name: unit-coverage
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: bdd-coverage
+          pattern: bdd-shard-*-coverage
+          merge-multiple: true
+          path: bdd-coverage-shards
       - name: Coverage gate
         run: |
+          shopt -s nullglob
+          mapfile -t bdd_data_files < <(find bdd-coverage-shards -name '.coverage.bdd-*' -type f | sort)
+          if [ "${#bdd_data_files[@]}" -eq 0 ]; then
+            echo "No BDD coverage data files downloaded."
+            exit 1
+          fi
           if [ ! -f .coverage ]; then
             echo "Unit coverage data file missing."
             exit 1
           fi
-          if [ ! -f .coverage.bdd ]; then
-            echo "BDD coverage data file missing."
-            exit 1
-          fi
-          uv run coverage combine --data-file=.coverage.combined .coverage .coverage.bdd
+          uv run coverage combine --data-file=.coverage.combined .coverage "${bdd_data_files[@]}"
           ./scripts/ci/coverage_report.sh --data-file .coverage.combined
 
   summary:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,7 +354,15 @@ jobs:
       - name: Resolve BDD shard paths
         id: bdd_shard
         run: |
-          mapfile -t TEST_FILES < <(uv run python scripts/ci/shard_paths.py bdd ${{ matrix.shard }})
+          set -euo pipefail
+          shard_list=$(mktemp)
+          trap 'rm -f "$shard_list"' EXIT
+          uv run python scripts/ci/shard_paths.py bdd ${{ matrix.shard }} > "$shard_list"
+          mapfile -t TEST_FILES < "$shard_list"
+          if [ "${#TEST_FILES[@]}" -eq 0 ]; then
+            echo "::error::shard_paths.py produced no files for bdd shard ${{ matrix.shard }}"
+            exit 1
+          fi
           joined="${TEST_FILES[*]}"
           echo "paths=${joined}" >> "$GITHUB_OUTPUT"
       - uses: ./.github/actions/_pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,7 +317,7 @@ jobs:
           extra_args: -m "not requires_server and not slow"
 
   bdd-tests-shard:
-    name: BDD Tests (Shard ${{ matrix.shard }}/2)
+    name: BDD Tests (Shard ${{ matrix.shard }}/${{ strategy.job-total }})
     strategy:
       fail-fast: false
       matrix:
@@ -398,6 +398,7 @@ jobs:
     if: always()
     permissions:
       contents: read
+    timeout-minutes: 5
     steps:
       - name: Aggregate BDD shards
         run: |
@@ -412,6 +413,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    timeout-minutes: 15
     services:
       postgres:
         image: postgres:15
@@ -467,10 +469,19 @@ jobs:
           path: bdd-coverage-shards
       - name: Coverage gate
         run: |
-          shopt -s nullglob
-          mapfile -t bdd_data_files < <(find bdd-coverage-shards -name '.coverage.bdd-*' -type f | sort)
-          if [ "${#bdd_data_files[@]}" -eq 0 ]; then
-            echo "No BDD coverage data files downloaded."
+          set -euo pipefail
+          expected_bdd_shards="$(uv run python -c "from scripts.ci.shard_split import SHARD_COUNTS; print(SHARD_COUNTS['bdd'])")"
+          bdd_data_files=()
+          for shard in $(seq 1 "${expected_bdd_shards}"); do
+            found="$(find bdd-coverage-shards -name ".coverage.bdd-${shard}" -type f | head -1)"
+            if [ -z "${found}" ]; then
+              echo "::error::Missing BDD coverage artifact for shard ${shard} (.coverage.bdd-${shard})"
+              exit 1
+            fi
+            bdd_data_files+=("${found}")
+          done
+          if [ "${#bdd_data_files[@]}" -ne "${expected_bdd_shards}" ]; then
+            echo "::error::Expected ${expected_bdd_shards} BDD coverage files, found ${#bdd_data_files[@]}"
             exit 1
           fi
           if [ ! -f .coverage ]; then
@@ -484,6 +495,8 @@ jobs:
     name: Summary
     runs-on: ubuntu-latest
     if: always()
+    permissions:
+      contents: read
     timeout-minutes: 5
     needs:
       [

--- a/docs/development/ci-pipeline.md
+++ b/docs/development/ci-pipeline.md
@@ -63,6 +63,16 @@ status-only. Shard jobs route pytest through the shared `_pytest` composite.
 | 1/2 | 5 | 479 |
 | 2/2 | 8 | 441 |
 
+Reproduce a CI shard locally:
+
+```bash
+uv run pytest $(uv run python scripts/ci/shard_paths.py bdd 1)
+```
+
+`make test-bdd` (full `tests/bdd/`) runs the same scenarios as both shards combined.
+
+**Load metric note:** greedy assignment balances Gherkin `Scenario` line counts (~920 total). Collected pytest items are much higher (~9×) because each scenario expands by `Examples:` rows and transport parametrization. Wall-clock is dominated by slow DB-heavy scenarios, not test volume — the reason 2 shards was chosen over 3–4.
+
 Structural guard: `tests/unit/test_architecture_ci_bdd_shard_manifest.py`.
 
 ## Integration Test Shards

--- a/docs/development/ci-pipeline.md
+++ b/docs/development/ci-pipeline.md
@@ -18,11 +18,14 @@ git rebase upstream/main
 git diff upstream/main --stat   # target: ~20-30 files, no alembic/versions/ changes
 ```
 
-## Required checks (18 rendered names)
+## Required checks (20 rendered names after PR #1379)
 
 Run `./scripts/capture-rendered-names.sh` after any job rename. The frozen guard
 [`tests/unit/test_architecture_required_ci_checks_frozen.py`](../../tests/unit/test_architecture_required_ci_checks_frozen.py)
 must stay in sync.
+
+PR #1372 (PR3) establishes **18** checks. PR #1379 adds **2 BDD shard** checks
+plus the aggregate `CI / BDD Tests` status proxy (replacing PR3's single BDD job).
 
 | Rendered check name | Job |
 |---------------------|-----|
@@ -40,10 +43,27 @@ must stay in sync.
 | `CI / Integration (other)` | integration shard |
 | `CI / E2E Tests` | full stack |
 | `CI / Admin UI Tests` | admin suite |
-| `CI / BDD Tests` | BDD suite (single job in PR3; sharding is PR #1379) |
+| `CI / BDD Tests (Shard 1/2)` | BDD greedy scenario shard |
+| `CI / BDD Tests (Shard 2/2)` | BDD greedy scenario shard |
+| `CI / BDD Tests` | aggregate status proxy (shard pass/fail) |
 | `CI / Migration Roundtrip` | alembic upgrade |
 | `CI / Coverage` | `--fail-under` from `.coverage-baseline` using unit + BDD artifacts |
 | `CI / Summary` | aggregation gate |
+
+## BDD Test Shards
+
+BDD tests (`tests/bdd/test_*.py`, 13 files) run in **2 parallel shards** via
+greedy min-load assignment by Gherkin scenario count (`scripts/ci/shard_split.py`).
+Each shard uploads coverage; the **Coverage** job combines unit + BDD shard
+artifacts and enforces `.coverage-baseline`. The aggregate `BDD Tests` job is
+status-only. Shard jobs route pytest through the shared `_pytest` composite.
+
+| Shard | Files | Scenarios (approx.) |
+|-------|------:|--------------------:|
+| 1/2 | 5 | 479 |
+| 2/2 | 8 | 441 |
+
+Structural guard: `tests/unit/test_architecture_ci_bdd_shard_manifest.py`.
 
 ## Integration Test Shards
 
@@ -139,7 +159,7 @@ required (or stay blocked on stale `Test Suite / …` names).
    - Add all 18 checks prefixed with `CI /` from the script output.
 4. Keep non-CI required checks unchanged (`check-pr-title`, CodeQL, `security.yml` jobs, etc.).
 5. Merge PR #1372 only after a test PR shows all 18 `CI / …` checks as required and green.
-6. For BDD parallel sharding (PR #1379): update branch protection again when shard check names are added — do **not** combine with PR3.
+6. After PR #1379 (BDD sharding): add the 2 `CI / BDD Tests (Shard …/2)` required checks and keep `CI / BDD Tests` as the aggregate proxy — **separate** branch-protection update from PR3.
 
 ### Local vs CI quality targets
 

--- a/scripts/ci/migration_roundtrip.py
+++ b/scripts/ci/migration_roundtrip.py
@@ -15,16 +15,20 @@ from alembic.runtime.migration import MigrationContext
 from sqlalchemy import create_engine
 
 from alembic import command
-from tests.unit._migration_helpers import get_migration_heads, resolve_roundtrip_downgrade_target
+from tests.unit._migration_helpers import (
+    expected_heads_after_roundtrip_downgrade,
+    get_migration_heads,
+    resolve_roundtrip_downgrade_target,
+)
 
 
-def _assert_revision(cfg: Config, expected: str, label: str) -> None:
+def _assert_heads(cfg: Config, expected: set[str], label: str) -> None:
     engine = create_engine(cfg.get_main_option("sqlalchemy.url"))
     with engine.connect() as conn:
         context = MigrationContext.configure(conn)
-        current = context.get_current_revision()
+        current = set(context.get_current_heads())
     if current != expected:
-        msg = f"{label}: expected revision {expected}, got {current}"
+        msg = f"{label}: expected heads {sorted(expected)}, got {sorted(current)}"
         raise RuntimeError(msg)
 
 
@@ -34,16 +38,17 @@ def main() -> int:
 
     print("Running alembic upgrade head...")
     command.upgrade(cfg, "head")
-    _assert_revision(cfg, head_revision, "after initial upgrade")
+    _assert_heads(cfg, {head_revision}, "after initial upgrade")
 
     target = resolve_roundtrip_downgrade_target(head_revision)
+    expected_after_downgrade = expected_heads_after_roundtrip_downgrade(head_revision)
     print(f"Running alembic downgrade {target}...")
     command.downgrade(cfg, target)
-    _assert_revision(cfg, target, "after downgrade")
+    _assert_heads(cfg, expected_after_downgrade, "after downgrade")
 
     print("Running alembic upgrade head...")
     command.upgrade(cfg, "head")
-    _assert_revision(cfg, head_revision, "after final upgrade")
+    _assert_heads(cfg, {head_revision}, "after final upgrade")
 
     print("Migration roundtrip completed successfully.")
     return 0

--- a/scripts/ci/migration_roundtrip.py
+++ b/scripts/ci/migration_roundtrip.py
@@ -11,26 +11,39 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from alembic.config import Config
+from alembic.runtime.migration import MigrationContext
+from sqlalchemy import create_engine
 
 from alembic import command
-from tests.unit._migration_helpers import resolve_roundtrip_downgrade_target
+from tests.unit._migration_helpers import get_migration_heads, resolve_roundtrip_downgrade_target
+
+
+def _assert_revision(cfg: Config, expected: str, label: str) -> None:
+    engine = create_engine(cfg.get_main_option("sqlalchemy.url"))
+    with engine.connect() as conn:
+        context = MigrationContext.configure(conn)
+        current = context.get_current_revision()
+    if current != expected:
+        msg = f"{label}: expected revision {expected}, got {current}"
+        raise RuntimeError(msg)
 
 
 def main() -> int:
     cfg = Config(str(_REPO_ROOT / "alembic.ini"))
+    head_revision = next(iter(get_migration_heads()))
 
     print("Running alembic upgrade head...")
     command.upgrade(cfg, "head")
-    command.current(cfg)
+    _assert_revision(cfg, head_revision, "after initial upgrade")
 
-    target = resolve_roundtrip_downgrade_target()
+    target = resolve_roundtrip_downgrade_target(head_revision)
     print(f"Running alembic downgrade {target}...")
     command.downgrade(cfg, target)
-    command.current(cfg)
+    _assert_revision(cfg, target, "after downgrade")
 
     print("Running alembic upgrade head...")
     command.upgrade(cfg, "head")
-    command.current(cfg)
+    _assert_revision(cfg, head_revision, "after final upgrade")
 
     print("Migration roundtrip completed successfully.")
     return 0

--- a/scripts/ci/shard_paths.py
+++ b/scripts/ci/shard_paths.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Print test paths for a CI BDD shard (one path per line)."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.ci.shard_split import SHARD_COUNTS, paths_for_shard  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("suite", choices=sorted(SHARD_COUNTS))
+    parser.add_argument("shard", type=int, help="1-based shard index")
+    args = parser.parse_args()
+    try:
+        paths = paths_for_shard(args.suite, args.shard)
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+    if not paths:
+        print(f"No tests assigned to {args.suite} shard {args.shard}", file=sys.stderr)
+        return 1
+    print("\n".join(paths))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/shard_split.py
+++ b/scripts/ci/shard_split.py
@@ -1,0 +1,82 @@
+"""Deterministic CI test sharding for BDD parallel jobs.
+
+BDD files are assigned one at a time (sorted path order) to the shard with the
+lowest current scenario count. Ties go to the lowest shard index. Scenario counts
+are read from each test file's ``scenarios("features/....feature")`` binding.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_SCENARIO_LINE = re.compile(r"^\s*Scenario", re.MULTILINE)
+_SCENARIOS_CALL = re.compile(r"""scenarios\s*\(\s*["'](features/[^"']+)["']""")
+
+# Keep in sync with strategy.matrix.shard in .github/workflows/ci.yml (bdd-tests-shard).
+SHARD_COUNTS: dict[str, int] = {
+    "bdd": 2,
+}
+
+SUITE_GLOBS: dict[str, str] = {
+    "bdd": "tests/bdd/test_*.py",
+}
+
+
+def list_suite_files(suite: str, repo_root: Path | None = None) -> list[str]:
+    if suite not in SUITE_GLOBS:
+        raise KeyError(f"Unknown suite {suite!r}")
+    root = repo_root or _REPO_ROOT
+    return sorted(str(p.relative_to(root)) for p in root.glob(SUITE_GLOBS[suite]))
+
+
+def bdd_scenario_count(test_path: str, repo_root: Path | None = None) -> int:
+    """Return the number of Gherkin scenarios bound by a BDD test module."""
+    root = repo_root or _REPO_ROOT
+    text = (root / test_path).read_text(encoding="utf-8")
+    match = _SCENARIOS_CALL.search(text)
+    if match is None:
+        raise ValueError(f"No scenarios() feature binding found in {test_path}")
+    feature_path = root / "tests/bdd" / match.group(1)
+    if not feature_path.is_file():
+        raise ValueError(f"Feature file not found for {test_path}: {feature_path}")
+    return len(_SCENARIO_LINE.findall(feature_path.read_text(encoding="utf-8")))
+
+
+def _assign_round_robin(files: list[str], shard_count: int) -> dict[int, list[str]]:
+    buckets: dict[int, list[str]] = {i: [] for i in range(1, shard_count + 1)}
+    for index, path in enumerate(files):
+        buckets[(index % shard_count) + 1].append(path)
+    return buckets
+
+
+def _assign_greedy_by_scenario_count(
+    files: list[str],
+    shard_count: int,
+    repo_root: Path,
+) -> dict[int, list[str]]:
+    loads: dict[int, int] = dict.fromkeys(range(1, shard_count + 1), 0)
+    buckets: dict[int, list[str]] = {i: [] for i in range(1, shard_count + 1)}
+    for path in files:
+        shard = min(range(1, shard_count + 1), key=lambda index: (loads[index], index))
+        buckets[shard].append(path)
+        loads[shard] += bdd_scenario_count(path, repo_root=repo_root)
+    return buckets
+
+
+def assign_files_to_shards(suite: str, repo_root: Path | None = None) -> dict[int, list[str]]:
+    root = repo_root or _REPO_ROOT
+    files = list_suite_files(suite, repo_root=root)
+    shard_count = SHARD_COUNTS[suite]
+    if suite == "bdd":
+        return _assign_greedy_by_scenario_count(files, shard_count, root)
+    return _assign_round_robin(files, shard_count)
+
+
+def paths_for_shard(suite: str, shard: int, repo_root: Path | None = None) -> list[str]:
+    buckets = assign_files_to_shards(suite, repo_root=repo_root)
+    if shard not in buckets:
+        raise ValueError(f"Shard {shard} out of range 1..{SHARD_COUNTS[suite]} for {suite}")
+    return buckets[shard]

--- a/scripts/ci/shard_split.py
+++ b/scripts/ci/shard_split.py
@@ -45,18 +45,13 @@ def bdd_scenario_count(test_path: str, repo_root: Path | None = None) -> int:
     return len(_SCENARIO_LINE.findall(feature_path.read_text(encoding="utf-8")))
 
 
-def _assign_round_robin(files: list[str], shard_count: int) -> dict[int, list[str]]:
-    buckets: dict[int, list[str]] = {i: [] for i in range(1, shard_count + 1)}
-    for index, path in enumerate(files):
-        buckets[(index % shard_count) + 1].append(path)
-    return buckets
-
-
 def _assign_greedy_by_scenario_count(
     files: list[str],
     shard_count: int,
     repo_root: Path,
 ) -> dict[int, list[str]]:
+    if shard_count > len(files):
+        raise ValueError(f"shard_count={shard_count} exceeds {len(files)} bdd files; a shard would be empty")
     loads: dict[int, int] = dict.fromkeys(range(1, shard_count + 1), 0)
     buckets: dict[int, list[str]] = {i: [] for i in range(1, shard_count + 1)}
     for path in files:
@@ -67,12 +62,12 @@ def _assign_greedy_by_scenario_count(
 
 
 def assign_files_to_shards(suite: str, repo_root: Path | None = None) -> dict[int, list[str]]:
+    if suite != "bdd":
+        raise KeyError(f"Unknown suite {suite!r}")
     root = repo_root or _REPO_ROOT
     files = list_suite_files(suite, repo_root=root)
     shard_count = SHARD_COUNTS[suite]
-    if suite == "bdd":
-        return _assign_greedy_by_scenario_count(files, shard_count, root)
-    return _assign_round_robin(files, shard_count)
+    return _assign_greedy_by_scenario_count(files, shard_count, root)
 
 
 def paths_for_shard(suite: str, shard: int, repo_root: Path | None = None) -> list[str]:

--- a/scripts/ci/shard_split.py
+++ b/scripts/ci/shard_split.py
@@ -12,7 +12,8 @@ from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
-_SCENARIO_LINE = re.compile(r"^\s*Scenario", re.MULTILINE)
+_PLAIN_SCENARIO = re.compile(r"^\s*Scenario:\s", re.MULTILINE)
+_SCENARIO_OUTLINE = re.compile(r"^\s*Scenario Outline:", re.MULTILINE)
 _SCENARIOS_CALL = re.compile(r"""scenarios\s*\(\s*["'](features/[^"']+)["']""")
 
 # Keep in sync with strategy.matrix.shard in .github/workflows/ci.yml (bdd-tests-shard).
@@ -42,7 +43,8 @@ def bdd_scenario_count(test_path: str, repo_root: Path | None = None) -> int:
     feature_path = root / "tests/bdd" / match.group(1)
     if not feature_path.is_file():
         raise ValueError(f"Feature file not found for {test_path}: {feature_path}")
-    return len(_SCENARIO_LINE.findall(feature_path.read_text(encoding="utf-8")))
+    feature_text = feature_path.read_text(encoding="utf-8")
+    return len(_PLAIN_SCENARIO.findall(feature_text)) + len(_SCENARIO_OUTLINE.findall(feature_text))
 
 
 def _assign_greedy_by_scenario_count(

--- a/tests/unit/_migration_helpers.py
+++ b/tests/unit/_migration_helpers.py
@@ -154,6 +154,34 @@ def resolve_roundtrip_downgrade_target(head_revision: str | None = None) -> str:
     raise ValueError(msg)
 
 
+def expected_heads_after_roundtrip_downgrade(head_revision: str | None = None) -> set[str]:
+    """Return alembic_version heads expected after CI roundtrip downgrade from head.
+
+    Non-merge heads land on a single parent revision. Merge heads restore every
+    branch tip listed in ``down_revision`` (Alembic branches docs).
+    """
+    if head_revision is None:
+        heads = get_migration_heads()
+        if len(heads) != 1:
+            msg = f"Expected exactly 1 migration head, found {sorted(heads)}"
+            raise ValueError(msg)
+        head_revision = next(iter(heads))
+
+    for path in get_migration_files():
+        revision, down_revisions = extract_revision_info(path)
+        if revision != head_revision:
+            continue
+        if not down_revisions:
+            msg = f"Cannot downgrade from base revision {head_revision}"
+            raise ValueError(msg)
+        if len(down_revisions) == 1:
+            return {down_revisions[0]}
+        return set(down_revisions)
+
+    msg = f"Migration file not found for head revision {head_revision}"
+    raise ValueError(msg)
+
+
 def is_merge_migration(tree: ast.Module) -> bool:
     """Check if this is a merge migration (empty upgrade + downgrade is OK).
 

--- a/tests/unit/_migration_helpers.py
+++ b/tests/unit/_migration_helpers.py
@@ -21,15 +21,28 @@ def get_migration_files() -> list[Path]:
     return sorted(f for f in MIGRATIONS_DIR.glob("*.py") if f.name != "__init__.py" and not f.name.startswith("__"))
 
 
-def parse_function(tree: ast.Module, name: str) -> ast.FunctionDef | None:
+def parse_function(tree: ast.Module, name: str) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
     """Find a top-level function by name in the AST."""
     for node in ast.iter_child_nodes(tree):
-        if isinstance(node, ast.FunctionDef) and node.name == name:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
             return node
     return None
 
 
-def is_empty_body(node: ast.FunctionDef) -> bool:
+def iter_migration_trees() -> list[tuple[Path, ast.Module]]:
+    """Parse every migration file into (path, ast.Module) pairs."""
+    trees: list[tuple[Path, ast.Module]] = []
+    for path in get_migration_files():
+        source = path.read_text()
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError:
+            continue
+        trees.append((path, tree))
+    return trees
+
+
+def is_empty_body(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
     """Check if a function body contains only pass/docstring."""
     for stmt in node.body:
         if isinstance(stmt, ast.Pass):

--- a/tests/unit/test_architecture_ci_bdd_shard_manifest.py
+++ b/tests/unit/test_architecture_ci_bdd_shard_manifest.py
@@ -20,7 +20,7 @@ from scripts.ci.shard_split import (
 from tests.unit.workflow_helpers import CI_WORKFLOW_PATH
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
-_BDD_MODULE_LINE = re.compile(r"^\s*<Module ([^>]+)>\s*$")
+_COLLECT_TAG = re.compile(r"^<(Dir|Package|Module) ([^>]+)>$")
 
 
 def _pytest_bdd_module_paths(repo_root: Path) -> set[str]:
@@ -45,13 +45,26 @@ def _pytest_bdd_module_paths(repo_root: Path) -> set[str]:
         msg = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
         pytest.fail(f"pytest --collect-only tests/bdd/ failed: {msg}")
 
+    stack: list[str] = []
     paths: set[str] = set()
     for line in result.stdout.splitlines():
-        match = _BDD_MODULE_LINE.match(line)
-        if match:
-            paths.add(f"tests/bdd/{match.group(1)}")
+        stripped = line.strip()
+        match = _COLLECT_TAG.match(stripped)
+        if match is None:
+            continue
+        kind, name = match.groups()
+        if kind == "Module":
+            if "bdd" not in stack:
+                continue
+            bdd_idx = stack.index("bdd")
+            if bdd_idx < 1:
+                continue
+            paths.add("/".join(stack[bdd_idx - 1 : bdd_idx + 1] + [name]))
+        elif kind in {"Dir", "Package"}:
+            stack.append(name)
+
     if not paths:
-        pytest.fail("pytest --collect-only tests/bdd/ returned no <Module …> entries")
+        pytest.fail("pytest --collect-only tests/bdd/ returned no BDD module paths")
     return paths
 
 
@@ -70,6 +83,16 @@ def test_ci_bdd_matrix_matches_shard_config() -> None:
     workflow = yaml.safe_load(CI_WORKFLOW_PATH.read_text(encoding="utf-8"))
     matrix = workflow["jobs"]["bdd-tests-shard"]["strategy"]["matrix"]["shard"]
     assert matrix == list(range(1, SHARD_COUNTS["bdd"] + 1))
+
+
+@pytest.mark.arch_guard
+def test_ci_bdd_shard_job_name_uses_matrix_total() -> None:
+    """Shard denominator must follow matrix size (not a hardcoded literal)."""
+    workflow = yaml.safe_load(CI_WORKFLOW_PATH.read_text(encoding="utf-8"))
+    name = workflow["jobs"]["bdd-tests-shard"]["name"]
+    assert "strategy.job-total" in name, (
+        "bdd-tests-shard job name must use strategy.job-total for the shard denominator."
+    )
 
 
 @pytest.mark.arch_guard

--- a/tests/unit/test_architecture_ci_bdd_shard_manifest.py
+++ b/tests/unit/test_architecture_ci_bdd_shard_manifest.py
@@ -9,6 +9,7 @@ import yaml
 
 from scripts.ci.shard_split import (
     SHARD_COUNTS,
+    _assign_greedy_by_scenario_count,
     assign_files_to_shards,
     bdd_scenario_count,
     list_suite_files,
@@ -39,7 +40,14 @@ def test_ci_bdd_matrix_matches_shard_config() -> None:
 @pytest.mark.arch_guard
 def test_bdd_shards_have_discoverable_scenario_counts() -> None:
     for path in list_suite_files("bdd", repo_root=_REPO_ROOT):
-        assert bdd_scenario_count(path, repo_root=_REPO_ROOT) >= 0
+        assert bdd_scenario_count(path, repo_root=_REPO_ROOT) >= 1
+
+
+@pytest.mark.arch_guard
+def test_bdd_greedy_split_rejects_shard_count_above_file_count() -> None:
+    files = list_suite_files("bdd", repo_root=_REPO_ROOT)
+    with pytest.raises(ValueError, match="shard would be empty"):
+        _assign_greedy_by_scenario_count(files, len(files) + 1, _REPO_ROOT)
 
 
 @pytest.mark.arch_guard

--- a/tests/unit/test_architecture_ci_bdd_shard_manifest.py
+++ b/tests/unit/test_architecture_ci_bdd_shard_manifest.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import re
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -17,17 +20,49 @@ from scripts.ci.shard_split import (
 from tests.unit.workflow_helpers import CI_WORKFLOW_PATH
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
+_BDD_MODULE_LINE = re.compile(r"^\s*<Module ([^>]+)>\s*$")
+
+
+def _pytest_bdd_module_paths(repo_root: Path) -> set[str]:
+    """Collect BDD test module paths via pytest (independent of shard_split glob)."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/bdd/",
+            "--collect-only",
+            "-q",
+            "--no-header",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        timeout=120,
+        check=False,
+    )
+    if result.returncode != 0:
+        msg = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        pytest.fail(f"pytest --collect-only tests/bdd/ failed: {msg}")
+
+    paths: set[str] = set()
+    for line in result.stdout.splitlines():
+        match = _BDD_MODULE_LINE.match(line)
+        if match:
+            paths.add(f"tests/bdd/{match.group(1)}")
+    if not paths:
+        pytest.fail("pytest --collect-only tests/bdd/ returned no <Module …> entries")
+    return paths
 
 
 @pytest.mark.arch_guard
 def test_bdd_shards_partition_suite() -> None:
-    expected = list_suite_files("bdd", repo_root=_REPO_ROOT)
+    expected = _pytest_bdd_module_paths(_REPO_ROOT)
     buckets = assign_files_to_shards("bdd", repo_root=_REPO_ROOT)
-    assigned = [path for paths in buckets.values() for path in paths]
+    assigned = {path for paths in buckets.values() for path in paths}
 
     assert len(buckets) == SHARD_COUNTS["bdd"]
-    assert set(assigned) == set(expected)
-    assert len(assigned) == len(expected)
+    assert assigned == expected
 
 
 @pytest.mark.arch_guard

--- a/tests/unit/test_architecture_ci_bdd_shard_manifest.py
+++ b/tests/unit/test_architecture_ci_bdd_shard_manifest.py
@@ -1,0 +1,53 @@
+"""Guard: BDD CI shards cover every tests/bdd file exactly once."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.ci.shard_split import (
+    SHARD_COUNTS,
+    assign_files_to_shards,
+    bdd_scenario_count,
+    list_suite_files,
+)
+from tests.unit.workflow_helpers import CI_WORKFLOW_PATH
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.arch_guard
+def test_bdd_shards_partition_suite() -> None:
+    expected = list_suite_files("bdd", repo_root=_REPO_ROOT)
+    buckets = assign_files_to_shards("bdd", repo_root=_REPO_ROOT)
+    assigned = [path for paths in buckets.values() for path in paths]
+
+    assert len(buckets) == SHARD_COUNTS["bdd"]
+    assert set(assigned) == set(expected)
+    assert len(assigned) == len(expected)
+
+
+@pytest.mark.arch_guard
+def test_ci_bdd_matrix_matches_shard_config() -> None:
+    workflow = yaml.safe_load(CI_WORKFLOW_PATH.read_text(encoding="utf-8"))
+    matrix = workflow["jobs"]["bdd-tests-shard"]["strategy"]["matrix"]["shard"]
+    assert matrix == list(range(1, SHARD_COUNTS["bdd"] + 1))
+
+
+@pytest.mark.arch_guard
+def test_bdd_shards_have_discoverable_scenario_counts() -> None:
+    for path in list_suite_files("bdd", repo_root=_REPO_ROOT):
+        assert bdd_scenario_count(path, repo_root=_REPO_ROOT) >= 0
+
+
+@pytest.mark.arch_guard
+def test_bdd_shard_scenario_load_is_balanced() -> None:
+    """Greedy min-load assignment should keep shard totals within ~35%."""
+    buckets = assign_files_to_shards("bdd", repo_root=_REPO_ROOT)
+    loads = [sum(bdd_scenario_count(path, repo_root=_REPO_ROOT) for path in paths) for paths in buckets.values()]
+    assert loads, "BDD shard assignment produced no files"
+    assert max(loads) / min(loads) <= 1.35, (
+        f"BDD shard scenario loads too skewed: {dict(zip(buckets.keys(), loads, strict=True))}"
+    )

--- a/tests/unit/test_architecture_ci_suite_coverage.py
+++ b/tests/unit/test_architecture_ci_suite_coverage.py
@@ -20,53 +20,40 @@ class TestCISuiteCoverage:
     """BDD and E2E suites must run in CI and gate the test summary."""
 
     def test_bdd_job_exists(self):
-        """A dedicated BDD job must exist in the CI workflow.
-
-        Before this guard, ``tests/bdd/`` was never executed in CI, so any
-        PR could break every BDD scenario and still show green.
-        """
+        """BDD aggregate + parallel shard jobs must exist in CI."""
         jobs = load_ci_workflow()["jobs"]
 
-        assert "bdd-tests" in jobs, (
-            "No 'bdd-tests' job in .github/workflows/ci.yml. The BDD suite "
-            "(tests/bdd/) is run by ./run_all_tests.sh but has zero CI "
-            "coverage — a broken BDD suite can silently land on main. Add a "
-            "'bdd-tests' job mirroring 'integration-tests' (Postgres service "
-            "+ migrations + pytest tests/bdd/)."
+        assert "bdd-tests" in jobs, "No 'bdd-tests' aggregate job in .github/workflows/ci.yml."
+        assert "bdd-tests-shard" in jobs, "No 'bdd-tests-shard' matrix job in .github/workflows/ci.yml."
+
+    def test_bdd_shards_run_the_bdd_suite(self):
+        """Each BDD shard must resolve paths via shard_paths and run pytest."""
+        shard_job = load_ci_workflow()["jobs"]["bdd-tests-shard"]
+        steps_text = " ".join(
+            str(step.get("run", "")) + " " + str(step.get("uses", "")) + " " + str(step.get("with", {}))
+            for step in shard_job.get("steps", [])
         )
 
-    def test_bdd_job_runs_the_bdd_suite(self):
-        """The BDD job must actually invoke ``pytest tests/bdd/``.
-
-        A job that exists but doesn't run the suite is worse than no job —
-        it gives false confidence.
-        """
-        bdd_job = load_ci_workflow()["jobs"]["bdd-tests"]
-        run_steps = " ".join(str(step.get("run", "")) for step in bdd_job.get("steps", []))
-        pytest_inputs = " ".join(
-            str(step.get("with", {}).get("paths", ""))
-            for step in bdd_job.get("steps", [])
-            if str(step.get("uses", "")).endswith("/_pytest")
+        assert "shard_paths.py bdd" in steps_text, (
+            "bdd-tests-shard must resolve test files via scripts/ci/shard_paths.py bdd."
+        )
+        assert "./.github/actions/_pytest" in steps_text or "pytest" in steps_text, (
+            "bdd-tests-shard must invoke pytest (via _pytest composite or explicit run)."
         )
 
-        assert "tests/bdd/" in run_steps or "tests/bdd/" in pytest_inputs, (
-            "The 'bdd-tests' job does not run 'pytest tests/bdd/'. The job "
-            "must execute the BDD suite, not merely exist."
-        )
+    def test_bdd_shards_have_postgres_service(self):
+        """BDD harnesses use the integration_db fixture (real PostgreSQL)."""
+        services = load_ci_workflow()["jobs"]["bdd-tests-shard"].get("services", {})
 
-    def test_bdd_job_has_postgres_service(self):
-        """BDD harnesses use the integration_db fixture (real PostgreSQL).
+        assert "postgres" in services, "bdd-tests-shard has no postgres service."
 
-        Without a Postgres service the BDD job cannot run, so the gate would
-        be hollow.
-        """
-        bdd_job = load_ci_workflow()["jobs"]["bdd-tests"]
-        services = bdd_job.get("services", {})
-
-        assert "postgres" in services, (
-            "The 'bdd-tests' job has no 'postgres' service. BDD scenarios use "
-            "the integration_db fixture and require a real PostgreSQL "
-            "instance (mirror the integration-tests job)."
+    def test_bdd_aggregate_is_status_proxy_only(self):
+        """Aggregate BDD job must gate shard status, not merge coverage."""
+        aggregate = load_ci_workflow()["jobs"]["bdd-tests"]
+        steps_text = " ".join(str(step.get("run", "")) for step in aggregate.get("steps", []))
+        assert "needs.bdd-tests-shard.result" in steps_text, "bdd-tests aggregate must fail when bdd-tests-shard fails."
+        assert "coverage combine" not in steps_text, (
+            "bdd-tests aggregate must not merge coverage; that belongs in the Coverage job."
         )
 
     def test_admin_job_has_postgres_service(self):
@@ -129,8 +116,10 @@ class TestCISuiteCoverage:
         )
 
         assert "unit-tests" in needs, "coverage job must depend on unit-tests."
-        assert "bdd-tests" in needs, "coverage job must depend on bdd-tests."
-        assert steps_text.count("download-artifact") >= 2, "coverage job must download unit and BDD coverage artifacts."
+        assert "bdd-tests-shard" in needs, "coverage job must depend on bdd-tests-shard."
+        assert steps_text.count("download-artifact") >= 2, (
+            "coverage job must download unit and BDD shard coverage artifacts."
+        )
         run_steps = " ".join(str(step.get("run", "")) for step in coverage_job.get("steps", []))
         assert "pytest" not in run_steps, "coverage job must not re-run tests."
         assert "coverage combine" in run_steps, "coverage job must combine unit and BDD coverage data."

--- a/tests/unit/test_architecture_ci_suite_coverage.py
+++ b/tests/unit/test_architecture_ci_suite_coverage.py
@@ -13,6 +13,8 @@ No allowlist — zero tolerance. Every locally-run suite must have a gating
 CI job, or a broken suite can silently land on main again.
 """
 
+import pytest
+
 from tests.unit.workflow_helpers import load_ci_workflow
 
 
@@ -123,6 +125,39 @@ class TestCISuiteCoverage:
         run_steps = " ".join(str(step.get("run", "")) for step in coverage_job.get("steps", []))
         assert "pytest" not in run_steps, "coverage job must not re-run tests."
         assert "coverage combine" in run_steps, "coverage job must combine unit and BDD coverage data."
+
+    @pytest.mark.arch_guard
+    def test_coverage_gate_requires_all_bdd_shard_artifacts(self):
+        """Coverage must fail on partial BDD shard artifact sets, not combine survivors."""
+        coverage_job = load_ci_workflow()["jobs"]["coverage"]
+        run_steps = " ".join(str(step.get("run", "")) for step in coverage_job.get("steps", []))
+
+        assert "SHARD_COUNTS" in run_steps, "coverage gate must read SHARD_COUNTS from shard_split."
+        assert "expected_bdd_shards" in run_steps, "coverage gate must bind BDD shard count to a variable."
+        assert "Missing BDD coverage artifact for shard" in run_steps, (
+            "coverage gate must fail when any shard's .coverage.bdd-N file is missing."
+        )
+        bdd_downloads = [
+            step.get("with", {})
+            for step in coverage_job.get("steps", [])
+            if step.get("with", {}).get("pattern") == "bdd-shard-*-coverage"
+        ]
+        assert bdd_downloads, "coverage job must download BDD shard artifacts via bdd-shard-*-coverage pattern."
+        assert bdd_downloads[0].get("path") == "bdd-coverage-shards", (
+            "BDD shard coverage artifacts must land under bdd-coverage-shards/."
+        )
+
+    @pytest.mark.arch_guard
+    def test_ci_jobs_declare_permissions_and_timeout(self):
+        """Every CI job must declare permissions and timeout (workflow hygiene)."""
+        jobs = load_ci_workflow()["jobs"]
+        missing: list[str] = []
+        for job_name, job in jobs.items():
+            if "permissions" not in job:
+                missing.append(f"{job_name}: permissions")
+            if "timeout-minutes" not in job:
+                missing.append(f"{job_name}: timeout-minutes")
+        assert not missing, "CI jobs missing hygiene fields:\n" + "\n".join(f"  - {m}" for m in missing)
 
     def test_summary_gates_bdd_and_e2e(self):
         """summary must depend on AND fail for bdd + e2e.

--- a/tests/unit/test_architecture_migration_completeness.py
+++ b/tests/unit/test_architecture_migration_completeness.py
@@ -17,9 +17,9 @@ import ast
 
 from tests.unit._migration_helpers import (
     MIGRATIONS_DIR,
-    get_migration_files,
     is_empty_body,
     is_merge_migration,
+    iter_migration_trees,
     parse_function,
 )
 
@@ -58,7 +58,7 @@ KNOWN_DOWNGRADE_COVERAGE_GAPS = {
 }
 
 
-def _extract_table_names(node: ast.FunctionDef) -> set[str]:
+def _extract_table_names(node: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
     """Extract table names referenced in op.XXX() calls."""
     tables = set()
     for child in ast.walk(node):
@@ -83,13 +83,7 @@ class TestMigrationCompleteness:
         missing = []
         empty = []
 
-        for path in get_migration_files():
-            source = path.read_text()
-            try:
-                tree = ast.parse(source, filename=str(path))
-            except SyntaxError:
-                continue
-
+        for path, tree in iter_migration_trees():
             if is_merge_migration(tree):
                 continue
 
@@ -112,14 +106,8 @@ class TestMigrationCompleteness:
         missing = []
         empty = []
 
-        for path in get_migration_files():
+        for path, tree in iter_migration_trees():
             if path.name in KNOWN_EMPTY_DOWNGRADE:
-                continue
-
-            source = path.read_text()
-            try:
-                tree = ast.parse(source, filename=str(path))
-            except SyntaxError:
                 continue
 
             if is_merge_migration(tree):
@@ -147,14 +135,8 @@ class TestMigrationCompleteness:
         """
         gaps = []
 
-        for path in get_migration_files():
+        for path, tree in iter_migration_trees():
             if path.name in KNOWN_DOWNGRADE_COVERAGE_GAPS:
-                continue
-
-            source = path.read_text()
-            try:
-                tree = ast.parse(source, filename=str(path))
-            except SyntaxError:
                 continue
 
             if is_merge_migration(tree):

--- a/tests/unit/test_architecture_required_ci_checks_frozen.py
+++ b/tests/unit/test_architecture_required_ci_checks_frozen.py
@@ -23,6 +23,8 @@ REQUIRED_RENDERED_CHECKS = {
     "CI / Integration (other)",
     "CI / E2E Tests",
     "CI / Admin UI Tests",
+    "CI / BDD Tests (Shard 1/2)",
+    "CI / BDD Tests (Shard 2/2)",
     "CI / BDD Tests",
     "CI / Migration Roundtrip",
     "CI / Coverage",

--- a/tests/unit/test_architecture_single_migration_head.py
+++ b/tests/unit/test_architecture_single_migration_head.py
@@ -14,6 +14,7 @@ No allowlist — zero tolerance. Multiple heads must be resolved before merge.
 import pytest
 
 from tests.unit._migration_helpers import (
+    expected_heads_after_roundtrip_downgrade,
     extract_revision_info,
     get_migration_files,
     get_migration_heads,
@@ -61,3 +62,12 @@ class TestRoundtripDowngradeTarget:
                 assert resolve_roundtrip_downgrade_target(revision) == downs[0]
                 return
         pytest.fail("No single-parent migration found in graph.")
+
+    def test_merge_head_downgrade_restores_all_branch_tips(self):
+        """After downgrading a merge head, alembic_version should list every parent."""
+        for path in get_migration_files():
+            revision, downs = extract_revision_info(path)
+            if revision and len(downs) > 1:
+                assert expected_heads_after_roundtrip_downgrade(revision) == set(downs)
+                return
+        pytest.skip("No merge migration in graph.")

--- a/tests/unit/workflow_helpers.py
+++ b/tests/unit/workflow_helpers.py
@@ -14,6 +14,28 @@ def load_ci_workflow() -> dict:
     return yaml.safe_load(CI_WORKFLOW_PATH.read_text(encoding="utf-8"))
 
 
+def _matrix_job_total(matrix: dict) -> int:
+    """Mirror GitHub Actions ``strategy.job-total`` for a job matrix."""
+    include = matrix.get("include")
+    if include:
+        return len(include)
+    lists = [values for values in matrix.values() if isinstance(values, list)]
+    if not lists:
+        return 1
+    total = 1
+    for values in lists:
+        total *= len(values)
+    return total
+
+
+def _render_job_name(name: str, matrix: dict, substitutions: dict[str, str]) -> str:
+    rendered = name
+    for key, value in substitutions.items():
+        rendered = rendered.replace("${{ matrix." + key + " }}", value)
+    rendered = rendered.replace("${{ strategy.job-total }}", str(_matrix_job_total(matrix)))
+    return rendered
+
+
 def rendered_ci_check_names(workflow: dict | None = None) -> set[str]:
     """Return rendered ``CI / …`` check names, expanding strategy.matrix jobs."""
     jobs = (workflow or load_ci_workflow())["jobs"]
@@ -29,10 +51,8 @@ def rendered_ci_check_names(workflow: dict | None = None) -> set[str]:
         include = matrix.get("include")
         if include:
             for row in include:
-                rendered = name
-                for key, value in row.items():
-                    rendered = rendered.replace("${{ matrix." + key + " }}", str(value))
-                names.add(f"CI / {rendered}")
+                subs = {key: str(value) for key, value in row.items()}
+                names.add(f"CI / {_render_job_name(name, matrix, subs)}")
             continue
 
         expanded = False
@@ -42,7 +62,7 @@ def rendered_ci_check_names(workflow: dict | None = None) -> set[str]:
             token = "${{ matrix." + key + " }}"
             if token in name:
                 for value in values:
-                    names.add(f"CI / {name.replace(token, str(value))}")
+                    names.add(f"CI / {_render_job_name(name, matrix, {key: str(value)})}")
                 expanded = True
                 break
         if not expanded:


### PR DESCRIPTION
Closes #1234.

## Summary

Stacked follow-up to **PR #1372** (merged as `68fd9066`). Parallelizes **BDD tests only** via **2 greedy scenario-count shards** while keeping branch protection stable.

| Suite | Before (PR3 on main) | After (this PR) |
|-------|----------------------|-----------------|
| BDD Tests | 1 job, all `tests/bdd/test_*.py` sequential | **2 parallel shards** + aggregate **`CI / BDD Tests`** (status proxy) |

**Branch protection:** grows from **18 → 20** rendered names (+2 `CI / BDD Tests (Shard N/2)`). Aggregate `CI / BDD Tests` gates shard pass/fail only; **Coverage** job combines unit + BDD shard artifacts and enforces `.coverage-baseline`.

**Head:** `2ff10d1c` · **CI:** [green — run 27373922220](https://github.com/prebid/salesagent/actions/runs/27373922220) · **Diff:** 13 files / ~510 insertions vs `main`

## How it works

- **`bdd-tests-shard`** — matrix `BDD Tests (Shard 1/2)` … `(Shard 2/2)` via `${{ strategy.job-total }}`; disjoint subsets via `scripts/ci/shard_split.py` greedy assignment.
- **`bdd-tests`** — aggregate status proxy only (fails if any shard fails).
- **`coverage`** — per-shard artifact gate (`SHARD_COUNTS['bdd']`), then `coverage combine`, `--fail-under`.
- **Structural guards** — partition via pytest collect-only; frozen check guard (**20 names**).

## Shard layout

13 BDD test files, greedy-balanced by scenario count:

| Shard | Files | Scenarios |
|-------|-------|-----------|
| 1/2 | 5 | ~479 |
| 2/2 | 8 | ~441 |

## Review closure

### ChrisHuie (items 1–5) — `956027ba`, `f35ce7b4`

- [x] Fail shard job on `shard_paths.py` error / empty output
- [x] Guard `shard_count > len(files)`
- [x] Partition guard anchored to pytest collect-only
- [x] Scenario assert `>= 1`; remove dead round-robin path
- [x] Local shard repro + load-metric note in `docs/development/ci-pipeline.md`

### KonstantinMirin (items 1–6 + follow-up) — `f7b06163`, `2ff10d1c`

- [x] Coverage gate requires **all** BDD shard artifacts (no partial combine)
- [x] Shard denominator bound to `strategy.job-total`; coverage reads `SHARD_COUNTS`
- [x] Migration roundtrip asserts DB revision **heads** after upgrade / downgrade / upgrade (`2ff10d1c` fixes merge-head multi-tip downgrade)
- [x] Every job declares `permissions` + `timeout-minutes`
- [x] DRY `iter_migration_trees()`; `parse_function` supports `AsyncFunctionDef`
- [x] Stack-aware collect-only partition guard; separate `Scenario` vs `Scenario Outline` regexes

## Test plan

- [x] Arch guards pass locally (`test_architecture_required_ci_checks_frozen`, `test_architecture_ci_bdd_shard_manifest`, `test_architecture_ci_suite_coverage`, `test_architecture_single_migration_head`)
- [x] All **20** branch-protection checks green on [CI run 27373922220 (tip `2ff10d1c`; re-run if needed after stack updates)](https://github.com/prebid/salesagent/actions/runs/27373922220)

Depends on: ~~#1372~~ (merged)
Part of: #1234
Stacked: #1424 (PR3-3, `4c4b2913`) → #1390 (PR4, `ce20bdbd`)
