### PR TITLE
fix: Mismatch in multiple assignment

### DIFF
--- a/scripts/compile_bdd.py
+++ b/scripts/compile_bdd.py
@@ -1597,7 +1597,7 @@ def verify_features(adcp_req_path: Path) -> bool:
         text = source_path.read_text()
         feature = parse_feature_file(text)
         uc_key = _extract_uc_key(source_path.name)
-        expected, _new = _render_feature(feature, traceability, uc_key, source_path.name, commit_sha)
+        expected, _new, _unused = _render_feature(feature, traceability, uc_key, source_path.name, commit_sha)
         actual = output_path.read_text()
         # Compare ignoring timestamp differences in the generation stamp
         # (first two lines contain the timestamp)


### PR DESCRIPTION
The fix is to unpack all values returned by `_render_feature` (3 values) and ignore only the ones not needed in `verify_features`.  
Best minimal fix: update line 1600 in `scripts/compile_bdd.py` from two-target unpacking to three-target unpacking, keeping `expected` and discarding the extra return values with throwaway variables. This avoids changing functionality and only resolves the arity mismatch.

Concretely in `verify_features(...)`, replace:

- `expected, _new = _render_feature(...)`

with:

- `expected, _new, _unused = _render_feature(...)`

No imports, helper methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._