### PR TITLE
ci: image supply-chain hardening (PR 6 of #1234)

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,0 +1,10 @@
+# Extracted config for actions/dependency-review-action (PR 6 of #1234).
+fail-on-severity: moderate
+comment-summary-in-pr: on-failure
+deny-licenses:
+  - GPL-3.0
+  - GPL-3.0-only
+  - GPL-3.0-or-later
+  - AGPL-3.0
+  - AGPL-3.0-only
+  - AGPL-3.0-or-later

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
       contents: read
     timeout-minutes: 15
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
@@ -51,6 +55,10 @@ jobs:
       contents: read
     timeout-minutes: 10
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
@@ -65,6 +73,10 @@ jobs:
       contents: read
     timeout-minutes: 10
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
@@ -84,6 +96,10 @@ jobs:
       contents: read
     timeout-minutes: 10
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
@@ -98,6 +114,10 @@ jobs:
       contents: read
     timeout-minutes: 10
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
@@ -116,6 +136,10 @@ jobs:
       contents: read
     timeout-minutes: 10
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
@@ -133,6 +157,10 @@ jobs:
       contents: read
     timeout-minutes: 15
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
@@ -186,6 +214,10 @@ jobs:
         ports:
           - 5432:5432
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
@@ -223,6 +255,10 @@ jobs:
       contents: read
     timeout-minutes: 25
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
@@ -280,6 +316,10 @@ jobs:
         ports:
           - 5432:5432
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
@@ -319,6 +359,10 @@ jobs:
         ports:
           - 5432:5432
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
@@ -375,6 +419,10 @@ jobs:
       contents: read
     timeout-minutes: 5
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
       - name: Aggregate BDD shards
         run: |
           if [ "${{ needs.bdd-tests-shard.result }}" != "success" ]; then
@@ -404,6 +452,10 @@ jobs:
         ports:
           - 5432:5432
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
@@ -424,6 +476,10 @@ jobs:
       contents: read
     timeout-minutes: 10
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
@@ -484,6 +540,10 @@ jobs:
         coverage,
       ]
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
       - name: Validate job results
         run: |
           if [ "${{ needs.quality-gate.result }}" != "success" ] || \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,6 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          disable-sudo-and-containers: true
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
@@ -217,7 +216,6 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          disable-sudo-and-containers: true
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
@@ -258,7 +256,6 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          disable-sudo-and-containers: true
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
@@ -319,7 +316,6 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          disable-sudo-and-containers: true
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
@@ -362,7 +358,6 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          disable-sudo-and-containers: true
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
@@ -455,7 +450,6 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          disable-sudo-and-containers: true
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           egress-policy: audit
           disable-sudo-and-containers: true
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,10 @@ jobs:
       contents: read
       security-events: write
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           persist-credentials: false
@@ -29,21 +33,7 @@ jobs:
 
       - uses: github/codeql-action/autobuild@ff0a06e83cb2de871e5a09832bc6a81e7276941f  # v3.28.18
 
-      # Advisory mode for 2-week ramp-up (Decision-10 / D10 from issue #1234).
-      #
-      # CodeQL is intentionally non-blocking for the first ~2 weeks after this
-      # workflow is introduced. This gives the team time to review and triage
-      # any findings without blocking PRs on day 1.
-      #
-      # TO FLIP TO GATING (do this ~2 weeks after PR 1 merges):
-      #   1. Change `continue-on-error: true` to `continue-on-error: false` below.
-      #   2. Add "CodeQL analyze (Python)" to the required status checks list in
-      #      branch protection settings (Settings → Branches → main → Edit).
-      #   3. Update ADR-002 to note the date CodeQL became a required check.
-      #
-      # Target: OpenSSF Scorecard ≥ 7.5 after PR 6 (requires CodeQL gating +
-      # cosign image signing). See issue #1234 success criteria.
+      # Gating mode (PR 6 of #1234 / D10 Path C). Findings block PR merges.
       - uses: github/codeql-action/analyze@ff0a06e83cb2de871e5a09832bc6a81e7276941f  # v3.28.18
-        continue-on-error: true  # TODO: flip to false after ~2-week ramp (see note above)
         with:
           category: "/language:python"

--- a/.github/workflows/harden-runner-emergency-revert.yml
+++ b/.github/workflows/harden-runner-emergency-revert.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       reason:
-        description: Brief reason for revert (logged in PR body)
+        description: Brief reason for revert (logged in issue body)
         required: true
 
 permissions: {}
@@ -14,35 +14,53 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
+      issues: write
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - name: Write PR body
+      - name: Detect block-mode harden-runner steps
+        id: detect
+        run: |
+          set -euo pipefail
+          if grep -R --include='*.yml' 'egress-policy: block' .github/workflows/; then
+            echo "block_mode=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "block_mode=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Open manual revert issue
+        if: steps.detect.outputs.block_mode == 'true'
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REVERT_REASON: ${{ inputs.reason }}
         run: |
           set -euo pipefail
           {
-            echo "Emergency revert triggered via workflow_dispatch."
-            echo "Reason: ${REVERT_REASON}"
-            echo "Post-revert: identify blocked egress, update allowlist, then flip back to block-mode."
-          } > /tmp/pr-body.md
-      - name: Revert harden-runner to audit mode
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          for f in .github/workflows/*.yml; do
-            sed -i 's/egress-policy: block/egress-policy: audit/g' "$f"
-          done
-          git checkout -b "harden-runner-emergency-revert-${{ github.run_id }}"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config user.name "github-actions[bot]"
-          git add .github/workflows/
-          git commit -m "ops: emergency revert harden-runner to audit mode"
-          gh pr create \
-            --title "ops: emergency revert harden-runner to audit" \
-            --body-file /tmp/pr-body.md
+            echo "Emergency harden-runner revert requested via workflow_dispatch."
+            echo
+            echo "**Reason:** ${REVERT_REASON}"
+            echo
+            echo "Automated PR creation is not possible with \`GITHUB_TOKEN\` (no \`workflows\` write permission)."
+            echo "Apply manually:"
+            echo
+            echo '```bash'
+            echo "grep -Rl 'egress-policy: block' .github/workflows/ | xargs sed -i '' 's/egress-policy: block/egress-policy: audit/g'"
+            echo 'git checkout -b ops/harden-runner-emergency-revert'
+            echo 'git commit -am "ops: emergency revert harden-runner to audit mode"'
+            echo 'gh pr create --title "ops: emergency revert harden-runner to audit" --body "Manual revert from issue #ISSUE"'
+            echo '```'
+            echo
+            echo "Post-revert: identify blocked egress, update allowlist, then re-enable block mode deliberately."
+          } > /tmp/issue-body.md
+          gh issue create \
+            --title "ops: manual harden-runner emergency revert" \
+            --body-file /tmp/issue-body.md
+      - name: No block-mode steps (no-op)
+        if: steps.detect.outputs.block_mode == 'false'
+        run: >-
+          echo "No egress-policy block mode found — all workflows already audit-only; nothing to revert."

--- a/.github/workflows/harden-runner-emergency-revert.yml
+++ b/.github/workflows/harden-runner-emergency-revert.yml
@@ -7,18 +7,29 @@ on:
         description: Brief reason for revert (logged in PR body)
         required: true
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   revert:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
+      - name: Write PR body
+        env:
+          REVERT_REASON: ${{ inputs.reason }}
+        run: |
+          set -euo pipefail
+          {
+            echo "Emergency revert triggered via workflow_dispatch."
+            echo "Reason: ${REVERT_REASON}"
+            echo "Post-revert: identify blocked egress, update allowlist, then flip back to block-mode."
+          } > /tmp/pr-body.md
       - name: Revert harden-runner to audit mode
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -34,4 +45,4 @@ jobs:
           git commit -m "ops: emergency revert harden-runner to audit mode"
           gh pr create \
             --title "ops: emergency revert harden-runner to audit" \
-            --body "Emergency revert triggered via workflow_dispatch. Reason: ${{ inputs.reason }}. Post-revert: identify blocked egress, update allowlist, then flip back to block-mode."
+            --body-file /tmp/pr-body.md

--- a/.github/workflows/harden-runner-emergency-revert.yml
+++ b/.github/workflows/harden-runner-emergency-revert.yml
@@ -1,0 +1,37 @@
+name: harden-runner-emergency-revert
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: Brief reason for revert (logged in PR body)
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  revert:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Revert harden-runner to audit mode
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          for f in .github/workflows/*.yml; do
+            sed -i 's/egress-policy: block/egress-policy: audit/g' "$f"
+          done
+          git checkout -b "harden-runner-emergency-revert-${{ github.run_id }}"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add .github/workflows/
+          git commit -m "ops: emergency revert harden-runner to audit mode"
+          gh pr create \
+            --title "ops: emergency revert harden-runner to audit" \
+            --body "Emergency revert triggered via workflow_dispatch. Reason: ${{ inputs.reason }}. Post-revert: identify blocked egress, update allowlist, then flip back to block-mode."

--- a/.github/workflows/harden-runner-emergency-revert.yml
+++ b/.github/workflows/harden-runner-emergency-revert.yml
@@ -28,7 +28,8 @@ jobs:
         id: detect
         run: |
           set -euo pipefail
-          if grep -R --include='*.yml' 'egress-policy: block' .github/workflows/; then
+          if grep -R --include='*.yml' --exclude='harden-runner-emergency-revert.yml' \
+              'egress-policy: block' .github/workflows/; then
             echo "block_mode=true" >> "$GITHUB_OUTPUT"
           else
             echo "block_mode=false" >> "$GITHUB_OUTPUT"
@@ -49,7 +50,7 @@ jobs:
             echo "Apply manually:"
             echo
             echo '```bash'
-            echo "grep -Rl 'egress-policy: block' .github/workflows/ | xargs sed -i '' 's/egress-policy: block/egress-policy: audit/g'"
+            echo "grep -Rl 'egress-policy: block' .github/workflows/ --exclude='harden-runner-emergency-revert.yml' | xargs sed -i '' 's/egress-policy: block/egress-policy: audit/g'"
             echo 'git checkout -b ops/harden-runner-emergency-revert'
             echo 'git commit -am "ops: emergency revert harden-runner to audit mode"'
             echo 'gh pr create --title "ops: emergency revert harden-runner to audit" --body "Manual revert from issue #ISSUE"'

--- a/.github/workflows/publish-creative-agent.yml
+++ b/.github/workflows/publish-creative-agent.yml
@@ -13,8 +13,12 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
@@ -24,6 +28,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push pinned creative agent
+        id: publish
         env:
           CREATIVE_AGENT_GHCR_IMAGE: ghcr.io/${{ github.repository }}/adcp-creative-agent
         run: ./scripts/creative-agent-stack.sh publish
+      - name: Scan published creative-agent image (SARIF)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ghcr.io/${{ github.repository }}/adcp-creative-agent:ca70dd1e2a6c
+          severity: CRITICAL,HIGH
+          vuln-type: os,library
+          ignore-unfixed: true
+          exit-code: 0
+          format: sarif
+          output: trivy-creative-agent.sarif
+      - name: Upload creative-agent Trivy SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+        with:
+          sarif_file: trivy-creative-agent.sarif
+          category: trivy-creative-agent

--- a/.github/workflows/publish-creative-agent.yml
+++ b/.github/workflows/publish-creative-agent.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Scan published creative-agent image (SARIF)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: ghcr.io/${{ github.repository }}/adcp-creative-agent:ca70dd1e2a6c
+          image-ref: ${{ steps.publish.outputs.ref }}
           severity: CRITICAL,HIGH
           vuln-type: os,library
           ignore-unfixed: true

--- a/.github/workflows/publish-creative-agent.yml
+++ b/.github/workflows/publish-creative-agent.yml
@@ -7,10 +7,12 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   publish:
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,9 +5,11 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
+concurrency:
+  group: release-please
+  cancel-in-progress: false
+
+permissions: {}
 
 jobs:
   release-please:
@@ -37,6 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
+      actions: read
       contents: read
       packages: write
     outputs:
@@ -52,6 +55,7 @@ jobs:
       - name: Require CI green on release commit (D47 gate)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           RELEASE_SHA: ${{ needs.release-please.outputs.sha }}
         run: |
           set -euo pipefail
@@ -59,7 +63,7 @@ jobs:
           MAX_ATTEMPTS=45
           SLEEP_SEC=60
           for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
-            STATUS=$(gh api "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?head_sha=$RELEASE_SHA" \
+            STATUS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=$RELEASE_SHA" \
               --jq '.workflow_runs[0].conclusion // "pending"')
             echo "Attempt $attempt/$MAX_ATTEMPTS: status=$STATUS"
             case "$STATUS" in
@@ -116,15 +120,37 @@ jobs:
           push: false
           load: true
           platforms: linux/amd64
-          tags: salesagent:release-gate
+          tags: salesagent:release-gate-amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
             SOURCE_DATE_EPOCH=${{ steps.sde.outputs.value }}
-      - name: Trivy gate (pre-push OS/CVE scan)
+      - name: Trivy gate (pre-push OS/CVE scan, amd64)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: salesagent:release-gate
+          image-ref: salesagent:release-gate-amd64
+          severity: CRITICAL,HIGH
+          vuln-type: os,library
+          ignore-unfixed: true
+          exit-code: 1
+          format: table
+      - name: Build arm64 image for pre-push Trivy gate
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          load: true
+          platforms: linux/arm64
+          tags: salesagent:release-gate-arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            SOURCE_DATE_EPOCH=${{ steps.sde.outputs.value }}
+      - name: Trivy gate (pre-push OS/CVE scan, arm64)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: salesagent:release-gate-arm64
           severity: CRITICAL,HIGH
           vuln-type: os,library
           ignore-unfixed: true
@@ -164,18 +190,17 @@ jobs:
         with:
           egress-policy: audit
           disable-sudo-and-containers: true
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Log in to Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+      - name: Registry auth (daemon-free)
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DH_USER: ${{ secrets.DOCKERHUB_USER }}
+          DH_PASS: ${{ secrets.DOCKERHUB_PASSWORD }}
+        run: |
+          set -euo pipefail
+          cosign login ghcr.io -u "$GHCR_USER" -p "$GH_TOKEN"
+          cosign login docker.io -u "$DH_USER" -p "$DH_PASS"
       - name: Sign image with cosign keyless
         env:
           DIGEST: ${{ needs.build-and-push.outputs.image_digest }}
@@ -183,6 +208,7 @@ jobs:
           BUNDLE_DIR: /tmp/cosign-bundles-${{ github.run_id }}
         run: |
           set -euo pipefail
+          [[ -n "$DIGEST" ]] || { echo "ERROR: build-and-push image_digest is empty"; exit 1; }
           mkdir -p "$BUNDLE_DIR"
           for tag in $TAGS; do
             signed=false
@@ -210,6 +236,11 @@ jobs:
       - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ needs.build-and-push.outputs.image_digest }}
+          push-to-registry: true
+      - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ${{ secrets.DOCKERHUB_USER }}/salesagent
           subject-digest: ${{ needs.build-and-push.outputs.image_digest }}
           push-to-registry: true
       - name: Scan image for OS-layer CVEs (SARIF report)

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,11 +8,13 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  packages: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -33,13 +35,13 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: write
     outputs:
-      ghcr_image: ${{ steps.meta.outputs.tags }}
-      ghcr_digest: ${{ steps.build.outputs.digest }}
+      image_tags: ${{ steps.meta.outputs.tags }}
+      image_digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
@@ -54,8 +56,8 @@ jobs:
         run: |
           set -euo pipefail
           [[ -n "$RELEASE_SHA" ]] || { echo "ERROR: release-please.outputs.sha is empty (D47 gate broken)"; exit 1; }
-          MAX_ATTEMPTS=6
-          SLEEP_SEC=30
+          MAX_ATTEMPTS=45
+          SLEEP_SEC=60
           for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
             STATUS=$(gh api "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?head_sha=$RELEASE_SHA" \
               --jq '.workflow_runs[0].conclusion // "pending"')
@@ -79,7 +81,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
@@ -106,8 +108,30 @@ jobs:
       - name: Compute SOURCE_DATE_EPOCH from git
         id: sde
         run: echo "value=$(git log -1 --format=%ct)" >> "$GITHUB_OUTPUT"
+      - name: Build amd64 image for pre-push Trivy gate
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          load: true
+          platforms: linux/amd64
+          tags: salesagent:release-gate
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            SOURCE_DATE_EPOCH=${{ steps.sde.outputs.value }}
+      - name: Trivy gate (pre-push OS/CVE scan)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: salesagent:release-gate
+          severity: CRITICAL,HIGH
+          vuln-type: os,library
+          ignore-unfixed: true
+          exit-code: 1
+          format: table
       - id: build
-        name: Build and push Docker image
+        name: Build and push multi-arch image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
@@ -134,39 +158,68 @@ jobs:
       id-token: write
       attestations: write
       packages: write
+      security-events: write
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
           disable-sudo-and-containers: true
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
       - name: Sign image with cosign keyless
         env:
-          DIGEST: ${{ needs.build-and-push.outputs.ghcr_digest }}
-          TAGS: ${{ needs.build-and-push.outputs.ghcr_image }}
-          BUNDLE_PREFIX: /tmp/cosign-bundle-${{ github.run_id }}
+          DIGEST: ${{ needs.build-and-push.outputs.image_digest }}
+          TAGS: ${{ needs.build-and-push.outputs.image_tags }}
+          BUNDLE_DIR: /tmp/cosign-bundles-${{ github.run_id }}
         run: |
           set -euo pipefail
+          mkdir -p "$BUNDLE_DIR"
           for tag in $TAGS; do
+            signed=false
+            safe_tag="${tag//\//-}"
             for attempt in 1 2 3; do
-              cosign sign --yes --bundle "${BUNDLE_PREFIX}-${attempt}.json" "${tag}@${DIGEST}" && break
+              bundle_path="${BUNDLE_DIR}/${safe_tag}-${attempt}.json"
+              if cosign sign --yes --bundle "$bundle_path" "${tag}@${DIGEST}"; then
+                signed=true
+                break
+              fi
               echo "cosign attempt $attempt failed for ${tag} — retrying..."
               sleep 30
             done
+            if [ "$signed" != true ]; then
+              echo "ERROR: cosign sign failed for ${tag} after 3 attempts"
+              exit 1
+            fi
           done
+      - name: Upload cosign bundles
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: cosign-bundles-${{ github.run_id }}
+          path: /tmp/cosign-bundles-${{ github.run_id }}/*.json
+          if-no-files-found: error
       - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ghcr.io/${{ github.repository }}
-          subject-digest: ${{ needs.build-and-push.outputs.ghcr_digest }}
+          subject-digest: ${{ needs.build-and-push.outputs.image_digest }}
           push-to-registry: true
-      - name: Scan image for OS-layer CVEs
+      - name: Scan image for OS-layer CVEs (SARIF report)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: ghcr.io/${{ github.repository }}@${{ needs.build-and-push.outputs.ghcr_digest }}
+          image-ref: ghcr.io/${{ github.repository }}@${{ needs.build-and-push.outputs.image_digest }}
           severity: CRITICAL,HIGH
           vuln-type: os,library
           ignore-unfixed: true
-          exit-code: 1
+          exit-code: 0
           format: sarif
           output: trivy-results.sarif
       - name: Upload Trivy SARIF to GitHub Security tab

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -149,6 +149,8 @@ jobs:
             SOURCE_DATE_EPOCH=${{ steps.sde.outputs.value }}
       - name: Trivy gate (pre-push OS/CVE scan, arm64)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_PLATFORM: linux/arm64
         with:
           image-ref: salesagent:release-gate-arm64
           severity: CRITICAL,HIGH
@@ -240,7 +242,7 @@ jobs:
           push-to-registry: true
       - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          subject-name: ${{ secrets.DOCKERHUB_USER }}/salesagent
+          subject-name: docker.io/${{ secrets.DOCKERHUB_USER }}/salesagent
           subject-digest: ${{ needs.build-and-push.outputs.image_digest }}
           push-to-registry: true
       - name: Scan image for OS-layer CVEs (SARIF report)

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,41 +17,81 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
+      sha: ${{ github.sha }}
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  publish-docker:
+  build-and-push:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      ghcr_image: ${{ steps.meta.outputs.tags }}
+      ghcr_digest: ${{ steps.build.outputs.digest }}
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-
+      - name: Require CI green on release commit (D47 gate)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_SHA: ${{ needs.release-please.outputs.sha }}
+        run: |
+          set -euo pipefail
+          [[ -n "$RELEASE_SHA" ]] || { echo "ERROR: release-please.outputs.sha is empty (D47 gate broken)"; exit 1; }
+          MAX_ATTEMPTS=6
+          SLEEP_SEC=30
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            STATUS=$(gh api "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?head_sha=$RELEASE_SHA" \
+              --jq '.workflow_runs[0].conclusion // "pending"')
+            echo "Attempt $attempt/$MAX_ATTEMPTS: status=$STATUS"
+            case "$STATUS" in
+              success)
+                echo "CI green on release commit"
+                exit 0
+                ;;
+              failure|cancelled|timed_out)
+                echo "CI ${STATUS} on release commit — refusing to publish broken image"
+                exit 1
+                ;;
+              *)
+                sleep "$SLEEP_SEC"
+                ;;
+            esac
+          done
+          echo "CI did not complete within $((MAX_ATTEMPTS * SLEEP_SEC))s (D47 gate timeout)"
+          exit 1
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
-
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Log in to Docker Hub
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
       - name: Extract metadata for Docker
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
@@ -64,9 +104,12 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ needs.release-please.outputs.version }}
             type=semver,pattern={{major}},value=${{ needs.release-please.outputs.version }}
             type=raw,value=latest
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
+      - name: Compute SOURCE_DATE_EPOCH from git
+        id: sde
+        run: echo "value=$(git log -1 --format=%ct)" >> "$GITHUB_OUTPUT"
+      - id: build
+        name: Build and push Docker image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: Dockerfile
@@ -76,3 +119,60 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: mode=max
+          sbom: true
+          build-args: |
+            SOURCE_DATE_EPOCH=${{ steps.sde.outputs.value }}
+          outputs: type=image,rewrite-timestamp=true
+
+  sign-and-attest:
+    needs: [release-please, build-and-push]
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      packages: write
+    steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
+      - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+      - name: Sign image with cosign keyless
+        env:
+          DIGEST: ${{ needs.build-and-push.outputs.ghcr_digest }}
+          TAGS: ${{ needs.build-and-push.outputs.ghcr_image }}
+          BUNDLE_PREFIX: /tmp/cosign-bundle-${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          for tag in $TAGS; do
+            for attempt in 1 2 3; do
+              cosign sign --yes --bundle "${BUNDLE_PREFIX}-${attempt}.json" "${tag}@${DIGEST}" && break
+              echo "cosign attempt $attempt failed for ${tag} — retrying..."
+              sleep 30
+            done
+          done
+      - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ needs.build-and-push.outputs.ghcr_digest }}
+          push-to-registry: true
+      - name: Scan image for OS-layer CVEs
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        with:
+          image-ref: ghcr.io/${{ github.repository }}@${{ needs.build-and-push.outputs.ghcr_digest }}
+          severity: CRITICAL,HIGH
+          vuln-type: os,library
+          ignore-unfixed: true
+          exit-code: 1
+          format: sarif
+          output: trivy-results.sarif
+      - name: Upload Trivy SARIF to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-os-layer

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -44,7 +44,6 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          disable-sudo-and-containers: true
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
@@ -161,7 +160,7 @@ jobs:
           subject-digest: ${{ needs.build-and-push.outputs.ghcr_digest }}
           push-to-registry: true
       - name: Scan image for OS-layer CVEs
-        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ghcr.io/${{ github.repository }}@${{ needs.build-and-push.outputs.ghcr_digest }}
           severity: CRITICAL,HIGH

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,40 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '0 6 * * 1'
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+    steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+      - uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [main]
 
-permissions: read-all
+permissions: {}
 
 jobs:
   analysis:
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -73,6 +73,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions/dependency-review-action@ce3cf9537a52e8119d91fd484ab5b8a807627bf8 # v4.6.0
+        continue-on-error: true  # until dependency graph enabled on prebid/salesagent (post-merge admin)
         with:
           config-file: ./.github/dependency-review-config.yml
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           egress-policy: audit
           disable-sudo-and-containers: true
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - uses: ./.github/actions/_install-uv
@@ -46,7 +46,7 @@ jobs:
         with:
           egress-policy: audit
           disable-sudo-and-containers: true
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - uses: ./.github/actions/_install-uv
@@ -69,7 +69,7 @@ jobs:
         with:
           egress-policy: audit
           disable-sudo-and-containers: true
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - uses: actions/dependency-review-action@ce3cf9537a52e8119d91fd484ab5b8a807627bf8 # v4.6.0
@@ -87,7 +87,7 @@ jobs:
         with:
           egress-policy: audit
           disable-sudo-and-containers: true
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - run: |
@@ -116,7 +116,7 @@ jobs:
         with:
           egress-policy: audit
           disable-sudo-and-containers: true
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,6 +16,10 @@ jobs:
     permissions:
       contents: read
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           persist-credentials: false
@@ -38,6 +42,10 @@ jobs:
       contents: read
       security-events: write
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           persist-credentials: false
@@ -47,7 +55,26 @@ jobs:
       - uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f  # v3.28.18
         with:
           sarif_file: zizmor.sarif
-      - run: uvx zizmor --min-severity medium --config .github/zizmor.yml .github/workflows/
+      - run: uvx zizmor --min-severity medium --persona=auditor --config .github/zizmor.yml .github/workflows/
+
+  dependency-review:
+    name: Security / Dependency Review
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/dependency-review-action@ce3cf9537a52e8119d91fd484ab5b8a807627bf8 # v4.6.0
+        with:
+          config-file: ./.github/dependency-review-config.yml
 
   pinact:
     name: pinact (action SHA-pin enforcement)
@@ -55,6 +82,10 @@ jobs:
     permissions:
       contents: read
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           persist-credentials: false
@@ -80,6 +111,10 @@ jobs:
     permissions:
       contents: read
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+          disable-sudo-and-containers: true
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           persist-credentials: false

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -40,9 +40,9 @@ rules:
   # CLA-assistant action to commit signatures and post status checks.
   # Minimum required permissions; no narrowing possible without breaking the action.
   #
-  # release-please.yml: contents/pull-requests/packages: write are required at
-  # workflow level for release-please-action (tag/release creation) and
-  # docker/build-push-action (GHCR push). Narrowing to job-level tracked for #1234-pr3.
+  # release-please.yml: job-level permissions only (workflow default is contents +
+  # pull-requests). No workflow-level packages: write — excessive-permissions no
+  # longer fires for this file (verified via zizmor --persona=auditor).
   #
   # pr-title-check.yml: no explicit permissions block — uses workflow default.
   # The amannn/action-semantic-pull-request action requires pull-requests: write
@@ -51,7 +51,6 @@ rules:
   excessive-permissions:
     ignore:
       - ipr-agreement.yml
-      - release-please.yml
       - pr-title-check.yml
 
   # ─────────────────────────────────────────────────────────────────────────────

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -53,3 +53,21 @@ rules:
       - ipr-agreement.yml
       - release-please.yml
       - pr-title-check.yml
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # unpinned-images — ci.yml postgres service containers use the unified rolling
+  # tag postgres:17-alpine (PR 5 / ADR-008). Digest pin for service containers
+  # is deferred; test_architecture_postgres_image_anchor enforces tag consistency.
+  # ─────────────────────────────────────────────────────────────────────────────
+  unpinned-images:
+    ignore:
+      - ci.yml
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # secrets-outside-env — release-please.yml publishes to Docker Hub via repo
+  # secrets (DOCKERHUB_USER/PASSWORD). A dedicated GitHub Environment is deferred
+  # until org-level environment protection is configured (post-#1234 admin).
+  # ─────────────────────────────────────────────────────────────────────────────
+  secrets-outside-env:
+    ignore:
+      - release-please.yml

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -29,6 +29,7 @@ a decision without understanding its rationale.
 | [ADR-001](adr-001-single-source-pre-commit-deps.md) | uv.lock as single source of truth for pre-commit deps | Accepted |
 | [ADR-002](adr-002-solo-maintainer-bypass.md) | Solo-maintainer branch protection with bypass | Accepted |
 | [ADR-003](adr-003-pull-request-target-trust.md) | pull_request_target trust boundary for CLA and PR-title workflows | Accepted |
+| [ADR-007](adr-007-build-provenance.md) | Build provenance attestation (SLSA L2) | Accepted |
 | [ADR-008](adr-008-target-version-bump.md) | Defer black/ruff target-version bump out of #1234 | Accepted |
 
 ## How to add a new ADR

--- a/docs/decisions/adr-007-build-provenance.md
+++ b/docs/decisions/adr-007-build-provenance.md
@@ -45,16 +45,19 @@ Preferred — `gh attestation verify` (insulates from cosign v3/v4 churn):
 gh attestation verify oci://ghcr.io/prebid/salesagent@sha256:<digest> --owner prebid
 ```
 
-If using raw `cosign verify` directly, cosign v3+ requires the `--bundle`
-flag (mandatory; was optional in v2.x):
+If using raw `cosign verify` directly (cosign-installer@v4.1.1 ships **binary v3.0.5**;
+signatures are attached to the registry by `cosign sign`, so `--bundle` is not used
+for image verification):
 
 ```bash
 cosign verify \
   --certificate-identity-regexp 'https://github.com/prebid/salesagent/\.github/workflows/release-please\.yml@refs/heads/main' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
-  --bundle <bundle.json> \
   ghcr.io/prebid/salesagent@sha256:<digest>
 ```
+
+Cosign bundle files uploaded as workflow artifacts support offline `cosign verify-blob`
+for detached signatures; registry-attached signatures use the command above.
 
 ## Consequences
 

--- a/docs/decisions/adr-007-build-provenance.md
+++ b/docs/decisions/adr-007-build-provenance.md
@@ -1,0 +1,78 @@
+# ADR-007: Build provenance attestation
+
+## Status
+
+Accepted (2026-04-25). Implemented in PR 6 of the CI/pre-commit refactor
+follow-ups (issue #1234). Tripwire: if Sigstore's Rekor transparency log
+experiences sustained downtime (>4h), evaluate a fallback to long-lived
+cosign keypair signing.
+
+## Context
+
+PR 6 introduces `provenance: mode=max` on all `docker/build-push-action` steps
+and `actions/attest-build-provenance` for cosign keyless image signing. Build
+provenance attestations are SLSA Level 2 evidence about how an artifact was
+built — what source commit, what builder, what dependencies, what build flags.
+
+Without explicit provenance, downstream consumers (e.g., an enterprise
+pulling `ghcr.io/prebid/salesagent`) cannot:
+
+1. Verify which source commit produced the image.
+2. Confirm the image came from this repo's official CI rather than a
+   compromised fork or local build.
+3. Audit the build environment that produced the image.
+
+This matters for the salesagent project specifically because Prebid.org's
+ecosystem includes Fortune-50 ad tech consumers who increasingly require
+SLSA evidence as part of vendor assessments.
+
+Adding provenance has measurable overhead: ~40s per image build for the
+in-toto attestation generation and Rekor log entry.
+
+## Decision
+
+Adopt `provenance: mode=max` (full SLSA provenance) on all image builds
+configured in `.github/workflows/release-please.yml` and any docker-build job
+that publishes to `ghcr.io/prebid/salesagent`. Pair this with
+`actions/attest-build-provenance` to write the attestation to GitHub's storage
+AND to Sigstore's public Rekor transparency log via OIDC.
+
+**Verification path (downstream consumer).**
+
+Preferred — `gh attestation verify` (insulates from cosign v3/v4 churn):
+
+```bash
+gh attestation verify oci://ghcr.io/prebid/salesagent@sha256:<digest> --owner prebid
+```
+
+If using raw `cosign verify` directly, cosign v3+ requires the `--bundle`
+flag (mandatory; was optional in v2.x):
+
+```bash
+cosign verify \
+  --certificate-identity-regexp 'https://github.com/prebid/salesagent/\.github/workflows/release-please\.yml@refs/heads/main' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  --bundle <bundle.json> \
+  ghcr.io/prebid/salesagent@sha256:<digest>
+```
+
+## Consequences
+
+**Positive.**
+
+- Downstream consumers can verify provenance via `gh attestation verify`.
+- Sigstore Rekor provides a public, append-only audit log of every signed image.
+- Workflow-identity signing avoids PII leakage that personal-key signing would create.
+
+**Negative.**
+
+- ~40s per build overhead (acceptable on release jobs; not on per-PR builds).
+- Dependency on Sigstore's Rekor log being available.
+
+## Tripwire
+
+If Sigstore's Rekor log experiences **sustained downtime exceeding 4 hours**:
+
+1. Pause release builds (the workflow will fail attestation publication).
+2. Evaluate a fallback to long-lived cosign keypair signing as a temporary measure.
+3. Document the temporary configuration; revert to keyless once Rekor stabilizes.

--- a/scripts/creative-agent-stack.sh
+++ b/scripts/creative-agent-stack.sh
@@ -114,13 +114,17 @@ _ensure_image() {
 
 cmd_publish() {
     [ -n "${CREATIVE_AGENT_GHCR_IMAGE:-}" ] || { echo "CREATIVE_AGENT_GHCR_IMAGE required" >&2; return 1; }
+    local ref="$(_ghcr_ref)"
     if _ghcr_image_exists; then
-        echo "[creative-agent] $(_ghcr_ref) already published; nothing to do"
-        return 0
+        echo "[creative-agent] ${ref} already published; nothing to do"
+    else
+        _ensure_tarball
+        _retry 3 _build_for_ghcr
+        _retry 3 _push_to_ghcr
     fi
-    _ensure_tarball
-    _retry 3 _build_for_ghcr
-    _retry 3 _push_to_ghcr
+    if [ -n "${GITHUB_OUTPUT:-}" ]; then
+        echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+    fi
 }
 
 cmd_url() { echo "$CREATIVE_AGENT_URL"; }

--- a/tests/unit/test_architecture_image_supply_chain.py
+++ b/tests/unit/test_architecture_image_supply_chain.py
@@ -8,6 +8,10 @@ import pytest
 
 from tests.unit._architecture_helpers import repo_root
 
+# Jobs that need Docker or GitHub service containers cannot use disable-sudo-and-containers
+# (harden-runner removes the host Docker daemon). Audit-only harden-runner is sufficient.
+_DOCKER_AWARE_WORKFLOWS = frozenset({"ci.yml", "release-please.yml"})
+
 
 @pytest.mark.arch_guard
 def test_harden_runner_present_on_workflows() -> None:
@@ -18,10 +22,17 @@ def test_harden_runner_present_on_workflows() -> None:
         if wf.name == "harden-runner-emergency-revert.yml":
             continue
         text = wf.read_text()
-        if "step-security/harden-runner@" in text:
-            count += text.count("step-security/harden-runner@")
-            assert "egress-policy: audit" in text, f"{wf.name} missing audit egress-policy"
-            assert "disable-sudo-and-containers: true" in text, f"{wf.name} missing CVE-2025-32955 mitigation"
+        if "step-security/harden-runner@" not in text:
+            continue
+        hr_count = text.count("step-security/harden-runner@")
+        sudo_count = text.count("disable-sudo-and-containers: true")
+        count += hr_count
+        assert "egress-policy: audit" in text, f"{wf.name} missing audit egress-policy"
+        if wf.name in _DOCKER_AWARE_WORKFLOWS:
+            assert sudo_count >= 1, f"{wf.name} must disable sudo on non-docker jobs"
+            assert sudo_count < hr_count, f"{wf.name} must omit disable-sudo on docker/service jobs"
+        else:
+            assert sudo_count == hr_count, f"{wf.name} missing CVE-2025-32955 mitigation on a harden-runner step"
     assert count >= 5, f"expected >=5 harden-runner steps, found {count}"
 
 

--- a/tests/unit/test_architecture_image_supply_chain.py
+++ b/tests/unit/test_architecture_image_supply_chain.py
@@ -45,6 +45,7 @@ def _job_uses_docker(job: dict[str, Any]) -> bool:
             "docker build" in run_script
             or "docker run" in run_script
             or "docker push" in run_script
+            or "docker compose" in run_script
             or "./scripts/creative-agent-stack.sh" in run_script
         ):
             return True
@@ -76,16 +77,27 @@ def _assert_sign_and_attest_job(job: dict[str, Any]) -> None:
     for perm in ("id-token", "attestations", "packages", "security-events"):
         assert perms.get(perm) == "write", f"sign-and-attest missing permissions.{perm}: write"
 
-    step_uses = [_step_uses(step) for step in _job_steps(job)]
-    assert any(u.startswith("docker/login-action@") for u in step_uses), "sign-and-attest missing docker/login-action"
-    assert sum(u.startswith("docker/login-action@") for u in step_uses) >= 2, (
-        "sign-and-attest needs ghcr + Docker Hub login"
+    steps = _job_steps(job)
+    step_uses = [_step_uses(step) for step in steps]
+    assert any(u.startswith("sigstore/cosign-installer@") for u in step_uses), (
+        "sign-and-attest missing cosign-installer"
     )
-    assert any("cosign sign" in (step.get("run") or "") for step in _job_steps(job)), (
-        "sign-and-attest missing cosign sign"
+    login_runs = [step.get("run") or "" for step in steps]
+    assert any("cosign login ghcr.io" in run for run in login_runs), (
+        "sign-and-attest must daemon-free cosign login for ghcr.io"
     )
-    assert any(u.startswith("actions/attest-build-provenance@") for u in step_uses), (
-        "sign-and-attest missing provenance"
+    assert any("cosign login docker.io" in run for run in login_runs), (
+        "sign-and-attest must daemon-free cosign login for docker.io"
+    )
+    assert not any(u.startswith("docker/login-action@") for u in step_uses), (
+        "sign-and-attest must not use docker/login-action (Docker uninstalled by harden-runner)"
+    )
+    assert any("cosign sign" in run for run in login_runs), "sign-and-attest missing cosign sign"
+    assert any('[[ -n "$DIGEST" ]]' in run for run in login_runs), (
+        "sign-and-attest must guard empty image_digest before cosign sign"
+    )
+    assert sum(u.startswith("actions/attest-build-provenance@") for u in step_uses) >= 2, (
+        "sign-and-attest must attest ghcr.io and Docker Hub images"
     )
     assert any(u.startswith("actions/upload-artifact@") for u in step_uses), (
         "sign-and-attest must upload cosign bundles"
@@ -96,11 +108,32 @@ def _assert_sign_and_attest_job(job: dict[str, Any]) -> None:
 
 
 def _assert_build_and_push_job(job: dict[str, Any]) -> None:
-    names = [step.get("name", "") for step in _job_steps(job)]
-    assert any("pre-push" in name.lower() for name in names), "build-and-push missing pre-push Trivy gate"
-    push_steps = [step for step in _job_steps(job) if _step_uses(step).startswith("docker/build-push-action@")]
-    assert len(push_steps) >= 2, "build-and-push must build scan artifact then push multi-arch image"
+    perms = job.get("permissions", {})
+    assert isinstance(perms, dict)
+    assert perms.get("actions") == "read", "build-and-push D47 gate needs permissions.actions: read"
+
+    steps = _job_steps(job)
+    names = [step.get("name", "") for step in steps]
+    assert sum("pre-push" in name.lower() for name in names) >= 2, (
+        "build-and-push must Trivy-gate amd64 and arm64 before push"
+    )
+    gate_steps = [
+        step
+        for step in steps
+        if _step_uses(step).startswith("aquasecurity/trivy-action@") and "pre-push" in (step.get("name") or "").lower()
+    ]
+    assert len(gate_steps) >= 2, "build-and-push missing per-arch pre-push Trivy steps"
+    for step in gate_steps:
+        assert step.get("with", {}).get("exit-code") == 1, f"pre-push Trivy step {step.get('name')} must exit-code: 1"
+    push_steps = [step for step in steps if _step_uses(step).startswith("docker/build-push-action@")]
+    assert len(push_steps) >= 3, "build-and-push must gate amd64, gate arm64, then push multi-arch"
     assert push_steps[-1].get("with", {}).get("push") is True, "final build step must push to registry"
+
+    d47_runs = [step.get("run") or "" for step in steps if "D47 gate" in (step.get("name") or "")]
+    assert d47_runs, "build-and-push missing D47 gate step"
+    assert all("${{ github.repository }}" not in run for run in d47_runs), (
+        "D47 gate must not interpolate github.repository in run: (use env:)"
+    )
 
 
 @pytest.mark.arch_guard
@@ -135,6 +168,7 @@ def test_release_workflow_supply_chain_wiring() -> None:
     assert "image_tags:" in text
     assert "image_digest:" in text
     assert "ghcr_image:" not in text
+    assert "concurrency:" in text
     assert "provenance: mode=max" in text
     assert "sbom: true" in text
 
@@ -172,7 +206,7 @@ def test_harden_runner_guard_detects_docker_job_with_disable_sudo() -> None:
 
 @pytest.mark.arch_guard
 def test_sign_and_attest_guard_detects_missing_registry_login() -> None:
-    """Negative probe: sign-and-attest without docker login must fail."""
+    """Negative probe: sign-and-attest without daemon-free cosign login must fail."""
     job = {
         "permissions": {
             "id-token": "write",
@@ -184,11 +218,12 @@ def test_sign_and_attest_guard_detects_missing_registry_login() -> None:
             {"uses": "sigstore/cosign-installer@abc"},
             {"run": "cosign sign --yes --bundle /tmp/b.json image@sha256:abc"},
             {"uses": "actions/attest-build-provenance@abc"},
+            {"uses": "actions/attest-build-provenance@abc"},
             {"uses": "actions/upload-artifact@abc"},
             {"uses": "github/codeql-action/upload-sarif@abc"},
         ],
     }
-    with pytest.raises(AssertionError, match="docker/login-action"):
+    with pytest.raises(AssertionError, match="cosign login"):
         _assert_sign_and_attest_job(job)
 
 
@@ -206,9 +241,37 @@ def test_dependency_review_configured() -> None:
 
 @pytest.mark.arch_guard
 def test_codeql_is_gating() -> None:
-    """CodeQL analyze must block merges (no continue-on-error)."""
-    text = (repo_root() / ".github/workflows/codeql.yml").read_text(encoding="utf-8")
-    assert "continue-on-error: true" not in text
+    """CodeQL analyze job must block merges (no continue-on-error)."""
+    jobs = _load_workflow(repo_root() / ".github/workflows/codeql.yml").get("jobs", {})
+    assert isinstance(jobs, dict)
+    analyze_jobs = [job for name, job in jobs.items() if "analyze" in name.lower()]
+    assert analyze_jobs, "codeql.yml must define an analyze job"
+    for job in analyze_jobs:
+        assert job.get("continue-on-error") is not True, "CodeQL analyze must not continue-on-error"
+
+
+@pytest.mark.arch_guard
+def test_emergency_revert_detect_excludes_self() -> None:
+    """Emergency revert must not match its own grep instruction lines."""
+    text = (repo_root() / ".github/workflows/harden-runner-emergency-revert.yml").read_text(encoding="utf-8")
+    assert "--exclude='harden-runner-emergency-revert.yml'" in text
+
+
+@pytest.mark.arch_guard
+def test_creative_agent_scan_uses_publish_output_ref() -> None:
+    """publish-creative-agent Trivy must scan the ref emitted by publish, not a hardcoded pin."""
+    wf_path = repo_root() / ".github/workflows/publish-creative-agent.yml"
+    jobs = _load_workflow(wf_path).get("jobs", {})
+    publish_job = jobs.get("publish", {})
+    trivy_steps = [
+        step for step in _job_steps(publish_job) if _step_uses(step).startswith("aquasecurity/trivy-action@")
+    ]
+    assert trivy_steps, "publish-creative-agent missing Trivy scan"
+    image_ref = trivy_steps[0].get("with", {}).get("image-ref", "")
+    assert image_ref == "${{ steps.publish.outputs.ref }}", "Trivy must reference steps.publish.outputs.ref"
+    assert "ca70dd1e2a6c" not in wf_path.read_text(encoding="utf-8"), (
+        "publish-creative-agent must not hardcode ADCP pin in workflow"
+    )
 
 
 @pytest.mark.arch_guard

--- a/tests/unit/test_architecture_image_supply_chain.py
+++ b/tests/unit/test_architecture_image_supply_chain.py
@@ -2,70 +2,212 @@
 
 from __future__ import annotations
 
-import re
+from pathlib import Path
+from typing import Any
 
 import pytest
+import yaml
 
 from tests.unit._architecture_helpers import repo_root
 
-# Jobs that need Docker or GitHub service containers cannot use disable-sudo-and-containers
-# (harden-runner removes the host Docker daemon). Audit-only harden-runner is sufficient.
-_DOCKER_AWARE_WORKFLOWS = frozenset({"ci.yml", "release-please.yml"})
+_IMAGE_PUBLISHING_WORKFLOWS = frozenset({"release-please.yml", "publish-creative-agent.yml"})
+_SIGN_ATTEST_JOB = "sign-and-attest"
 
 
-@pytest.mark.arch_guard
-def test_harden_runner_present_on_workflows() -> None:
-    """Every hardened workflow must run harden-runner in audit mode."""
-    repo = repo_root()
-    count = 0
-    for wf in (repo / ".github" / "workflows").glob("*.yml"):
-        if wf.name == "harden-runner-emergency-revert.yml":
-            continue
-        text = wf.read_text()
-        if "step-security/harden-runner@" not in text:
-            continue
-        hr_count = text.count("step-security/harden-runner@")
-        sudo_count = text.count("disable-sudo-and-containers: true")
-        count += hr_count
-        assert "egress-policy: audit" in text, f"{wf.name} missing audit egress-policy"
-        if wf.name in _DOCKER_AWARE_WORKFLOWS:
-            assert sudo_count >= 1, f"{wf.name} must disable sudo on non-docker jobs"
-            assert sudo_count < hr_count, f"{wf.name} must omit disable-sudo on docker/service jobs"
+def _load_workflow(path: Path) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _job_steps(job: dict[str, Any]) -> list[dict[str, Any]]:
+    steps = job.get("steps", [])
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def _step_uses(step: dict[str, Any]) -> str:
+    return str(step.get("uses", ""))
+
+
+def _job_uses_docker(job: dict[str, Any]) -> bool:
+    if job.get("container") or job.get("services"):
+        return True
+    for step in _job_steps(job):
+        uses = _step_uses(step)
+        if uses.startswith(
+            (
+                "docker/build-push-action@",
+                "docker/setup-buildx-action@",
+                "docker/setup-qemu-action@",
+            )
+        ):
+            return True
+        run_script = step.get("run", "")
+        if isinstance(run_script, str) and (
+            "docker build" in run_script
+            or "docker run" in run_script
+            or "docker push" in run_script
+            or "./scripts/creative-agent-stack.sh" in run_script
+        ):
+            return True
+    return False
+
+
+def _harden_runner_steps(job: dict[str, Any]) -> list[dict[str, Any]]:
+    return [step for step in _job_steps(job) if _step_uses(step).startswith("step-security/harden-runner@")]
+
+
+def _assert_harden_runner_job(wf_name: str, job_name: str, job: dict[str, Any]) -> None:
+    hr_steps = _harden_runner_steps(job)
+    assert hr_steps, f"{wf_name} job {job_name} missing harden-runner step"
+    uses_docker = _job_uses_docker(job)
+    for step in hr_steps:
+        with_block = step.get("with", {})
+        assert isinstance(with_block, dict), f"{wf_name} job {job_name} harden-runner missing with:"
+        assert with_block.get("egress-policy") == "audit", f"{wf_name} job {job_name} must use egress-policy: audit"
+        sudo_disabled = with_block.get("disable-sudo-and-containers") is True
+        if uses_docker:
+            assert not sudo_disabled, f"{wf_name} job {job_name} must omit disable-sudo (docker/service job)"
         else:
-            assert sudo_count == hr_count, f"{wf.name} missing CVE-2025-32955 mitigation on a harden-runner step"
-    assert count >= 5, f"expected >=5 harden-runner steps, found {count}"
+            assert sudo_disabled, f"{wf_name} job {job_name} must set disable-sudo-and-containers: true"
+
+
+def _assert_sign_and_attest_job(job: dict[str, Any]) -> None:
+    perms = job.get("permissions", {})
+    assert isinstance(perms, dict)
+    for perm in ("id-token", "attestations", "packages", "security-events"):
+        assert perms.get(perm) == "write", f"sign-and-attest missing permissions.{perm}: write"
+
+    step_uses = [_step_uses(step) for step in _job_steps(job)]
+    assert any(u.startswith("docker/login-action@") for u in step_uses), "sign-and-attest missing docker/login-action"
+    assert sum(u.startswith("docker/login-action@") for u in step_uses) >= 2, (
+        "sign-and-attest needs ghcr + Docker Hub login"
+    )
+    assert any("cosign sign" in (step.get("run") or "") for step in _job_steps(job)), (
+        "sign-and-attest missing cosign sign"
+    )
+    assert any(u.startswith("actions/attest-build-provenance@") for u in step_uses), (
+        "sign-and-attest missing provenance"
+    )
+    assert any(u.startswith("actions/upload-artifact@") for u in step_uses), (
+        "sign-and-attest must upload cosign bundles"
+    )
+    assert any(u.startswith("github/codeql-action/upload-sarif@") for u in step_uses), (
+        "sign-and-attest missing SARIF upload"
+    )
+
+
+def _assert_build_and_push_job(job: dict[str, Any]) -> None:
+    names = [step.get("name", "") for step in _job_steps(job)]
+    assert any("pre-push" in name.lower() for name in names), "build-and-push missing pre-push Trivy gate"
+    push_steps = [step for step in _job_steps(job) if _step_uses(step).startswith("docker/build-push-action@")]
+    assert len(push_steps) >= 2, "build-and-push must build scan artifact then push multi-arch image"
+    assert push_steps[-1].get("with", {}).get("push") is True, "final build step must push to registry"
 
 
 @pytest.mark.arch_guard
-def test_release_workflow_signs_and_attests() -> None:
-    """release-please.yml must split publish/sign and include supply-chain fields."""
-    text = (repo_root() / ".github/workflows/release-please.yml").read_text()
-    assert "build-and-push:" in text
-    assert "sign-and-attest:" in text
-    assert re.search(r"sha:\s+\$\{\{\s*github\.sha\s*\}\}", text)
-    assert "cosign sign --yes --bundle" in text
-    assert "actions/attest-build-provenance" in text
+def test_image_publishing_workflows_harden_runner_per_job() -> None:
+    """Image workflows must harden every job; docker jobs omit disable-sudo."""
+    repo = repo_root()
+    wf_dir = repo / ".github" / "workflows"
+    hardened_jobs = 0
+    for wf_name in sorted(_IMAGE_PUBLISHING_WORKFLOWS):
+        wf_path = wf_dir / wf_name
+        assert wf_path.exists(), f"missing workflow {wf_name}"
+        jobs = _load_workflow(wf_path).get("jobs", {})
+        assert isinstance(jobs, dict) and jobs, f"{wf_name} has no jobs"
+        for job_name, job in jobs.items():
+            assert isinstance(job, dict), f"{wf_name} job {job_name} malformed"
+            _assert_harden_runner_job(wf_name, job_name, job)
+            hardened_jobs += len(_harden_runner_steps(job))
+    assert hardened_jobs >= 3, f"expected hardened steps across publishing workflows, found {hardened_jobs}"
+
+
+@pytest.mark.arch_guard
+def test_release_workflow_supply_chain_wiring() -> None:
+    """release-please.yml must gate before push, then sign/attest with registry auth."""
+    wf_path = repo_root() / ".github/workflows/release-please.yml"
+    jobs = _load_workflow(wf_path).get("jobs", {})
+    assert "build-and-push" in jobs
+    assert _SIGN_ATTEST_JOB in jobs
+    _assert_build_and_push_job(jobs["build-and-push"])
+    _assert_sign_and_attest_job(jobs[_SIGN_ATTEST_JOB])
+
+    text = wf_path.read_text(encoding="utf-8")
+    assert "image_tags:" in text
+    assert "image_digest:" in text
+    assert "ghcr_image:" not in text
     assert "provenance: mode=max" in text
     assert "sbom: true" in text
-    assert "aquasecurity/trivy-action" in text
+
+
+@pytest.mark.arch_guard
+def test_harden_runner_guard_detects_missing_disable_sudo() -> None:
+    """Negative probe: non-docker job without disable-sudo must fail the guard."""
+    job = {
+        "runs-on": "ubuntu-latest",
+        "steps": [
+            {"uses": "step-security/harden-runner@abc", "with": {"egress-policy": "audit"}},
+            {"run": "echo ok"},
+        ],
+    }
+    with pytest.raises(AssertionError, match="disable-sudo"):
+        _assert_harden_runner_job("probe.yml", "probe", job)
+
+
+@pytest.mark.arch_guard
+def test_harden_runner_guard_detects_docker_job_with_disable_sudo() -> None:
+    """Negative probe: docker job with disable-sudo must fail the guard."""
+    job = {
+        "runs-on": "ubuntu-latest",
+        "services": {"postgres": {"image": "postgres:17-alpine"}},
+        "steps": [
+            {
+                "uses": "step-security/harden-runner@abc",
+                "with": {"egress-policy": "audit", "disable-sudo-and-containers": True},
+            },
+        ],
+    }
+    with pytest.raises(AssertionError, match="omit disable-sudo"):
+        _assert_harden_runner_job("probe.yml", "docker-probe", job)
+
+
+@pytest.mark.arch_guard
+def test_sign_and_attest_guard_detects_missing_registry_login() -> None:
+    """Negative probe: sign-and-attest without docker login must fail."""
+    job = {
+        "permissions": {
+            "id-token": "write",
+            "attestations": "write",
+            "packages": "write",
+            "security-events": "write",
+        },
+        "steps": [
+            {"uses": "sigstore/cosign-installer@abc"},
+            {"run": "cosign sign --yes --bundle /tmp/b.json image@sha256:abc"},
+            {"uses": "actions/attest-build-provenance@abc"},
+            {"uses": "actions/upload-artifact@abc"},
+            {"uses": "github/codeql-action/upload-sarif@abc"},
+        ],
+    }
+    with pytest.raises(AssertionError, match="docker/login-action"):
+        _assert_sign_and_attest_job(job)
 
 
 @pytest.mark.arch_guard
 def test_dependency_review_configured() -> None:
     """security.yml runs dependency-review with extracted config."""
     repo = repo_root()
-    security = (repo / ".github/workflows/security.yml").read_text()
+    security = (repo / ".github/workflows/security.yml").read_text(encoding="utf-8")
     assert "actions/dependency-review-action" in security
     assert "Security / Dependency Review" in security
     config = repo / ".github/dependency-review-config.yml"
     assert config.exists()
-    assert "fail-on-severity: moderate" in config.read_text()
+    assert "fail-on-severity: moderate" in config.read_text(encoding="utf-8")
 
 
 @pytest.mark.arch_guard
 def test_codeql_is_gating() -> None:
     """CodeQL analyze must block merges (no continue-on-error)."""
-    text = (repo_root() / ".github/workflows/codeql.yml").read_text()
+    text = (repo_root() / ".github/workflows/codeql.yml").read_text(encoding="utf-8")
     assert "continue-on-error: true" not in text
 
 
@@ -74,6 +216,16 @@ def test_scorecard_workflow_present() -> None:
     """OpenSSF Scorecard self-host workflow must exist."""
     path = repo_root() / ".github/workflows/scorecard.yml"
     assert path.exists()
-    text = path.read_text()
+    text = path.read_text(encoding="utf-8")
     assert "ossf/scorecard-action" in text
     assert "publish_results: true" in text
+
+
+@pytest.mark.arch_guard
+def test_checkout_pins_consistent_on_hardened_workflows() -> None:
+    """Hardened workflows use a single actions/checkout SHA pin."""
+    expected = "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5"
+    for wf_name in ("ci.yml", "security.yml", "codeql.yml", "release-please.yml", "publish-creative-agent.yml"):
+        text = (repo_root() / ".github/workflows" / wf_name).read_text(encoding="utf-8")
+        assert expected in text, f"{wf_name} must pin checkout to {expected}"
+        assert "actions/checkout@11bd719" not in text, f"{wf_name} still uses stale checkout pin"

--- a/tests/unit/test_architecture_image_supply_chain.py
+++ b/tests/unit/test_architecture_image_supply_chain.py
@@ -96,9 +96,14 @@ def _assert_sign_and_attest_job(job: dict[str, Any]) -> None:
     assert any('[[ -n "$DIGEST" ]]' in run for run in login_runs), (
         "sign-and-attest must guard empty image_digest before cosign sign"
     )
-    assert sum(u.startswith("actions/attest-build-provenance@") for u in step_uses) >= 2, (
-        "sign-and-attest must attest ghcr.io and Docker Hub images"
-    )
+    attest_steps = [step for step in steps if _step_uses(step).startswith("actions/attest-build-provenance@")]
+    assert len(attest_steps) >= 2, "sign-and-attest must attest ghcr.io and Docker Hub images"
+    ghcr_attest = [s for s in attest_steps if "ghcr.io/" in str(s.get("with", {}).get("subject-name", ""))]
+    dockerhub_attest = [
+        s for s in attest_steps if str(s.get("with", {}).get("subject-name", "")).startswith("docker.io/")
+    ]
+    assert ghcr_attest, "sign-and-attest must attest ghcr.io image with registry host"
+    assert dockerhub_attest, "sign-and-attest Docker Hub attest must use docker.io/ registry host in subject-name"
     assert any(u.startswith("actions/upload-artifact@") for u in step_uses), (
         "sign-and-attest must upload cosign bundles"
     )
@@ -125,6 +130,11 @@ def _assert_build_and_push_job(job: dict[str, Any]) -> None:
     assert len(gate_steps) >= 2, "build-and-push missing per-arch pre-push Trivy steps"
     for step in gate_steps:
         assert step.get("with", {}).get("exit-code") == 1, f"pre-push Trivy step {step.get('name')} must exit-code: 1"
+    arm64_gate = [step for step in gate_steps if "arm64" in (step.get("name") or "").lower()]
+    assert arm64_gate, "build-and-push missing arm64 pre-push Trivy gate"
+    assert arm64_gate[0].get("env", {}).get("TRIVY_PLATFORM") == "linux/arm64", (
+        "arm64 pre-push Trivy must set TRIVY_PLATFORM=linux/arm64"
+    )
     push_steps = [step for step in steps if _step_uses(step).startswith("docker/build-push-action@")]
     assert len(push_steps) >= 3, "build-and-push must gate amd64, gate arm64, then push multi-arch"
     assert push_steps[-1].get("with", {}).get("push") is True, "final build step must push to registry"
@@ -205,6 +215,33 @@ def test_harden_runner_guard_detects_docker_job_with_disable_sudo() -> None:
 
 
 @pytest.mark.arch_guard
+def test_sign_and_attest_guard_detects_bare_dockerhub_subject_name() -> None:
+    """Negative probe: Docker Hub attest without docker.io/ host must fail."""
+    job = {
+        "permissions": {
+            "id-token": "write",
+            "attestations": "write",
+            "packages": "write",
+            "security-events": "write",
+        },
+        "steps": [
+            {"uses": "sigstore/cosign-installer@abc"},
+            {"run": "cosign login ghcr.io\ncosign login docker.io"},
+            {"run": '[[ -n "$DIGEST" ]]\ncosign sign --yes image@sha256:abc'},
+            {"uses": "actions/attest-build-provenance@abc", "with": {"subject-name": "ghcr.io/org/repo"}},
+            {
+                "uses": "actions/attest-build-provenance@abc",
+                "with": {"subject-name": "${{ secrets.DOCKERHUB_USER }}/salesagent"},
+            },
+            {"uses": "actions/upload-artifact@abc"},
+            {"uses": "github/codeql-action/upload-sarif@abc"},
+        ],
+    }
+    with pytest.raises(AssertionError, match="docker.io/"):
+        _assert_sign_and_attest_job(job)
+
+
+@pytest.mark.arch_guard
 def test_sign_and_attest_guard_detects_missing_registry_login() -> None:
     """Negative probe: sign-and-attest without daemon-free cosign login must fail."""
     job = {
@@ -241,13 +278,30 @@ def test_dependency_review_configured() -> None:
 
 @pytest.mark.arch_guard
 def test_codeql_is_gating() -> None:
-    """CodeQL analyze job must block merges (no continue-on-error)."""
+    """CodeQL analyze job and steps must block merges (no continue-on-error)."""
     jobs = _load_workflow(repo_root() / ".github/workflows/codeql.yml").get("jobs", {})
     assert isinstance(jobs, dict)
     analyze_jobs = [job for name, job in jobs.items() if "analyze" in name.lower()]
     assert analyze_jobs, "codeql.yml must define an analyze job"
     for job in analyze_jobs:
-        assert job.get("continue-on-error") is not True, "CodeQL analyze must not continue-on-error"
+        assert job.get("continue-on-error") is not True, "CodeQL analyze job must not continue-on-error"
+        for step in _job_steps(job):
+            assert step.get("continue-on-error") is not True, (
+                f"CodeQL analyze step {_step_uses(step) or step.get('name')} must not continue-on-error"
+            )
+
+
+@pytest.mark.arch_guard
+def test_codeql_guard_detects_step_level_continue_on_error() -> None:
+    """Negative probe: step-level continue-on-error on analyze must fail the guard."""
+    job = {
+        "steps": [
+            {"uses": "github/codeql-action/analyze@abc", "continue-on-error": True},
+        ],
+    }
+    with pytest.raises(AssertionError, match="continue-on-error"):
+        for step in _job_steps(job):
+            assert step.get("continue-on-error") is not True
 
 
 @pytest.mark.arch_guard

--- a/tests/unit/test_architecture_image_supply_chain.py
+++ b/tests/unit/test_architecture_image_supply_chain.py
@@ -1,0 +1,68 @@
+"""Structural guards for PR 6 image supply-chain hardening (issue #1234)."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from tests.unit._architecture_helpers import repo_root
+
+
+@pytest.mark.arch_guard
+def test_harden_runner_present_on_workflows() -> None:
+    """Every hardened workflow must run harden-runner in audit mode."""
+    repo = repo_root()
+    count = 0
+    for wf in (repo / ".github" / "workflows").glob("*.yml"):
+        if wf.name == "harden-runner-emergency-revert.yml":
+            continue
+        text = wf.read_text()
+        if "step-security/harden-runner@" in text:
+            count += text.count("step-security/harden-runner@")
+            assert "egress-policy: audit" in text, f"{wf.name} missing audit egress-policy"
+            assert "disable-sudo-and-containers: true" in text, f"{wf.name} missing CVE-2025-32955 mitigation"
+    assert count >= 5, f"expected >=5 harden-runner steps, found {count}"
+
+
+@pytest.mark.arch_guard
+def test_release_workflow_signs_and_attests() -> None:
+    """release-please.yml must split publish/sign and include supply-chain fields."""
+    text = (repo_root() / ".github/workflows/release-please.yml").read_text()
+    assert "build-and-push:" in text
+    assert "sign-and-attest:" in text
+    assert re.search(r"sha:\s+\$\{\{\s*github\.sha\s*\}\}", text)
+    assert "cosign sign --yes --bundle" in text
+    assert "actions/attest-build-provenance" in text
+    assert "provenance: mode=max" in text
+    assert "sbom: true" in text
+    assert "aquasecurity/trivy-action" in text
+
+
+@pytest.mark.arch_guard
+def test_dependency_review_configured() -> None:
+    """security.yml runs dependency-review with extracted config."""
+    repo = repo_root()
+    security = (repo / ".github/workflows/security.yml").read_text()
+    assert "actions/dependency-review-action" in security
+    assert "Security / Dependency Review" in security
+    config = repo / ".github/dependency-review-config.yml"
+    assert config.exists()
+    assert "fail-on-severity: moderate" in config.read_text()
+
+
+@pytest.mark.arch_guard
+def test_codeql_is_gating() -> None:
+    """CodeQL analyze must block merges (no continue-on-error)."""
+    text = (repo_root() / ".github/workflows/codeql.yml").read_text()
+    assert "continue-on-error: true" not in text
+
+
+@pytest.mark.arch_guard
+def test_scorecard_workflow_present() -> None:
+    """OpenSSF Scorecard self-host workflow must exist."""
+    path = repo_root() / ".github/workflows/scorecard.yml"
+    assert path.exists()
+    text = path.read_text()
+    assert "ossf/scorecard-action" in text
+    assert "publish_results: true" in text


### PR DESCRIPTION
## Summary

Part of **#1234 — PR 6 of 6 (final)**. Image and workflow supply-chain hardening: egress auditing, signed release artifacts, OS-layer CVE gating, and security workflow expansion. Closes the #1234 rollout code path; post-merge admin steps remain (branch protection, dependency graph).

**Branch tip:** `2bbcc645` · **CI:** green (Summary ✅ on latest run)

## What changed

### harden-runner (step-security v2.19.0, CVE-2025-32955)
- Added to **all Ubuntu jobs** in `ci.yml`, `security.yml`, `codeql.yml`, `release-please.yml`, `scorecard.yml`
- **Tiered policy:** `disable-sudo-and-containers: true` on jobs without Docker; audit-only on Docker/service-container jobs (quickstart, integration, e2e, admin, BDD, migration, `build-and-push`) — host Docker required for GHA services
- `harden-runner-emergency-revert.yml` — `workflow_dispatch` PR creator to flip `block` → `audit` if egress lockout occurs

### Release pipeline (`release-please.yml`)
Split into **`build-and-push`** + **`sign-and-attest`**:
- `cosign sign --yes --bundle` keyless signing
- `actions/attest-build-provenance` with `provenance: mode=max`, `sbom: true`
- `aquasecurity/trivy-action` — CRITICAL/HIGH OS-layer scan gates release
- **D47 gate:** sign/attest only when CI is green on release commit
- `SOURCE_DATE_EPOCH` from git + BuildKit `rewrite-timestamp=true`

### Security workflows
- **`dependency-review`** job (`Security / Dependency Review`) with `.github/dependency-review-config.yml` (`fail-on-severity: moderate`)
  - `continue-on-error: true` until dependency graph enabled on `prebid/salesagent` (post-merge admin)
- **`scorecard.yml`** — OpenSSF Scorecard self-host, SARIF upload
- **`codeql.yml`** — removed `continue-on-error` (gating per D10 Week 5)
- **`.github/zizmor.yml`** — allowlist entries for intentional postgres rolling tag + Docker Hub secrets
- **zizmor auditor persona** in `security.yml` — catches workflow permission drift

### Governance
- `docs/decisions/adr-007-build-provenance.md` — cosign/SBOM/provenance policy
- `test_architecture_image_supply_chain.py` — 5 `arch_guard` tests (harden-runner tiering, release signing fields, dependency-review wiring, CodeQL gating, scorecard presence)

> **Canonical BDD sharding (PR #1379):** 2 parallel shards, greedy scenario-count assignment, **20** rendered `CI / …` check names. Older PR comments mentioning 3/4 shards or 21/22 checks are superseded.

## Stack order (#1234)

Merge in order: **#1370 → #1372 → #1379 → #1424 → #1390 → #1400 (PR5) → this PR**.

**Review focus** — commits unique to PR6:

```bash
git log ci/pr5-version-consolidation..ci/pr6-image-supply-chain
```

→ `8afa387b` (main PR6) · `ef39c075` (harden-runner tiering + CI fixes) · `2bbcc645` (zizmor: job-level `packages: write` on publish-creative-agent)

```bash
git diff ci/pr5-version-consolidation..ci/pr6-image-supply-chain --stat
```

→ 12 files, +482/−27

### Suggested review focus (@ChrisHuie)
- Confirm PR6-only diff scope matches this description (`git log` range above)
- harden-runner tiering (Docker jobs stay audit-only; non-Docker jobs get `disable-sudo-and-containers`)
- release sign/attest/Trivy pipeline + D47 CI-green gate
- security workflow expansion (dependency-review, scorecard, CodeQL gating, zizmor auditor)
- Regression guards from earlier stack PRs preserved (called out below)

## Post-merge admin (maintainer — not in this PR)

1. Enable **dependency graph** on `prebid/salesagent`; add `Security / Dependency Review` to branch protection
2. Enable **secret scanning + push protection**
3. After ≥2 weeks harden-runner **audit** telemetry on `main`: separate PR flipping `egress-policy: audit` → `block` (see note below)
4. OpenSSF Scorecard badge enrollment (target ≥7.5/10 per #1234 acceptance criteria)
5. Remove `continue-on-error` on dependency-review once graph is enabled (currently soft-fails until graph exists)

**Why audit → block is deferred:** This PR ships `egress-policy: audit` everywhere so CI keeps running while Step Security records outbound destinations (PyPI, GitHub API, Docker registries, Sigstore, etc.) across all job types — including release and Docker-heavy shards. Flipping to `block` on day one would reject any connection not yet on the allowlist and can mass-fail CI with no production signal yet. The ≥2 week window collects real `main` traffic (PRs, nightly CodeQL, releases) before tightening; `harden-runner-emergency-revert.yml` exists if block mode locks contributors out.

| Who | Other post-merge task |
|-----|----------------------|
| **Author** | Close #1234; open ADR-008 follow-up PR (black/ruff `target-version` py312) separately |

### Already done earlier in chain (do not repeat)
- PR3: migrate branch protection to **18** `CI / …` checks (remove `Test Suite / …`)
- PR3-2: add **3** BDD shard required checks (→ **21** total)

Run `./scripts/capture-rendered-names.sh` whenever renaming CI jobs.

## Regression guards (intentionally unchanged)

- **PR2–PR5:** pre-commit layering, 20 frozen CI checks, 2 greedy BDD shards, version anchors, Dockerfile digest + non-root

## Test plan

- [x] CI green on this branch (all jobs including Quickstart, Integration shards, BDD shards, zizmor auditor, CodeQL gating)
- [x] `uv run pytest tests/unit/test_architecture_image_supply_chain.py -v`
- [x] `uv run pytest tests/unit/ -m arch_guard -x`
- [x] `uvx zizmor --min-severity medium --persona=auditor --config .github/zizmor.yml .github/workflows/` — exit 0

Closes the image supply-chain slice of #1234 (PR 6 of 6 — final code PR).