### PR TITLE
fix: Fix for Invocation of non-function

### DIFF
--- a/templates/components/setup_checklist_widget.html
+++ b/templates/components/setup_checklist_widget.html
@@ -91,7 +91,7 @@
                 {% endfor %}
                 {% if incomplete_recommended | length > 2 %}
                 <div style="font-size: 0.75rem; opacity: 0.8; font-style: italic;">
-                    + {{ incomplete_recommended | length - 2 }} more recommended
+                    + {{ (incomplete_recommended | length) - 2 }} more recommended
                 </div>
                 {% endif %}
             </div>


### PR DESCRIPTION
To fix this cleanly without changing behavior, make the arithmetic precedence explicit by adding parentheses around the filtered length result.

Best single change in `templates/components/setup_checklist_widget.html`:
- Replace `{{ incomplete_recommended | length - 2 }}` with `{{ (incomplete_recommended | length) - 2 }}` on the “+ N more recommended” line.
- This preserves output exactly while removing ambiguity for static analysis tools.

No imports, helper methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._