### PR TITLE
fix(test-harness): implement MediaBuyCreateEnv's missing setup helpers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "logfire>=4.16.0",
     "pydantic-ai>=0.3.0",
     # Security patches for transitive dependencies
-    "pyjwt>=2.12.0",  # GHSA-752w-5fwx-jx9f
+    "pyjwt>=2.13.0",  # GHSA-752w-5fwx-jx9f; PYSEC-2026-175/177/178/179
     "filelock>=3.20.3",  # GHSA-qmgc-5h2g-mvrw
     "urllib3>=2.7.0",  # GHSA-38jv-5279-wg99 + GHSA-qccp-gfcp-xxvc + GHSA-mf9v-mfxr-j63j
     "werkzeug>=3.1.6",  # GHSA-87hc-h4r5-73f7 + GHSA-29vq-49wr-vm6x

--- a/tests/harness/media_buy_create.py
+++ b/tests/harness/media_buy_create.py
@@ -67,6 +67,75 @@ class MediaBuyCreateEnv(IntegrationEnv):
         product, pricing_option = self.setup_product_chain(tenant)
         return tenant, principal, product, pricing_option
 
+    def setup_product_chain(
+        self,
+        tenant: Any,
+        *,
+        product_id: str = "prod_1",
+        currency: str = "USD",
+        with_pricing: bool = True,
+        format_ids: list[dict[str, str]] | None = None,
+    ) -> tuple:
+        """Seed a real PropertyTag ("all_inventory") + Product + PricingOption row set.
+
+        The "all_inventory" tag is created once per env (idempotent across repeated
+        calls). Returns ``(product, pricing_option)``; ``pricing_option`` is ``None``
+        when ``with_pricing=False``.
+        """
+        from tests.factories import PricingOptionFactory, ProductFactory
+        from tests.factories.core import PropertyTagFactory
+
+        if not getattr(self, "_seeded_all_inventory_tag", False):
+            PropertyTagFactory(tenant=tenant, tag_id="all_inventory", name="All Inventory")
+            self._seeded_all_inventory_tag = True
+
+        if format_ids is None:
+            format_ids = [{"agent_url": "https://creative.adcontextprotocol.org", "id": "display_300x250"}]
+
+        product = ProductFactory(
+            tenant=tenant,
+            product_id=product_id,
+            delivery_type="non_guaranteed",
+            format_ids=format_ids,
+            property_tags=["all_inventory"],
+        )
+        pricing_option = None
+        if with_pricing:
+            pricing_option = PricingOptionFactory(
+                product=product, pricing_model="cpm", currency=currency, is_fixed=True
+            )
+        return product, pricing_option
+
+    def _build_mock_context_manager(self, tool_name: str) -> MagicMock:
+        """Mock context manager that delegates create_context / create_workflow_step to the REAL one.
+
+        Persisting real Context / WorkflowStep rows lets the manual-approval path satisfy
+        the ObjectWorkflowMapping foreign keys while the other ContextManager methods stay mocked.
+        """
+        from src.core.context_manager import get_context_manager
+
+        real = get_context_manager()
+        mgr = MagicMock()
+
+        def _create_context(*_args: Any, **kwargs: Any):
+            return real.create_context(
+                tenant_id=kwargs.get("tenant_id", self._tenant_id),
+                principal_id=kwargs.get("principal_id", self._principal_id),
+            )
+
+        def _create_workflow_step(*_args: Any, **kwargs: Any):
+            kwargs.setdefault("step_type", "media_buy_creation")
+            kwargs.setdefault("owner", "system")
+            kwargs.setdefault("tool_name", tool_name)
+            return real.create_workflow_step(**kwargs)
+
+        mgr.create_context.side_effect = _create_context
+        mgr.get_context.return_value = None
+        mgr.create_workflow_step.side_effect = _create_workflow_step
+        mgr.update_workflow_step.return_value = None
+        mgr.add_message.return_value = None
+        return mgr
+
     def _configure_mocks(self) -> None:
         """Set up happy-path defaults for external mocks."""
         # Adapter: mock create_media_buy — returns response matching the request packages.

--- a/tests/integration/test_media_buy_harness_smoke.py
+++ b/tests/integration/test_media_buy_harness_smoke.py
@@ -1,0 +1,53 @@
+"""Smoke tests that the media-buy harness envs actually enter and seed.
+
+The structural regression test (tests/unit/test_media_buy_harness.py) checks
+import/subclass/method presence but never ENTERS the env — which let
+MediaBuyCreateEnv ship referencing two undefined helpers (setup_product_chain,
+_build_mock_context_manager) without any test failing. These tests close that
+gap by entering the real (IntegrationEnv) envs against a real DB.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src.core.schemas._base import CreateMediaBuySuccess
+from tests.helpers.adcp_factories import create_test_package_request_dict
+
+pytestmark = [pytest.mark.integration, pytest.mark.requires_db]
+
+
+@pytest.mark.requires_db
+class TestMediaBuyCreateEnvEntersAndSeeds:
+    """MediaBuyCreateEnv enters cleanly, seeds the product chain, and drives a create."""
+
+    def test_enter_seed_and_create(self, integration_db):
+        from tests.harness.media_buy_create import MediaBuyCreateEnv
+
+        # tenant_id must be hyphen-free: TenantFactory derives subdomain "pub-{tenant_id}"
+        # and the product's publisher_domain from it; an underscore fails the AdCP domain regex.
+        with MediaBuyCreateEnv(tenant_id="smoketenant") as env:
+            # Entering already exercised _build_mock_context_manager (built in _configure_mocks).
+            tenant, principal, product, pricing_option = env.setup_media_buy_data()
+            assert product is not None, "setup_product_chain must create a Product"
+            assert pricing_option is not None, "setup_product_chain must create a PricingOption"
+
+            start = datetime.now(UTC) + timedelta(days=1)
+            end = start + timedelta(days=30)
+            result = env.call_impl(
+                brand={"domain": "harness-smoke.example"},
+                packages=[
+                    create_test_package_request_dict(
+                        product_id=product.product_id,
+                        pricing_option_id="cpm_usd_fixed",
+                        budget=5000.0,
+                    )
+                ],
+                start_time=start.isoformat(),
+                end_time=end.isoformat(),
+            )
+            created = result.response
+            assert isinstance(created, CreateMediaBuySuccess), f"create must succeed, got {type(created).__name__}"
+            assert created.media_buy_id is not None

--- a/tests/unit/test_media_buy_harness.py
+++ b/tests/unit/test_media_buy_harness.py
@@ -50,6 +50,13 @@ class TestMediaBuyCreateEnvExists:
         assert hasattr(MediaBuyCreateEnv, "REST_ENDPOINT")
         assert "media-buys" in MediaBuyCreateEnv.REST_ENDPOINT
 
+    def test_has_setup_helpers_it_calls_internally(self):
+        """setup_media_buy_data + _configure_mocks reference these; missing = AttributeError on __enter__."""
+        from tests.harness.media_buy_create import MediaBuyCreateEnv
+
+        assert callable(getattr(MediaBuyCreateEnv, "setup_product_chain", None))
+        assert callable(getattr(MediaBuyCreateEnv, "_build_mock_context_manager", None))
+
 
 class TestMediaBuyUpdateEnvExists:
     """Verify the update harness exists."""

--- a/tests/unit/test_oauth_config.py
+++ b/tests/unit/test_oauth_config.py
@@ -266,8 +266,9 @@ class TestExtractUserInfo:
             "name": "ID Token User",
             "picture": "https://example.com/photo.jpg",
         }
-        # Create unsigned token for testing
-        id_token = jwt.encode(id_token_payload, key="", algorithm="HS256")
+        # Signed with a throwaway key (pyjwt >=2.13.0 rejects empty HMAC keys); the
+        # signature is never checked — extract_user_info decodes with verify_signature=False.
+        id_token = jwt.encode(id_token_payload, key="unused-test-key", algorithm="HS256")
 
         token = {"id_token": id_token}
 

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ requires-dist = [
     { name = "psycopg2-binary", specifier = ">=2.9.9" },
     { name = "pyasn1", specifier = ">=0.6.3" },
     { name = "pydantic-ai", specifier = ">=0.3.0" },
-    { name = "pyjwt", specifier = ">=2.12.0" },
+    { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.1.0" },
     { name = "pytest-asyncio", marker = "extra == 'ui-tests'", specifier = ">=1.1.0" },
@@ -3503,11 +3503,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
`MediaBuyCreateEnv` (the integration harness for `_create_media_buy_impl`)
  referenced two helper methods it never defined, so it raised `AttributeError`
  on `__enter__`. This implements them and adds the coverage that would have
  caught the gap.
  
  ## What was broken

  `setup_media_buy_data()` calls `self.setup_product_chain(...)` and
  `_configure_mocks()` calls `self._build_mock_context_manager(...)`, but neither
  method exists on `MediaBuyCreateEnv` or its base. `MediaBuyDualEnv` (which
  extends it) inherits the same break.
  It shipped undetected because:
  - the only path that would exercise it (the BDD UC-002 non-account scenario)
    calls `pytest.xfail(...)` before touching the env, and
  - the harness regression test (`tests/unit/test_media_buy_harness.py`) only
    asserted import / subclass / method-presence — it never entered the env.

  ## Changes
  
  - Add `setup_product_chain` to `MediaBuyCreateEnv` — seeds a real `PropertyTag`
    ("all_inventory") + `Product` + `PricingOption` via factory-boy.
  - Add `_build_mock_context_manager` to `MediaBuyCreateEnv` — returns a mock
    `ContextManager` delegating `create_context` / `create_workflow_step` to the
    real one, so the manual-approval path's `ObjectWorkflowMapping` foreign keys
    resolve.
  - Add `tests/integration/test_media_buy_harness_smoke.py` — enters the env,
    seeds the chain, and drives a real create to success (closes the gap).
  - Add a unit method-presence check to `tests/unit/test_media_buy_harness.py`
    (fast guard that would have failed on this bug).
  
  ## Testing
  
  - `make quality` — green
  - New smoke test passes against Postgres
  
  ## Out of scope

  `MediaBuyDualEnv` has a separate remaining break: `tests/harness/media_buy_dual.py`
  imports `make_adapter_update_side_effect` from `tests.harness._mixins`, which is
  undefined. It inherits the two methods added here, so it should work once that
  import is provided — left for a follow-up.