### PR TITLE
fix: Wrong number of arguments in a class instantiation

### DIFF
--- a/tests/unit/test_format_id_spec_compliance.py
+++ b/tests/unit/test_format_id_spec_compliance.py
@@ -189,7 +189,8 @@ def test_pricing_service_receives_format_id_objects():
     """
     from src.services.dynamic_pricing_service import DynamicPricingService
 
-    service = DynamicPricingService()
+    pricing_dependency = MagicMock()
+    service = DynamicPricingService(pricing_dependency)
 
     mock_product = MagicMock()
     mock_product.format_ids = [


### PR DESCRIPTION
To fix this without changing functionality, update the test to instantiate `DynamicPricingService` with the required constructor argument using a lightweight mock dependency. This keeps the test focused on `_calculate_product_pricing` behavior while satisfying the class contract and preventing `TypeError`.

In `tests/unit/test_format_id_spec_compliance.py`, edit the `test_pricing_service_receives_format_id_objects` function around line 192:
- Create a `MagicMock()` (or similar) as the required init dependency.
- Pass it to `DynamicPricingService(...)` instead of calling with no arguments.

No new imports are needed because `MagicMock` is already imported on line 10.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._