### PR TITLE
fix: for Invocation of non-function

### DIFF
--- a/templates/policy_settings_comprehensive.html
+++ b/templates/policy_settings_comprehensive.html
@@ -129,7 +129,7 @@
                             </div>
                             {% if pending_reviews|length > 5 %}
                                 <div class="mt-2 text-center">
-                                    <small class="text-muted">and {{ pending_reviews|length - 5 }} more...</small>
+                                    <small class="text-muted">and {{ (pending_reviews|length) - 5 }} more...</small>
                                 </div>
                             {% endif %}
                         {% else %}


### PR DESCRIPTION
To fix this safely without changing functionality, make the arithmetic grouping explicit in the template output expression so the analyzer cannot misinterpret filter/arithmetic precedence.

Best change in `templates/policy_settings_comprehensive.html`:
- Replace `{{ pending_reviews|length - 5 }}` with `{{ (pending_reviews|length) - 5 }}` on the “and N more...” line.
- This preserves exact behavior while removing ambiguity.

No imports, helper methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._