### PR TITLE
refactor: consolidate account reference coercion

### DIFF
--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -66,6 +66,7 @@ from src.core.exceptions import (
     normalize_to_adcp_error,
 )
 from src.core.resolved_identity import ResolvedIdentity
+from src.core.schema_helpers import to_account_reference
 from src.core.schemas import CreativeStatusEnum
 from src.core.tool_context import ToolContext
 from src.core.tool_error_logging import record_boundary_error
@@ -109,21 +110,6 @@ from src.core.version import get_version
 from src.services.protocol_webhook_service import get_protocol_webhook_service
 
 logger = logging.getLogger(__name__)
-
-
-def _coerce_account_reference(account: Any) -> Any:
-    """Coerce a raw dict account param to AccountReference at the A2A boundary.
-
-    A2A clients may send account as a plain dict. The MCP wrapper's TypeAdapter
-    handles this automatically, but the A2A raw path passes dicts through. This
-    wraps dicts in the SDK AccountReference Pydantic model so downstream code
-    gets a typed object.
-    """
-    if account is None or not isinstance(account, dict):
-        return account
-    from adcp.types import AccountReference as LibraryAccountReference
-
-    return LibraryAccountReference.model_validate(account)
 
 
 def _dict_to_value(d: dict) -> struct_pb2.Value:
@@ -1631,7 +1617,7 @@ class AdCPRequestHandler(RequestHandler):
             validation_mode=parameters.get("validation_mode", "strict"),
             push_notification_config=parameters.get("push_notification_config"),
             context=context,
-            account=_coerce_account_reference(parameters.get("account")),
+            account=to_account_reference(parameters.get("account")),
             identity=identity,
         )
 

--- a/src/core/schema_helpers.py
+++ b/src/core/schema_helpers.py
@@ -95,6 +95,7 @@ def to_account_reference(account: dict[str, Any] | AccountReference | None) -> A
     if isinstance(account, AccountReference):
         return account
     if isinstance(account, dict):
+        # AccountReference is a RootModel, so validate the whole value instead of field-unpacking.
         return AccountReference.model_validate(account)
     return None  # Fallback for unexpected types
 

--- a/src/core/schema_helpers.py
+++ b/src/core/schema_helpers.py
@@ -13,7 +13,14 @@ Philosophy:
 from typing import Any
 
 from adcp import GetProductsResponse, Product
-from adcp.types import BrandReference, ContextObject, ProductFilters, PropertyListReference, ReportingWebhook
+from adcp.types import (
+    AccountReference,
+    BrandReference,
+    ContextObject,
+    ProductFilters,
+    PropertyListReference,
+    ReportingWebhook,
+)
 
 from src.core.schemas.product import GetProductsRequest
 
@@ -71,6 +78,24 @@ def to_brand_reference(brand: dict[str, Any] | BrandReference | str | None) -> B
         return BrandReference(domain=brand)
     if isinstance(brand, dict):
         return BrandReference(**brand)
+    return None  # Fallback for unexpected types
+
+
+def to_account_reference(account: dict[str, Any] | AccountReference | None) -> AccountReference | None:
+    """Convert dict to AccountReference for adcp compatibility.
+
+    Args:
+        account: Account reference as dict, AccountReference, or None
+
+    Returns:
+        AccountReference or None
+    """
+    if account is None:
+        return None
+    if isinstance(account, AccountReference):
+        return account
+    if isinstance(account, dict):
+        return AccountReference.model_validate(account)
     return None  # Fallback for unexpected types
 
 
@@ -139,6 +164,7 @@ def create_get_products_request(
 
 # Re-export commonly used generated types for convenience
 __all__ = [
+    "to_account_reference",
     "to_brand_reference",
     "to_context_object",
     "to_reporting_webhook",

--- a/src/routes/api_v1.py
+++ b/src/routes/api_v1.py
@@ -22,6 +22,7 @@ from fastapi import APIRouter
 from pydantic import BaseModel
 
 from src.core.auth_context import require_auth, resolve_auth
+from src.core.schema_helpers import to_account_reference
 from src.core.tools import accounts as accounts_module
 from src.core.tools import capabilities as capabilities_module
 from src.core.tools import creative_formats as creative_formats_module
@@ -253,11 +254,9 @@ async def update_media_buy(media_buy_id: str, body: UpdateMediaBuyBody, identity
 async def get_media_buy_delivery(body: GetMediaBuyDeliveryBody, identity: ResolvedIdentity = require_auth):
     """Get delivery metrics for media buys (auth required)."""
     if body.account is not None:
-        from adcp.types import AccountReference as LibraryAccountReference
-
         from src.core.transport_helpers import enrich_identity_with_account
 
-        account_ref = LibraryAccountReference(**body.account)
+        account_ref = to_account_reference(body.account)
         enriched = enrich_identity_with_account(identity, account_ref)
         assert enriched is not None  # identity is non-None (from require_auth)
         identity = enriched

--- a/tests/unit/test_rest_api_endpoints.py
+++ b/tests/unit/test_rest_api_endpoints.py
@@ -15,6 +15,7 @@ from starlette.testclient import TestClient
 
 from src.app import app
 from src.core.resolved_identity import ResolvedIdentity
+from tests.helpers import assert_envelope_shape
 
 client = TestClient(app)
 
@@ -161,11 +162,10 @@ class TestGetMediaBuyDeliveryEndpoint:
         )
 
         assert response.status_code == 200
-        mock_enrich.assert_called_once()
-        called_identity, called_account = mock_enrich.call_args.args
-        assert called_identity is _MOCK_IDENTITY
-        assert isinstance(called_account, LibraryAccountReference)
-        assert called_account.root.brand.domain == "example.com"
+        expected_account = LibraryAccountReference.model_validate(
+            {"brand": {"domain": "example.com"}, "operator": "op-1", "sandbox": False}
+        )
+        mock_enrich.assert_called_once_with(_MOCK_IDENTITY, expected_account)
         assert mock_impl.call_args.kwargs["identity"] is enriched_identity
 
     @patch("src.core.resolved_identity.resolve_identity", return_value=_MOCK_IDENTITY)
@@ -179,9 +179,7 @@ class TestGetMediaBuyDeliveryEndpoint:
         )
 
         assert response.status_code == 400
-        body = response.json()
-        assert body["adcp_error"]["code"] == "VALIDATION_ERROR"
-        assert body["errors"][0]["code"] == "VALIDATION_ERROR"
+        assert_envelope_shape(response.json(), "VALIDATION_ERROR", recovery="correctable")
         mock_enrich.assert_not_called()
         mock_impl.assert_not_called()
 

--- a/tests/unit/test_rest_api_endpoints.py
+++ b/tests/unit/test_rest_api_endpoints.py
@@ -10,6 +10,7 @@ beads: salesagent-b61l.15
 
 from unittest.mock import MagicMock, patch
 
+from adcp.types import AccountReference as LibraryAccountReference
 from starlette.testclient import TestClient
 
 from src.app import app
@@ -141,6 +142,48 @@ class TestGetMediaBuyDeliveryEndpoint:
             headers={"Authorization": "Bearer test-token"},
         )
         assert response.status_code == 200
+
+    @patch("src.core.resolved_identity.resolve_identity", return_value=_MOCK_IDENTITY)
+    @patch("src.core.transport_helpers.enrich_identity_with_account")
+    @patch("src.core.tools.media_buy_delivery.get_media_buy_delivery_raw")
+    def test_account_is_coerced_before_enriching_identity(self, mock_impl, mock_enrich, mock_resolve):
+        enriched_identity = _MOCK_IDENTITY.model_copy(update={"account_id": "acct-1"})
+        mock_enrich.return_value = enriched_identity
+        mock_impl.return_value = MagicMock(model_dump=lambda **kw: {"media_buys": []})
+
+        response = client.post(
+            "/api/v1/media-buys/delivery",
+            json={
+                "media_buy_ids": ["mb1"],
+                "account": {"brand": {"domain": "example.com"}, "operator": "op-1", "sandbox": False},
+            },
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        assert response.status_code == 200
+        mock_enrich.assert_called_once()
+        called_identity, called_account = mock_enrich.call_args.args
+        assert called_identity is _MOCK_IDENTITY
+        assert isinstance(called_account, LibraryAccountReference)
+        assert called_account.root.brand.domain == "example.com"
+        assert mock_impl.call_args.kwargs["identity"] is enriched_identity
+
+    @patch("src.core.resolved_identity.resolve_identity", return_value=_MOCK_IDENTITY)
+    @patch("src.core.transport_helpers.enrich_identity_with_account")
+    @patch("src.core.tools.media_buy_delivery.get_media_buy_delivery_raw")
+    def test_malformed_account_returns_validation_error(self, mock_impl, mock_enrich, mock_resolve):
+        response = client.post(
+            "/api/v1/media-buys/delivery",
+            json={"media_buy_ids": ["mb1"], "account": {}},
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        assert response.status_code == 400
+        body = response.json()
+        assert body["adcp_error"]["code"] == "VALIDATION_ERROR"
+        assert body["errors"][0]["code"] == "VALIDATION_ERROR"
+        mock_enrich.assert_not_called()
+        mock_impl.assert_not_called()
 
 
 class TestSyncCreativesEndpoint:

--- a/tests/unit/test_sync_creatives_a2a_account.py
+++ b/tests/unit/test_sync_creatives_a2a_account.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 from adcp.types import AccountReference as LibraryAccountReference
 
 from src.core.resolved_identity import ResolvedIdentity
+from src.core.schema_helpers import to_account_reference
 
 _MOCK_IDENTITY = ResolvedIdentity(
     principal_id="principal_123",
@@ -17,6 +18,18 @@ _MOCK_IDENTITY = ResolvedIdentity(
     tenant={"tenant_id": "tenant_123"},
     protocol="a2a",
 )
+
+
+def test_to_account_reference_handles_supported_inputs():
+    """The shared helper validates dicts and preserves typed/empty values."""
+    account_dict = {"brand": {"domain": "example.com"}, "operator": "op-1", "sandbox": False}
+    result = to_account_reference(account_dict)
+    assert isinstance(result, LibraryAccountReference)
+    assert result.root.brand.domain == "example.com"
+    assert result.root.operator == "op-1"
+    assert result.root.sandbox is False
+    assert to_account_reference(result) is result
+    assert to_account_reference(None) is None
 
 
 class TestSyncCreativesAccountCoercion:

--- a/tests/unit/test_sync_creatives_a2a_account.py
+++ b/tests/unit/test_sync_creatives_a2a_account.py
@@ -7,7 +7,9 @@ Verifies the A2A handler wraps the dict in AccountReference before forwarding.
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from adcp.types import AccountReference as LibraryAccountReference
+from pydantic import ValidationError
 
 from src.core.resolved_identity import ResolvedIdentity
 from src.core.schema_helpers import to_account_reference
@@ -30,6 +32,12 @@ def test_to_account_reference_handles_supported_inputs():
     assert result.root.sandbox is False
     assert to_account_reference(result) is result
     assert to_account_reference(None) is None
+
+
+def test_to_account_reference_rejects_invalid_account_payload():
+    """Malformed oneOf account payloads fail validation at the shared helper."""
+    with pytest.raises(ValidationError):
+        to_account_reference({})
 
 
 class TestSyncCreativesAccountCoercion:


### PR DESCRIPTION
## Summary
- add the missing shared `to_account_reference()` schema helper
- replace the A2A and REST dict-to-`AccountReference` coercion sites
- extend regression coverage for dict, typed, and `None` inputs

## Testing
- `uv run pytest tests/unit/test_sync_creatives_a2a_account.py tests/unit/test_rest_api_endpoints.py -q` (17 passed)
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src/ --config-file=mypy.ini`
- `uv run python .pre-commit-hooks/check_code_duplication.py`

`make quality` is not directly available in this Windows environment because `make` is not installed. Its unit-test step reaches pre-existing Windows-only path/encoding guard failures; CI Linux is the authoritative full run.

Closes #1435