### PR TITLE
fix(test): read step files as UTF-8 in BDD guard (Windows crash)

### DIFF
--- a/tests/unit/test_architecture_bdd_no_direct_call_impl.py
+++ b/tests/unit/test_architecture_bdd_no_direct_call_impl.py
@@ -74,7 +74,7 @@ def _scan_bdd_steps() -> list[str]:
     for py_file in sorted(_BDD_STEPS_DIR.rglob("*.py")):
         if py_file.name.startswith("__"):
             continue
-        source = py_file.read_text()
+        source = py_file.read_text(encoding="utf-8")
         source_lines = source.splitlines()
         tree = ast.parse(source, filename=str(py_file))
         relative = py_file.relative_to(_BDD_STEPS_DIR.parent.parent)
@@ -120,7 +120,7 @@ class TestBddNoDirectCallImpl:
             # Find the file
             matches = list(_BDD_STEPS_DIR.rglob(f"{file_stem}.py"))
             assert matches, f"Allowlisted file '{file_stem}.py' not found"
-            source = matches[0].read_text()
+            source = matches[0].read_text(encoding="utf-8")
             tree = ast.parse(source)
             found = False
             for node in ast.walk(tree):


### PR DESCRIPTION
## Summary
The `test_architecture_bdd_no_direct_call_impl` guard reads step files with the platform default encoding. On Windows that's cp1252, and the UTF-8 box-drawing section headers in the step files crash the guard with `UnicodeDecodeError` before it checks anything — the unit suite can't run on a Windows checkout. Pin `encoding='utf-8'` on both `read_text()` calls.

CI (Linux, UTF-8 default) was unaffected — this only fixes local dev on Windows.

## Test plan
- [x] `pytest tests/unit/test_architecture_bdd_no_direct_call_impl.py` passes on Windows after the fix (crashed before)