### PR TITLE
fix: detect v3 pricing fields in product summary

### DIFF
--- a/src/core/helpers/pricing_helpers.py
+++ b/src/core/helpers/pricing_helpers.py
@@ -7,27 +7,33 @@ from typing import Any
 
 
 def pricing_option_has_rate(pricing_option: Any) -> bool:
-    """Check if a pricing option has a rate value.
+    """Check if a pricing option exposes buyer-visible pricing.
 
     Handles multiple formats:
-    - Dict format (from JSON/serialization): checks po["rate"]
-    - Pydantic RootModel wrapper (adcp 2.14.0+): checks po.root.rate
-    - Direct attribute access (SQLAlchemy models): checks po.rate
+    - Dict format (from JSON/serialization)
+    - Pydantic RootModel wrapper (adcp 2.14.0+)
+    - Direct attribute access (SQLAlchemy models)
+
+    AdCP v2 used ``rate``. AdCP v3 renamed that value to ``fixed_price`` for
+    fixed pricing and ``floor_price`` for auction floors, so all three fields
+    indicate that pricing is present.
 
     Args:
         pricing_option: A pricing option in any supported format
 
     Returns:
-        True if the pricing option has a non-None rate value
+        True if the pricing option has a non-None pricing value.
     """
+    price_fields = ("rate", "fixed_price", "floor_price")
+
     # Dict format (JSON/serialization)
     if isinstance(pricing_option, dict):
-        return pricing_option.get("rate") is not None
+        return any(pricing_option.get(field) is not None for field in price_fields)
 
     # Try RootModel wrapper first (adcp 2.14.0+ Pydantic models)
     root = getattr(pricing_option, "root", None)
     if root is not None:
-        return getattr(root, "rate", None) is not None
+        return any(getattr(root, field, None) is not None for field in price_fields)
 
     # Direct attribute (SQLAlchemy models or plain objects)
-    return getattr(pricing_option, "rate", None) is not None
+    return any(getattr(pricing_option, field, None) is not None for field in price_fields)

--- a/tests/unit/test_get_products_response_str.py
+++ b/tests/unit/test_get_products_response_str.py
@@ -110,6 +110,56 @@ def test_get_products_response_str_anonymous_user():
     )
 
 
+def test_get_products_response_str_v3_fixed_price_is_not_anonymous():
+    """Regression for #1246: v3 fixed_price options are buyer-visible pricing."""
+    product = Product(
+        product_id="test-v3-fixed",
+        name="Test V3 Fixed",
+        description="A test",
+        format_ids=[create_test_format_id("banner")],
+        delivery_type="guaranteed",
+        delivery_measurement={"provider": "test_provider", "notes": "Test measurement"},
+        publisher_properties=[create_test_publisher_properties_by_tag(publisher_domain="test.com")],
+        pricing_options=[
+            {
+                "pricing_option_id": "cpm_usd_fixed",
+                "pricing_model": "cpm",
+                "currency": "USD",
+                "fixed_price": 10.0,
+            }
+        ],
+    )
+
+    response = GetProductsResponse(products=[product])
+
+    assert str(response) == "Found 1 product that matches your requirements."
+
+
+def test_get_products_response_str_v3_floor_price_is_not_anonymous():
+    """Regression for #1246: v3 floor_price auction options are buyer-visible pricing."""
+    product = Product(
+        product_id="test-v3-auction",
+        name="Test V3 Auction",
+        description="A test",
+        format_ids=[create_test_format_id("banner")],
+        delivery_type="guaranteed",
+        delivery_measurement={"provider": "test_provider", "notes": "Test measurement"},
+        publisher_properties=[create_test_publisher_properties_by_tag(publisher_domain="test.com")],
+        pricing_options=[
+            {
+                "pricing_option_id": "cpm_usd_auction",
+                "pricing_model": "cpm",
+                "currency": "USD",
+                "floor_price": 5.0,
+            }
+        ],
+    )
+
+    response = GetProductsResponse(products=[product])
+
+    assert str(response) == "Found 1 product that matches your requirements."
+
+
 def test_get_products_response_model_dump_still_has_full_data():
     """Verify that model_dump() still returns full structured data."""
     product = Product(

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",


### PR DESCRIPTION
Closes #1246.

## Summary
- Treat AdCP v3 `fixed_price` and `floor_price` as buyer-visible pricing in `pricing_option_has_rate`
- Keep the existing anonymous/no-`rate` behavior for price-guidance-only responses
- Add regressions for authenticated v3 fixed-price and auction-floor products so `GetProductsResponse.__str__` does not append the anonymous pricing message

This is intentionally narrower than #1260: it only addresses the buyer-visible #1246 message bug and avoids the broader v2-compat changes from that stale dirty PR.

## Verification
- `uv run pytest tests/unit/test_get_products_response_str.py -q`
- `uv run pytest tests/unit/test_get_products_response_str.py tests/unit/test_anonymous_user_pricing.py -q`
- `uv run ruff check src/core/helpers/pricing_helpers.py tests/unit/test_get_products_response_str.py`
