### PR TITLE
fix: forward typed account in get_media_buy_delivery A2A skill

### DIFF
--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -1947,7 +1947,15 @@ class AdCPRequestHandler(RequestHandler):
         if "media_buy_ids" not in params and "media_buy_id" in params:
             params["media_buy_ids"] = [params.pop("media_buy_id")]
 
-        req = GetMediaBuyDeliveryRequest.model_validate(params)
+        from pydantic import ValidationError
+
+        try:
+            req = GetMediaBuyDeliveryRequest.model_validate(params)
+        except ValidationError as e:
+            raise AdCPValidationError(
+                f"Invalid parameters: {e}",
+                field=first_validation_error_field(e),
+            ) from e
 
         # Call core function with validated fields (all optional per AdCP spec).
         # Every _impl parameter MUST be forwarded (Critical Pattern #5 —

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -1965,7 +1965,7 @@ class AdCPRequestHandler(RequestHandler):
             reporting_dimensions=req.reporting_dimensions,
             attribution_window=req.attribution_window,
             include_package_daily_breakdown=req.include_package_daily_breakdown,
-            account=params.get("account"),
+            account=req.account,
             context=params.get("context"),
             identity=identity,
         )

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -106,7 +106,7 @@ from src.core.tools import (
 from src.core.tools import (
     update_performance_index_raw as core_update_performance_index_tool,
 )
-from src.core.validation_helpers import first_validation_error_field
+from src.core.validation_helpers import adcp_validation_boundary
 from src.core.version import get_version
 from src.services.protocol_webhook_service import get_protocol_webhook_service
 
@@ -1528,8 +1528,6 @@ class AdCPRequestHandler(RequestHandler):
         tool_context = self._make_tool_context(identity, "create_media_buy")
 
         # Parse parameters into typed request model (validation at A2A boundary)
-        from pydantic import ValidationError
-
         from src.core.schemas import CreateMediaBuyRequest
 
         # Pre-process: A2A field name translations
@@ -1572,10 +1570,8 @@ class AdCPRequestHandler(RequestHandler):
                 suggestion=f"Required: {required_params}",
             )
 
-        try:
+        with adcp_validation_boundary():
             req = CreateMediaBuyRequest.model_validate(params)
-        except ValidationError as e:
-            raise AdCPValidationError(f"Invalid parameters: {e}", field=first_validation_error_field(e)) from e
 
         # Call core function with validated parameters and identity.
         # Per AdCP 4.3 (commit 3c604130) targeting_overlay and budgets live on each
@@ -1866,8 +1862,6 @@ class AdCPRequestHandler(RequestHandler):
         # Identity already resolved at transport boundary (on_message_send)
 
         # Parse parameters into typed request model (validation at A2A boundary)
-        from pydantic import ValidationError
-
         from src.core.schemas import UpdateMediaBuyRequest
 
         # Pre-process: support legacy 'updates.packages' → 'packages'
@@ -1887,7 +1881,7 @@ class AdCPRequestHandler(RequestHandler):
 
         # Validate top-level fields via typed model (packages validated by _raw
         # which handles legacy formats with extra fields like 'status')
-        try:
+        with adcp_validation_boundary():
             req = UpdateMediaBuyRequest(
                 media_buy_id=params.get("media_buy_id"),
                 paused=params.get("paused"),
@@ -1895,8 +1889,6 @@ class AdCPRequestHandler(RequestHandler):
                 end_time=params.get("end_time"),
                 context=params.get("context"),
             )
-        except ValidationError as e:
-            raise AdCPValidationError(f"Invalid parameters: {e}", field=first_validation_error_field(e)) from e
 
         # Call core function with validated fields + raw nested structures and identity
         response = core_update_media_buy_tool(
@@ -1947,15 +1939,8 @@ class AdCPRequestHandler(RequestHandler):
         if "media_buy_ids" not in params and "media_buy_id" in params:
             params["media_buy_ids"] = [params.pop("media_buy_id")]
 
-        from pydantic import ValidationError
-
-        try:
+        with adcp_validation_boundary():
             req = GetMediaBuyDeliveryRequest.model_validate(params)
-        except ValidationError as e:
-            raise AdCPValidationError(
-                f"Invalid parameters: {e}",
-                field=first_validation_error_field(e),
-            ) from e
 
         # Call core function with validated fields (all optional per AdCP spec).
         # Every _impl parameter MUST be forwarded (Critical Pattern #5 —
@@ -1985,15 +1970,10 @@ class AdCPRequestHandler(RequestHandler):
         # Identity already resolved at transport boundary (on_message_send)
 
         # Parse parameters into typed request model (validation at A2A boundary)
-        from pydantic import ValidationError
-
         from src.core.schemas import UpdatePerformanceIndexRequest
 
-        try:
+        with adcp_validation_boundary():
             req = UpdatePerformanceIndexRequest.model_validate(parameters)
-        except ValidationError as e:
-            # Raise typed AdCPValidationError so the outer dispatcher emits a two-layer envelope.
-            raise AdCPValidationError(f"Invalid parameters: {e}", field=first_validation_error_field(e)) from e
 
         # Call core function with validated fields and identity
         response = core_update_performance_index_tool(

--- a/src/core/validation_helpers.py
+++ b/src/core/validation_helpers.py
@@ -8,10 +8,32 @@ import asyncio
 import concurrent.futures
 import json
 import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 from pydantic import ValidationError
 
+from src.core.exceptions import AdCPValidationError
+
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def adcp_validation_boundary() -> Iterator[None]:
+    """Translate a Pydantic ``ValidationError`` into a typed ``AdCPValidationError``.
+
+    A2A skill handlers validate buyer parameters at the transport boundary. A raw
+    ``ValidationError`` leaking from ``model_validate`` (or a typed-model constructor)
+    would surface as an untyped error — and the outer dispatcher only builds the
+    two-layer error envelope for ``AdCPError`` subclasses, so the buyer would lose
+    the real code/recovery. Wrapping the construction in this boundary gives every
+    handler the same ``Invalid parameters: ...`` message plus a structured ``field``
+    path, instead of a hand-copied try/except per handler.
+    """
+    try:
+        yield
+    except ValidationError as e:
+        raise AdCPValidationError(f"Invalid parameters: {e}", field=first_validation_error_field(e)) from e
 
 
 def run_async_in_sync_context(coroutine):

--- a/tests/integration/test_a2a_error_responses.py
+++ b/tests/integration/test_a2a_error_responses.py
@@ -245,6 +245,49 @@ class TestA2AErrorPropagation:
         artifact_data = self.extract_data_from_artifact(result.artifacts[0])
         assert_envelope_shape(artifact_data, "INVALID_REQUEST", recovery="correctable")
 
+    async def test_get_media_buy_delivery_malformed_account_wire_envelope(self, handler, test_tenant, test_principal):
+        """A malformed account on get_media_buy_delivery surfaces VALIDATION_ERROR on the A2A wire.
+
+        Companion to the handler-level unit test in test_a2a_parameter_mapping.py: this drives
+        the real on_message_send pipeline so the buyer-facing two-layer DataPart envelope — not
+        just the raised exception — is asserted. An empty account dict ({}) matches neither
+        account-ref oneOf variant, so GetMediaBuyDeliveryRequest validation fails at the boundary.
+        """
+        identity = PrincipalFactory.make_identity(
+            principal_id=test_principal["principal_id"],
+            tenant_id=test_tenant["tenant_id"],
+            tenant=test_tenant,
+            auth_token=test_principal["access_token"],
+            protocol="a2a",
+        )
+        handler._get_auth_token = MagicMock(return_value=test_principal["access_token"])
+        handler._resolve_a2a_identity = MagicMock(return_value=identity)
+
+        from src.core.config_loader import set_current_tenant
+
+        set_current_tenant(test_tenant)
+
+        message = self.create_message_with_skill("get_media_buy_delivery", {"account": {}})
+        params = SendMessageRequest(message=message)
+
+        result = await handler.on_message_send(params, ServerCallContext())
+
+        assert isinstance(result, Task)
+        assert result.artifacts is not None
+        assert len(result.artifacts) > 0
+
+        artifact_data = self.extract_data_from_artifact(result.artifacts[0])
+        # message_substr is the load-bearing assertion: a bare pydantic ValidationError is a
+        # ValueError, which the dispatcher also normalizes to VALIDATION_ERROR/correctable — so
+        # only the handler's wrapped "Invalid parameters" message distinguishes the fix (typed
+        # AdCPValidationError) from the raw-leak it replaced. Keep it when editing this assert.
+        assert_envelope_shape(
+            artifact_data,
+            "VALIDATION_ERROR",
+            recovery="correctable",
+            message_substr="Invalid parameters",
+        )
+
     async def test_create_media_buy_negative_budget_wire_envelope(self, handler, test_tenant, test_principal):
         """A negative package budget surfaces VALIDATION_ERROR on the A2A wire.
 

--- a/tests/integration/test_a2a_skill_invocation.py
+++ b/tests/integration/test_a2a_skill_invocation.py
@@ -12,10 +12,15 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from a2a.types import Artifact, Message, Part, Role, SendMessageRequest, Task, TaskState, TaskStatus
+from adcp.types import AccountReference as LibraryAccountReference
 
 from src.a2a_server.adcp_a2a_server import AdCPRequestHandler
 from tests.factories.creative_asset import build_assets, image_spec
-from tests.utils.a2a_helpers import create_a2a_message_with_skill, create_a2a_text_message
+from tests.utils.a2a_helpers import (
+    assert_delivery_forwarded_account,
+    create_a2a_message_with_skill,
+    create_a2a_text_message,
+)
 
 pytestmark = [pytest.mark.integration, pytest.mark.requires_db]
 
@@ -993,6 +998,43 @@ class TestA2ASkillInvocation:
             assert result.metadata["invocation_type"] == "explicit_skill"
             assert "get_media_buy_delivery" in result.metadata["skills_requested"]
             assert result.artifacts is not None
+
+    @pytest.mark.asyncio
+    async def test_get_media_buy_delivery_skill_forwards_typed_account(
+        self, handler, sample_tenant, sample_principal, mock_identity, validator
+    ):
+        """A valid account survives the real on_message_send dispatch as a typed AccountReference.
+
+        The handler-level unit tests (test_a2a_parameter_mapping.py) prove the skill method
+        forwards req.account, and the malformed-account wire test (test_a2a_error_responses.py)
+        proves the error path. This is the missing happy-path half: it drives the full
+        DataPart-extraction → param-passing pipeline through on_message_send and asserts the
+        buyer's account reaches the core tool validated, not as the raw dict that crashed
+        resolve_account (account_ref.root on a dict).
+        """
+        handler._get_auth_token = MagicMock(return_value=sample_principal["access_token"])
+
+        with (
+            patch("src.core.resolved_identity.resolve_identity", return_value=mock_identity),
+            patch("src.a2a_server.adcp_a2a_server.core_get_media_buy_delivery_tool") as mock_delivery,
+        ):
+            mock_delivery.return_value = {"media_buys": []}
+
+            from tests.a2a_helpers import make_a2a_context
+
+            ctx = make_a2a_context(headers={"host": f"{sample_tenant['subdomain']}.example.com"})
+
+            skill_params = {"media_buy_ids": ["mb_test_123"], "account": {"account_id": "acct-1"}}
+            message = create_a2a_message_with_skill("get_media_buy_delivery", skill_params)
+            params = SendMessageRequest(message=message)
+
+            result = await handler.on_message_send(params, context=ctx)
+
+            assert isinstance(result, Task)
+            assert result.artifacts is not None
+
+            expected = LibraryAccountReference.model_validate({"account_id": "acct-1"})
+            assert_delivery_forwarded_account(mock_delivery, expected)
 
     @pytest.mark.asyncio
     async def test_approve_creative_skill(self, handler, sample_tenant, sample_principal, mock_identity, validator):

--- a/tests/unit/test_a2a_parameter_mapping.py
+++ b/tests/unit/test_a2a_parameter_mapping.py
@@ -255,6 +255,31 @@ class TestA2AParameterMapping:
                 context=ANY,
                 identity=ANY,
             )
+            
+    def test_get_media_buy_delivery_rejects_malformed_account(self):
+        """Malformed account should fail validation and not call the core tool."""
+        from src.a2a_server.adcp_a2a_server import AdCPRequestHandler
+        from src.core.exceptions import AdCPValidationError
+
+        handler = AdCPRequestHandler()
+
+        with (
+            patch("src.core.resolved_identity.resolve_identity", return_value=_MOCK_IDENTITY),
+            patch("src.a2a_server.adcp_a2a_server.core_get_media_buy_delivery_tool") as mock_delivery,
+        ):
+            parameters = {"account": {}}
+
+            import asyncio
+
+            with pytest.raises(AdCPValidationError):
+                asyncio.run(
+                    handler._handle_get_media_buy_delivery_skill(
+                        parameters=parameters,
+                        identity=_MOCK_IDENTITY,
+                    )
+                )
+
+            mock_delivery.assert_not_called()
 
     def test_create_media_buy_validates_required_adcp_parameters(self):
         """

--- a/tests/unit/test_a2a_parameter_mapping.py
+++ b/tests/unit/test_a2a_parameter_mapping.py
@@ -10,12 +10,13 @@ CRITICAL: These tests catch protocol mismatches like 'updates' vs 'packages'
 before they reach production.
 """
 
-from unittest.mock import ANY, patch
+from unittest.mock import patch
 
 import pytest
 from adcp.types import AccountReference as LibraryAccountReference
 
 from tests.factories.principal import PrincipalFactory
+from tests.utils.a2a_helpers import assert_delivery_forwarded_account
 
 _MOCK_IDENTITY = PrincipalFactory.make_identity(
     principal_id="principal_123",
@@ -240,18 +241,7 @@ class TestA2AParameterMapping:
 
             expected = LibraryAccountReference.model_validate({"account_id": "acct-1"})
 
-            mock_delivery.assert_called_once_with(
-                media_buy_ids=ANY,
-                status_filter=ANY,
-                start_date=ANY,
-                end_date=ANY,
-                reporting_dimensions=ANY,
-                attribution_window=ANY,
-                include_package_daily_breakdown=ANY,
-                account=expected,
-                context=ANY,
-                identity=ANY,
-            )
+            assert_delivery_forwarded_account(mock_delivery, expected)
 
     def test_get_media_buy_delivery_forwards_natural_key_account_reference(self):
         """A2A get_media_buy_delivery forwards the validated {brand, operator} account form.
@@ -276,18 +266,7 @@ class TestA2AParameterMapping:
 
             expected = LibraryAccountReference.model_validate(account)
 
-            mock_delivery.assert_called_once_with(
-                media_buy_ids=ANY,
-                status_filter=ANY,
-                start_date=ANY,
-                end_date=ANY,
-                reporting_dimensions=ANY,
-                attribution_window=ANY,
-                include_package_daily_breakdown=ANY,
-                account=expected,
-                context=ANY,
-                identity=ANY,
-            )
+            assert_delivery_forwarded_account(mock_delivery, expected)
 
     def test_get_media_buy_delivery_rejects_malformed_account(self):
         """Malformed account should fail validation and not call the core tool."""

--- a/tests/unit/test_a2a_parameter_mapping.py
+++ b/tests/unit/test_a2a_parameter_mapping.py
@@ -10,7 +10,7 @@ CRITICAL: These tests catch protocol mismatches like 'updates' vs 'packages'
 before they reach production.
 """
 
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 
@@ -240,7 +240,18 @@ class TestA2AParameterMapping:
 
             asyncio.run(handler._handle_get_media_buy_delivery_skill(parameters=parameters, identity=_MOCK_IDENTITY))
 
-            mock_delivery.assert_called_once()
+            mock_delivery.assert_called_once_with(
+                media_buy_ids=ANY,
+                status_filter=ANY,
+                start_date=ANY,
+                end_date=ANY,
+                reporting_dimensions=ANY,
+                attribution_window=ANY,
+                include_package_daily_breakdown=ANY,
+                account=ANY,
+                context=ANY,
+                identity=ANY,
+            )
             account = mock_delivery.call_args.kwargs["account"]
 
             assert account is not parameters["account"], "Should not forward the raw A2A account dict"

--- a/tests/unit/test_a2a_parameter_mapping.py
+++ b/tests/unit/test_a2a_parameter_mapping.py
@@ -222,6 +222,30 @@ class TestA2AParameterMapping:
             assert call_kwargs["start_date"] == "2025-01-01", "Should pass start_date"
             assert call_kwargs["end_date"] == "2025-01-31", "Should pass end_date"
 
+    def test_get_media_buy_delivery_forwards_typed_account_reference(self):
+        """A2A get_media_buy_delivery must pass the validated account model."""
+        from src.a2a_server.adcp_a2a_server import AdCPRequestHandler
+
+        handler = AdCPRequestHandler()
+
+        with (
+            patch("src.core.resolved_identity.resolve_identity", return_value=_MOCK_IDENTITY),
+            patch("src.a2a_server.adcp_a2a_server.core_get_media_buy_delivery_tool") as mock_delivery,
+        ):
+            mock_delivery.return_value = {"media_buys": []}
+
+            parameters = {"account": {"account_id": "acct-1"}}
+
+            import asyncio
+
+            asyncio.run(handler._handle_get_media_buy_delivery_skill(parameters=parameters, identity=_MOCK_IDENTITY))
+
+            mock_delivery.assert_called_once()
+            account = mock_delivery.call_args.kwargs["account"]
+
+            assert account is not parameters["account"], "Should not forward the raw A2A account dict"
+            assert hasattr(account, "root"), "Should forward a validated AccountReference"
+
     def test_create_media_buy_validates_required_adcp_parameters(self):
         """
         Test that create_media_buy validates required AdCP parameters.

--- a/tests/unit/test_a2a_parameter_mapping.py
+++ b/tests/unit/test_a2a_parameter_mapping.py
@@ -11,9 +11,9 @@ before they reach production.
 """
 
 from unittest.mock import ANY, patch
-from adcp.types import AccountReference as LibraryAccountReference
 
 import pytest
+from adcp.types import AccountReference as LibraryAccountReference
 
 from tests.factories.principal import PrincipalFactory
 
@@ -229,10 +229,7 @@ class TestA2AParameterMapping:
 
         handler = AdCPRequestHandler()
 
-        with (
-            patch("src.core.resolved_identity.resolve_identity", return_value=_MOCK_IDENTITY),
-            patch("src.a2a_server.adcp_a2a_server.core_get_media_buy_delivery_tool") as mock_delivery,
-        ):
+        with patch("src.a2a_server.adcp_a2a_server.core_get_media_buy_delivery_tool") as mock_delivery:
             mock_delivery.return_value = {"media_buys": []}
 
             parameters = {"account": {"account_id": "acct-1"}}
@@ -255,7 +252,43 @@ class TestA2AParameterMapping:
                 context=ANY,
                 identity=ANY,
             )
-            
+
+    def test_get_media_buy_delivery_forwards_natural_key_account_reference(self):
+        """A2A get_media_buy_delivery forwards the validated {brand, operator} account form.
+
+        Complements the {account_id} case above by pinning the natural-key
+        AccountReference variant — the form the delivery conformance storyboard
+        sends — whose nested brand exercises its own coercion path.
+        """
+        from src.a2a_server.adcp_a2a_server import AdCPRequestHandler
+
+        handler = AdCPRequestHandler()
+
+        with patch("src.a2a_server.adcp_a2a_server.core_get_media_buy_delivery_tool") as mock_delivery:
+            mock_delivery.return_value = {"media_buys": []}
+
+            account = {"brand": {"domain": "acmeoutdoor.example"}, "operator": "pinnacle-agency.example"}
+            parameters = {"account": account}
+
+            import asyncio
+
+            asyncio.run(handler._handle_get_media_buy_delivery_skill(parameters=parameters, identity=_MOCK_IDENTITY))
+
+            expected = LibraryAccountReference.model_validate(account)
+
+            mock_delivery.assert_called_once_with(
+                media_buy_ids=ANY,
+                status_filter=ANY,
+                start_date=ANY,
+                end_date=ANY,
+                reporting_dimensions=ANY,
+                attribution_window=ANY,
+                include_package_daily_breakdown=ANY,
+                account=expected,
+                context=ANY,
+                identity=ANY,
+            )
+
     def test_get_media_buy_delivery_rejects_malformed_account(self):
         """Malformed account should fail validation and not call the core tool."""
         from src.a2a_server.adcp_a2a_server import AdCPRequestHandler
@@ -263,10 +296,7 @@ class TestA2AParameterMapping:
 
         handler = AdCPRequestHandler()
 
-        with (
-            patch("src.core.resolved_identity.resolve_identity", return_value=_MOCK_IDENTITY),
-            patch("src.a2a_server.adcp_a2a_server.core_get_media_buy_delivery_tool") as mock_delivery,
-        ):
+        with patch("src.a2a_server.adcp_a2a_server.core_get_media_buy_delivery_tool") as mock_delivery:
             parameters = {"account": {}}
 
             import asyncio

--- a/tests/unit/test_a2a_parameter_mapping.py
+++ b/tests/unit/test_a2a_parameter_mapping.py
@@ -11,6 +11,7 @@ before they reach production.
 """
 
 from unittest.mock import ANY, patch
+from adcp.types import AccountReference as LibraryAccountReference
 
 import pytest
 
@@ -240,6 +241,8 @@ class TestA2AParameterMapping:
 
             asyncio.run(handler._handle_get_media_buy_delivery_skill(parameters=parameters, identity=_MOCK_IDENTITY))
 
+            expected = LibraryAccountReference.model_validate({"account_id": "acct-1"})
+
             mock_delivery.assert_called_once_with(
                 media_buy_ids=ANY,
                 status_filter=ANY,
@@ -248,14 +251,10 @@ class TestA2AParameterMapping:
                 reporting_dimensions=ANY,
                 attribution_window=ANY,
                 include_package_daily_breakdown=ANY,
-                account=ANY,
+                account=expected,
                 context=ANY,
                 identity=ANY,
             )
-            account = mock_delivery.call_args.kwargs["account"]
-
-            assert account is not parameters["account"], "Should not forward the raw A2A account dict"
-            assert hasattr(account, "root"), "Should forward a validated AccountReference"
 
     def test_create_media_buy_validates_required_adcp_parameters(self):
         """

--- a/tests/utils/a2a_helpers.py
+++ b/tests/utils/a2a_helpers.py
@@ -8,9 +8,32 @@ Updated for a2a-sdk 1.0 (protobuf API).
 import json
 import uuid
 from typing import Any
+from unittest.mock import ANY
 
 from a2a.types import Artifact, Message, Part, Role
 from google.protobuf import json_format, struct_pb2
+
+
+def assert_delivery_forwarded_account(mock_delivery, expected_account) -> None:
+    """Assert ``core_get_media_buy_delivery_tool`` was called once forwarding ``expected_account``.
+
+    Every other kwarg is ``ANY`` — the contract being pinned is that the *validated*
+    ``AccountReference`` reaches the core tool, not the raw dict that crashed
+    ``resolve_account`` (``account_ref.root`` on a dict). Shared by the handler-level
+    unit tests and the ``on_message_send`` wire test so the 10-kwarg assertion lives once.
+    """
+    mock_delivery.assert_called_once_with(
+        media_buy_ids=ANY,
+        status_filter=ANY,
+        start_date=ANY,
+        end_date=ANY,
+        reporting_dimensions=ANY,
+        attribution_window=ANY,
+        include_package_daily_breakdown=ANY,
+        account=expected_account,
+        context=ANY,
+        identity=ANY,
+    )
 
 
 def extract_data_from_artifact(artifact: Artifact) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Forward the validated account reference from GetMediaBuyDeliveryRequest instead of the raw A2A params dict.

Adds regression coverage for the A2A skill boundary to ensure get_media_buy_delivery passes a typed account reference to the raw delivery tool.

Closes #1434