### PR TITLE
fix(ci): cache creative agent build with buildx GHA cache (#1189)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      actions: write # GHA cache for buildx (creative shard only)
+      actions: write # GHA cache upload for buildx (used by creative shard step only)
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -219,6 +219,9 @@ jobs:
       - name: Set up Docker Buildx
         if: matrix.group == 'creative'
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - name: Expose GHA cache runtime to buildx
+        if: matrix.group == 'creative'
+        uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
       - name: Start pinned creative agent
         if: matrix.group == 'creative'
         run: ./scripts/creative-agent-stack.sh up

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      actions: write # GHA cache for buildx (creative shard only)
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -215,6 +216,9 @@ jobs:
       - uses: ./.github/actions/_postgres
         with:
           database-url: ${{ env.DATABASE_URL }}
+      - name: Set up Docker Buildx
+        if: matrix.group == 'creative'
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Start pinned creative agent
         if: matrix.group == 'creative'
         run: ./scripts/creative-agent-stack.sh up

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      actions: write # GHA cache upload for buildx (used by creative shard step only)
+      packages: write # push adcp-creative-agent to ghcr.io (creative shard step only)
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -216,14 +216,17 @@ jobs:
       - uses: ./.github/actions/_postgres
         with:
           database-url: ${{ env.DATABASE_URL }}
-      - name: Set up Docker Buildx
+      - name: Log in to GitHub Container Registry
         if: matrix.group == 'creative'
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - name: Expose GHA cache runtime to buildx
-        if: matrix.group == 'creative'
-        uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Start pinned creative agent
         if: matrix.group == 'creative'
+        env:
+          CREATIVE_AGENT_GHCR_IMAGE: ghcr.io/${{ github.repository }}/adcp-creative-agent
         run: ./scripts/creative-agent-stack.sh up
       - uses: ./.github/actions/_pytest
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write # push adcp-creative-agent to ghcr.io (creative shard step only)
+      packages: read # pull adcp-creative-agent from ghcr.io (publish runs on main via publish-creative-agent.yml)
     timeout-minutes: 15
     strategy:
       fail-fast: false

--- a/.github/workflows/publish-creative-agent.yml
+++ b/.github/workflows/publish-creative-agent.yml
@@ -1,0 +1,27 @@
+name: Publish creative agent image
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push pinned creative agent
+        env:
+          CREATIVE_AGENT_GHCR_IMAGE: ghcr.io/${{ github.repository }}/adcp-creative-agent
+        run: ./scripts/creative-agent-stack.sh publish

--- a/docs/development/ci-pipeline.md
+++ b/docs/development/ci-pipeline.md
@@ -128,6 +128,28 @@ commit without authentication.
 cleanly. Check the `community_points` / `users` table FK ordering — this was the
 failure that prompted pinning (April 2026).
 
+The pin lives only in [`scripts/creative-agent-stack.sh`](../../scripts/creative-agent-stack.sh)
+— both CI and `run_all_tests.sh` call that script so local and CI cannot diverge.
+
+### CI build cache and retries
+
+On ephemeral GitHub Actions runners, local `/tmp` tarball reuse and `docker image
+inspect` guards do not survive between runs. The creative shard therefore:
+
+1. Runs `docker/setup-buildx-action` (creative matrix leg only) before
+   `creative-agent-stack.sh up`.
+2. Uses `docker buildx build --cache-from/to type=gha` inside the script when
+   `ACTIONS_CACHE_URL` and `ACTIONS_RUNTIME_TOKEN` are present (CI). Cache scope
+   is `adcp-creative-agent-${ADCP_PIN}` so a pin bump invalidates stale layers.
+3. Falls back to plain `docker build` locally — no CI-only env required for
+   `run_all_tests.sh`.
+
+Tarball fetch (`curl -f`) and docker build each retry up to 3 times with
+exponential backoff to absorb transient `ECONNRESET` flakes.
+
+The `integration-tests` job grants `actions: write` so buildx can upload GHA
+cache entries (same pattern as [`release-please.yml`](../../.github/workflows/release-please.yml)).
+
 ### Creative agent infrastructure
 
 The agent runs in its own Docker network (`creative-net`) with a separate

--- a/docs/development/ci-pipeline.md
+++ b/docs/development/ci-pipeline.md
@@ -136,11 +136,14 @@ The pin lives only in [`scripts/creative-agent-stack.sh`](../../scripts/creative
 On ephemeral GitHub Actions runners, local `/tmp` tarball reuse and `docker image
 inspect` guards do not survive between runs. The creative shard therefore:
 
-1. Runs `docker/setup-buildx-action` (creative matrix leg only) before
-   `creative-agent-stack.sh up`.
+1. Runs `docker/setup-buildx-action` and `ghaction-github-runtime` (creative
+   matrix leg only) before `creative-agent-stack.sh up`. The runtime action
+   exposes `ACTIONS_RUNTIME_TOKEN` to shell steps — without it, `type=gha` cache
+   backends cannot authenticate (unlike `docker/build-push-action`, which injects
+   the token internally).
 2. Uses `docker buildx build --cache-from/to type=gha` inside the script when
-   `ACTIONS_CACHE_URL` and `ACTIONS_RUNTIME_TOKEN` are present (CI). Cache scope
-   is `adcp-creative-agent-${ADCP_PIN}` so a pin bump invalidates stale layers.
+   `ACTIONS_RUNTIME_TOKEN` is present. Cache scope is
+   `adcp-creative-agent-${ADCP_PIN}` so a pin bump invalidates stale layers.
 3. Falls back to plain `docker build` locally — no CI-only env required for
    `run_all_tests.sh`.
 

--- a/docs/development/ci-pipeline.md
+++ b/docs/development/ci-pipeline.md
@@ -131,27 +131,29 @@ failure that prompted pinning (April 2026).
 The pin lives only in [`scripts/creative-agent-stack.sh`](../../scripts/creative-agent-stack.sh)
 — both CI and `run_all_tests.sh` call that script so local and CI cannot diverge.
 
-### CI build cache and retries
+### CI image cache (ghcr.io) and retries
 
 On ephemeral GitHub Actions runners, local `/tmp` tarball reuse and `docker image
 inspect` guards do not survive between runs. The creative shard therefore:
 
-1. Runs `docker/setup-buildx-action` and `ghaction-github-runtime` (creative
-   matrix leg only) before `creative-agent-stack.sh up`. The runtime action
-   exposes `ACTIONS_RUNTIME_TOKEN` to shell steps — without it, `type=gha` cache
-   backends cannot authenticate (unlike `docker/build-push-action`, which injects
-   the token internally).
-2. Uses `docker buildx build --cache-from/to type=gha` inside the script when
-   `ACTIONS_RUNTIME_TOKEN` is present. Cache scope is
-   `adcp-creative-agent-${ADCP_PIN}` so a pin bump invalidates stale layers.
+1. Logs in to `ghcr.io` via `docker/login-action` (creative matrix leg only) and
+   sets `CREATIVE_AGENT_GHCR_IMAGE=ghcr.io/<repo>/adcp-creative-agent` before
+   `creative-agent-stack.sh up`.
+2. Inside the script, when `CREATIVE_AGENT_GHCR_IMAGE` is set:
+   - **Warm run** (image tag `${ADCP_PIN}` already in ghcr.io): `docker pull` +
+     retag to local `adcp-creative-agent` — no compile, no buildx `--load`.
+   - **Cold run** (pin bump or first publish): fetch tarball, `docker build`,
+     `docker push` to `ghcr.io/...:${ADCP_PIN}`.
 3. Falls back to plain `docker build` locally — no CI-only env required for
    `run_all_tests.sh`.
 
-Tarball fetch (`curl -f`) and docker build each retry up to 3 times with
-exponential backoff to absorb transient `ECONNRESET` flakes.
+Tarball fetch (`curl -f`), `docker pull`, `docker build`, and `docker push` each
+retry up to 3 times with exponential backoff to absorb transient `ECONNRESET`
+flakes.
 
-The `integration-tests` job grants `actions: write` so buildx can upload GHA
-cache entries (same pattern as [`release-please.yml`](../../.github/workflows/release-please.yml)).
+The `integration-tests` job grants `packages: write` so the creative shard can
+publish the pre-built image (same registry pattern as
+[`release-please.yml`](../../.github/workflows/release-please.yml)).
 
 ### Creative agent infrastructure
 

--- a/docs/development/ci-pipeline.md
+++ b/docs/development/ci-pipeline.md
@@ -134,26 +134,50 @@ The pin lives only in [`scripts/creative-agent-stack.sh`](../../scripts/creative
 ### CI image cache (ghcr.io) and retries
 
 On ephemeral GitHub Actions runners, local `/tmp` tarball reuse and `docker image
-inspect` guards do not survive between runs. The creative shard therefore:
+inspect` guards do not survive between runs. Pin-keyed images in GHCR avoid a
+full monolith compile on warm CI runs.
 
-1. Logs in to `ghcr.io` via `docker/login-action` (creative matrix leg only) and
-   sets `CREATIVE_AGENT_GHCR_IMAGE=ghcr.io/<repo>/adcp-creative-agent` before
-   `creative-agent-stack.sh up`.
-2. Inside the script, when `CREATIVE_AGENT_GHCR_IMAGE` is set:
-   - **Warm run** (image tag `${ADCP_PIN}` already in ghcr.io): `docker pull` +
-     retag to local `adcp-creative-agent` — no compile, no buildx `--load`.
-   - **Cold run** (pin bump or first publish): fetch tarball, `docker build`,
-     `docker push` to `ghcr.io/...:${ADCP_PIN}`.
-3. Falls back to plain `docker build` locally — no CI-only env required for
-   `run_all_tests.sh`.
+**Publish (trusted `main` context only).** The
+[`publish-creative-agent.yml`](../../.github/workflows/publish-creative-agent.yml)
+workflow runs on `push` to `main` and `workflow_dispatch`. It logs in to
+`ghcr.io` and calls `creative-agent-stack.sh publish`, which builds from the
+pinned tarball and pushes `ghcr.io/<repo>/adcp-creative-agent:${ADCP_PIN}`.
+If the tag already exists, publish is a no-op. Publish failures fail the
+workflow loudly (unlike the test shard, which degrades gracefully).
 
-Tarball fetch (`curl -f`), `docker pull`, `docker build`, and `docker push` each
-retry up to 3 times with exponential backoff to absorb transient `ECONNRESET`
-flakes.
+**CI test shard (pull-only).** The creative matrix leg logs in to `ghcr.io`
+(authenticated pulls dodge anonymous rate limits and work for public images
+from fork PRs), sets `CREATIVE_AGENT_GHCR_IMAGE`, and calls
+`creative-agent-stack.sh up`:
 
-The `integration-tests` job grants `packages: write` so the creative shard can
-publish the pre-built image (same registry pattern as
-[`release-please.yml`](../../.github/workflows/release-please.yml)).
+- **Warm run** (public image tag `${ADCP_PIN}` in ghcr.io): `docker pull` +
+  retag to local `adcp-creative-agent` — no compile.
+- **Cold / degraded** (package absent, private, or pull blip): fetch tarball and
+  `docker build` locally. The shard never pushes.
+
+**Local.** `run_all_tests.sh` calls `up` without `CREATIVE_AGENT_GHCR_IMAGE` —
+plain `docker build`, same pin source.
+
+Tarball fetch (`curl -f`), `docker pull`, and `docker build` each retry up to
+3 times with exponential backoff to absorb transient `ECONNRESET` flakes.
+Publish also retries `docker push`.
+
+The `integration-tests` job grants `packages: read` for GHCR pulls. Publishing
+uses `packages: write` only in `publish-creative-agent.yml` on `main`.
+
+**Maintainer prerequisites (org/repo — one-time):**
+
+1. After merge, trigger `Publish creative agent image` via `workflow_dispatch`
+   and confirm it creates `adcp-creative-agent` (not `denied: Create
+   organization package`). If denied, enable Actions package creation in Org →
+   Packages or have an admin pre-create the empty package, then re-run.
+2. Set the GHCR package **Public** so fork PRs can pull. Until then, the
+   creative shard builds locally everywhere (green, no speedup).
+
+**Fork PR caveat:** warm-cache pull is not verifiable on a fork PR until the
+public package exists. Measure the real pull time on `main` before claiming
+#1189's <30s warm step — a large image may still exceed 30s; slimming the
+image is a sensible follow-up if needed.
 
 ### Creative agent infrastructure
 

--- a/scripts/creative-agent-stack.sh
+++ b/scripts/creative-agent-stack.sh
@@ -55,21 +55,62 @@ _fetch_tarball() {
         | tar xz -C "$SRC" --strip-components=1
 }
 
-_build_image() {
-    local cache_scope="adcp-creative-agent-${ADCP_PIN}"
-    # ACTIONS_RUNTIME_TOKEN is exposed to run: steps via ghaction-github-runtime in CI
-    # (v1 ACTIONS_CACHE_URL is not available in shell steps; v2 uses ACTIONS_RESULTS_URL).
-    if [ -n "${ACTIONS_RUNTIME_TOKEN:-}" ]; then
-        echo "[creative-agent] buildx build $IMAGE (adcp@${ADCP_PIN}, gha cache scope=${cache_scope})"
-        docker buildx build \
-            --load \
-            -t "$IMAGE" \
-            --cache-from "type=gha,scope=${cache_scope}" \
-            --cache-to "type=gha,mode=max,scope=${cache_scope}" \
-            "$SRC"
+_ensure_tarball() {
+    if [ ! -f "$SRC/Dockerfile" ]; then
+        echo "[creative-agent] fetching adcp@${ADCP_PIN}"
+        _retry 3 _fetch_tarball
+    fi
+}
+
+_ghcr_ref() {
+    echo "${CREATIVE_AGENT_GHCR_IMAGE}:${ADCP_PIN}"
+}
+
+_ghcr_image_exists() {
+    docker manifest inspect "$(_ghcr_ref)" >/dev/null 2>&1
+}
+
+_pull_from_ghcr() {
+    local ref="$(_ghcr_ref)"
+    echo "[creative-agent] pulling ${ref} from ghcr.io"
+    docker pull "$ref"
+    docker tag "$ref" "$IMAGE"
+}
+
+_build_image_local() {
+    echo "[creative-agent] docker build $IMAGE (adcp@${ADCP_PIN})"
+    docker build -t "$IMAGE" "$SRC"
+}
+
+_build_for_ghcr() {
+    local ref="$(_ghcr_ref)"
+    echo "[creative-agent] docker build ${ref} (adcp@${ADCP_PIN})"
+    docker build -t "$ref" -t "$IMAGE" "$SRC"
+}
+
+_push_to_ghcr() {
+    local ref="$(_ghcr_ref)"
+    echo "[creative-agent] pushing ${ref} to ghcr.io"
+    docker push "$ref"
+}
+
+_ensure_image() {
+    if docker image inspect "$IMAGE" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    if [ -n "${CREATIVE_AGENT_GHCR_IMAGE:-}" ]; then
+        if _ghcr_image_exists; then
+            _retry 3 _pull_from_ghcr
+        else
+            _ensure_tarball
+            _retry 3 _build_for_ghcr
+            _retry 3 _push_to_ghcr || \
+                echo "[creative-agent] WARN: ghcr.io push skipped; using local image" >&2
+        fi
     else
-        echo "[creative-agent] docker build $IMAGE (adcp@${ADCP_PIN})"
-        docker build -t "$IMAGE" "$SRC"
+        _ensure_tarball
+        _retry 3 _build_image_local
     fi
 }
 
@@ -81,15 +122,7 @@ cmd_up() {
         return 0
     fi
 
-    # Source tarball pinned to ADCP_PIN (cached by pin in the path)
-    if [ ! -f "$SRC/Dockerfile" ]; then
-        echo "[creative-agent] fetching adcp@${ADCP_PIN}"
-        _retry 3 _fetch_tarball
-    fi
-
-    if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
-        _retry 3 _build_image
-    fi
+    _ensure_image
 
     docker network inspect "$NET" >/dev/null 2>&1 || docker network create "$NET"
 

--- a/scripts/creative-agent-stack.sh
+++ b/scripts/creative-agent-stack.sh
@@ -10,9 +10,10 @@
 # .github/workflows/ci.yml calls this same script (single source of the pin).
 #
 # Usage:
-#   scripts/creative-agent-stack.sh up     # idempotent: build+run if needed, wait healthy
-#   scripts/creative-agent-stack.sh down   # stop+rm containers+network (keeps image/tarball cache)
-#   scripts/creative-agent-stack.sh url    # print CREATIVE_AGENT_URL
+#   scripts/creative-agent-stack.sh up      # idempotent: build+run if needed, wait healthy
+#   scripts/creative-agent-stack.sh down    # stop+rm containers+network (keeps image/tarball cache)
+#   scripts/creative-agent-stack.sh url     # print CREATIVE_AGENT_URL
+#   scripts/creative-agent-stack.sh publish # build+push pin-keyed image to ghcr.io (CI publish workflow)
 set -euo pipefail
 
 # Pin to a known-good commit — upstream HEAD has broken migrations
@@ -99,19 +100,26 @@ _ensure_image() {
         return 0
     fi
 
-    if [ -n "${CREATIVE_AGENT_GHCR_IMAGE:-}" ]; then
-        if _ghcr_image_exists; then
-            _retry 3 _pull_from_ghcr
-        else
-            _ensure_tarball
-            _retry 3 _build_for_ghcr
-            _retry 3 _push_to_ghcr || \
-                echo "[creative-agent] WARN: ghcr.io push skipped; using local image" >&2
+    if [ -n "${CREATIVE_AGENT_GHCR_IMAGE:-}" ] && _ghcr_image_exists; then
+        if _retry 3 _pull_from_ghcr; then
+            return 0
         fi
-    else
-        _ensure_tarball
-        _retry 3 _build_image_local
+        echo "[creative-agent] WARN: ghcr pull failed; building locally" >&2
     fi
+
+    _ensure_tarball
+    _retry 3 _build_image_local
+}
+
+cmd_publish() {
+    [ -n "${CREATIVE_AGENT_GHCR_IMAGE:-}" ] || { echo "CREATIVE_AGENT_GHCR_IMAGE required" >&2; return 1; }
+    if _ghcr_image_exists; then
+        echo "[creative-agent] $(_ghcr_ref) already published; nothing to do"
+        return 0
+    fi
+    _ensure_tarball
+    _retry 3 _build_for_ghcr
+    _retry 3 _push_to_ghcr
 }
 
 cmd_url() { echo "$CREATIVE_AGENT_URL"; }
@@ -167,5 +175,6 @@ case "${1:-}" in
     up) cmd_up ;;
     down) cmd_down ;;
     url) cmd_url ;;
-    *) echo "usage: $0 {up|down|url}" >&2; exit 2 ;;
+    publish) cmd_publish ;;
+    *) echo "usage: $0 {up|down|url|publish}" >&2; exit 2 ;;
 esac

--- a/scripts/creative-agent-stack.sh
+++ b/scripts/creative-agent-stack.sh
@@ -29,6 +29,48 @@ CREATIVE_AGENT_URL="http://localhost:9999/api/creative-agent"
 
 _healthy() { curl -sf -m 3 "$HEALTH" >/dev/null 2>&1; }
 
+# Retry transient network failures (ECONNRESET during npm/tarball fetch in CI).
+_retry() {
+    local max="${1:-3}"
+    shift
+    local attempt=1 delay=2
+    while [ "$attempt" -le "$max" ]; do
+        if "$@"; then
+            return 0
+        fi
+        if [ "$attempt" -eq "$max" ]; then
+            break
+        fi
+        echo "[creative-agent] attempt ${attempt}/${max} failed, retrying in ${delay}s..." >&2
+        sleep "$delay"
+        delay=$((delay * 2))
+        attempt=$((attempt + 1))
+    done
+    return 1
+}
+
+_fetch_tarball() {
+    mkdir -p "$SRC"
+    curl -sLf "https://github.com/adcontextprotocol/adcp/archive/${ADCP_PIN}.tar.gz" \
+        | tar xz -C "$SRC" --strip-components=1
+}
+
+_build_image() {
+    local cache_scope="adcp-creative-agent-${ADCP_PIN}"
+    if [ -n "${ACTIONS_CACHE_URL:-}" ] && [ -n "${ACTIONS_RUNTIME_TOKEN:-}" ]; then
+        echo "[creative-agent] buildx build $IMAGE (adcp@${ADCP_PIN}, gha cache scope=${cache_scope})"
+        docker buildx build \
+            --load \
+            -t "$IMAGE" \
+            --cache-from "type=gha,scope=${cache_scope}" \
+            --cache-to "type=gha,mode=max,scope=${cache_scope}" \
+            "$SRC"
+    else
+        echo "[creative-agent] docker build $IMAGE (adcp@${ADCP_PIN})"
+        docker build -t "$IMAGE" "$SRC"
+    fi
+}
+
 cmd_url() { echo "$CREATIVE_AGENT_URL"; }
 
 cmd_up() {
@@ -40,14 +82,11 @@ cmd_up() {
     # Source tarball pinned to ADCP_PIN (cached by pin in the path)
     if [ ! -f "$SRC/Dockerfile" ]; then
         echo "[creative-agent] fetching adcp@${ADCP_PIN}"
-        mkdir -p "$SRC"
-        curl -sL "https://github.com/adcontextprotocol/adcp/archive/${ADCP_PIN}.tar.gz" \
-            | tar xz -C "$SRC" --strip-components=1
+        _retry 3 _fetch_tarball
     fi
 
     if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
-        echo "[creative-agent] docker build $IMAGE (adcp@${ADCP_PIN})"
-        docker build -t "$IMAGE" "$SRC"
+        _retry 3 _build_image
     fi
 
     docker network inspect "$NET" >/dev/null 2>&1 || docker network create "$NET"

--- a/scripts/creative-agent-stack.sh
+++ b/scripts/creative-agent-stack.sh
@@ -57,7 +57,9 @@ _fetch_tarball() {
 
 _build_image() {
     local cache_scope="adcp-creative-agent-${ADCP_PIN}"
-    if [ -n "${ACTIONS_CACHE_URL:-}" ] && [ -n "${ACTIONS_RUNTIME_TOKEN:-}" ]; then
+    # ACTIONS_RUNTIME_TOKEN is exposed to run: steps via ghaction-github-runtime in CI
+    # (v1 ACTIONS_CACHE_URL is not available in shell steps; v2 uses ACTIONS_RESULTS_URL).
+    if [ -n "${ACTIONS_RUNTIME_TOKEN:-}" ]; then
         echo "[creative-agent] buildx build $IMAGE (adcp@${ADCP_PIN}, gha cache scope=${cache_scope})"
         docker buildx build \
             --load \


### PR DESCRIPTION
## Summary
- Add buildx + GHA cache (`scope=adcp-creative-agent-${ADCP_PIN}`) to the creative integration shard so cold CI runs reuse Docker layers instead of rebuilding from scratch every time.
- Retry tarball fetch and docker build (3 attempts, exponential backoff) to absorb transient network flakes.
- Document CI cache behavior and local fallback in `docs/development/ci-pipeline.md`.

Closes #1189.

## Test plan
- [ ] CI creative integration shard completes on cold run (buildx cache upload)
- [ ] Second CI run on same pin shows faster creative agent startup (cache hit)
- [ ] Local `./scripts/creative-agent-stack.sh up` still uses plain `docker build` (no GHA env required)