### PR TITLE
fix: Non-exception in 'except' clause

### DIFF
--- a/tests/integration/test_a2a_skill_invocation.py
+++ b/tests/integration/test_a2a_skill_invocation.py
@@ -25,7 +25,11 @@ try:
 except ImportError:
     SCHEMA_VALIDATION_AVAILABLE = False
     AdCPSchemaValidator: type[AdCPSchemaValidator] | None = None  # type: ignore[no-redef]
-    SchemaValidationError: type[SchemaValidationError] | None = None  # type: ignore[no-redef]
+
+    class SchemaValidationError(Exception):
+        """Fallback exception type when schema validator is unavailable."""
+
+        pass
 
 # Configure logging for tests
 logging.basicConfig(level=logging.DEBUG)


### PR DESCRIPTION
To fix this without changing behavior, make sure `SchemaValidationError` is always an exception class, even when the optional import fails.

Best single fix in this file:
- In the `except ImportError:` block (lines 25–28 region), replace the `None` assignment for `SchemaValidationError` with a small local fallback exception class (e.g., `class SchemaValidationError(Exception): pass`).
- Keep `SCHEMA_VALIDATION_AVAILABLE = False` logic unchanged so schema validation is still skipped when unavailable.
- Leave `AdCPSchemaValidator` as `None`-typed placeholder if needed; it is not used in an `except` clause.

This preserves existing functionality (schema validation still disabled when missing) while making the exception handler always valid.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._