### PR TITLE
fix(schema): align GetProductsRequest push notification config

### DIFF
--- a/src/core/schemas/product.py
+++ b/src/core/schemas/product.py
@@ -14,6 +14,7 @@ from adcp.types import Product as LibraryProduct
 from adcp.types import ProductCard as LibraryProductCard
 from adcp.types import ProductCardDetailed as LibraryProductCardDetailed
 from adcp.types import ProductFilters as LibraryFilters
+from adcp.types import PushNotificationConfig as LibraryPushNotificationConfig
 from pydantic import ConfigDict, Field, model_validator
 
 from src.core.config import get_pydantic_extra_mode
@@ -247,6 +248,11 @@ class GetProductsRequest(LibraryGetProductsRequest):
     buying_mode: str | None = Field(  # type: ignore[assignment]
         None,
         description="Buyer intent: 'brief' (publisher curates) or 'wholesale' (buyer applies own audiences)",
+    )
+
+    push_notification_config: LibraryPushNotificationConfig | None = Field(
+        None,
+        description="Webhook configuration for async terminal notifications (brief/refine only per AdCP spec)",
     )
 
     # Internal-only fields (not in AdCP spec)

--- a/tests/unit/test_adcp_contract.py
+++ b/tests/unit/test_adcp_contract.py
@@ -120,9 +120,11 @@ class TestSchemaMatchesLibrary:
         lib_fields = set(LibGetProductsRequest.model_fields.keys())
         local_fields = set(GetProductsRequest.model_fields.keys())
         # product_selectors — internal-only field (not in AdCP spec)
+        # push_notification_config — in JSON schema but not yet in adcp library's
+        #   GetProductsWholesaleRequest (library gap); declared locally per Pattern #1
         # buying_mode and account are now in the library (adcp 3.9) but overridden locally
         # (buying_mode widened to str|None, account made optional)
-        local_extensions = {"product_selectors"}
+        local_extensions = {"product_selectors", "push_notification_config"}
         assert lib_fields == local_fields - local_extensions, (
             f"GetProductsRequest drift: lib={lib_fields}, local={local_fields}"
         )


### PR DESCRIPTION
## Summary

Aligns the local `GetProductsRequest` Pydantic model with the AdCP get-products request schema by accepting the optional `push_notification_config` field.

This fixes the schema alignment failures for `get-products-request.json` without changing product matching or runtime behavior.

## Changes

- Reuses the existing `adcp.types.PushNotificationConfig` type
- Adds optional `push_notification_config` to `GetProductsRequest`
- Documents `push_notification_config` as an intentional local extension while the upstream library base request model does not yet expose it
- Leaves `get_products` execution behavior unchanged

## Verification

- `uv run pytest tests/unit/test_pydantic_schema_alignment.py -k "get-products-request" --no-header -q`
  - 4 passed, 19 deselected
- `uv run pytest tests/unit/test_pydantic_schema_alignment.py --no-header -q`
  - 14 passed, 9 skipped
- `uv run pytest tests/unit/ -q --no-header`
  - 4714 passed, 12 skipped, 26 xfailed