### PR TITLE
fix:  for Invocation of non-function

### DIFF
--- a/templates/components/setup_checklist_widget.html
+++ b/templates/components/setup_checklist_widget.html
@@ -57,7 +57,7 @@
         </div>
         {% if incomplete_critical | length > 3 %}
         <div style="margin-top: 0.75rem; font-size: 0.75rem; opacity: 0.9;">
-            + {{ incomplete_critical | length - 3 }} more critical tasks
+            + {{ (incomplete_critical | length) - 3 }} more critical tasks
         </div>
         {% endif %}
     </div>


### PR DESCRIPTION
Use explicit parentheses so the arithmetic is unambiguously applied to the `length` result.

Best fix (no behavior change): in `templates/components/setup_checklist_widget.html`, line 60 region, change:
- `{{ incomplete_critical | length - 3 }}`
to:
- `{{ (incomplete_critical | length) - 3 }}`

This preserves output exactly while making the expression explicit and avoiding “callee is not a function” style misinterpretation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._