### PR TITLE
fix: Fix for Wrong number of arguments in a cally

### DIFF
--- a/tests/unit/test_format_id_spec_compliance.py
+++ b/tests/unit/test_format_id_spec_compliance.py
@@ -200,7 +200,13 @@ def test_pricing_service_receives_format_id_objects():
 
     # If format_ids are FormatId objects, the service should handle them
     # without needing isinstance checks for str or dict
-    result = service._calculate_product_pricing(mock_product)
+    result = service._calculate_product_pricing(
+        mock_product,
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+    )
     assert "base_rate" in result or result is not None
 
 


### PR DESCRIPTION
To fix this without changing product functionality, update the unit test to call `_calculate_product_pricing` with the full required argument list expected by `DynamicPricingService`. Since this is test code and we only need to satisfy invocation shape, pass lightweight placeholder values/mocks for the additional required parameters while preserving the test’s intent (that FormatId objects are handled).

Best fix in this file:
- Edit `tests/unit/test_format_id_spec_compliance.py` at the call on line 203.
- Replace the one-argument call with a five-argument call by adding `MagicMock()` placeholders for the missing required parameters.
- No import changes are needed because `MagicMock` is already imported on line 10.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._