### PR TITLE
docs: add 2.0.0 release notes and establish docs/releases convention

### DIFF
--- a/docs/releases/1.8.0.md
+++ b/docs/releases/1.8.0.md
@@ -235,6 +235,32 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 **🛠 Engineering**
 - `pyproject.toml` exact pin; new `test_adcp_spec_version.py` guard (`EXPECTED_SPEC_VERSION`); `docs/adcp-spec-version.md` plus README/CLAUDE references. No `src/` change.
 
+### Add CPA and time-based pricing models (AdCP 3.1)
+
+[`#1473`](https://github.com/prebid/salesagent/pull/1473) · AdCP protocol & schema · **T2** · `schema`
+
+*Adds AdCP 3.1 CPA and time-based pricing models to product pricing-option serialization. `get_products` now returns `CpaPricingOption` (with a validated `event_type`) and `TimeBasedPricingOption` (with a `time_unit` and optional min/max duration), in both fixed-price and auction variants. This is the product-level serialization only — placing a CPA or time-based buy through an adapter is not yet wired.*
+
+- **New pricing models on get_products** — `convert_pricing_option_to_adcp` maps DB pricing options to `CpaPricingOption` (CPA, with `event_type` plus optional `custom_event_name`/`event_source_id`) and `TimeBasedPricingOption` (hour/day/week/month, optional `min`/`max` duration).
+- **Fail-loud validation** — a missing rate, unknown `event_type`, `custom` without `custom_event_name`, unknown `time_unit`, or `max < min` duration raises rather than silently coercing.
+
+> [!NOTE]
+> **Behavioral change** — buyers now see CPA and time-based pricing options on `get_products`, but adapter execution for those models is not implemented yet, so a buy cannot be placed against them through GAM or mock.
+
+**🛠 Engineering**
+- `convert_pricing_option_to_adcp()` in `src/core/product_conversion.py` gains `cpa`/`time` branches returning `CpaPricingOption`/`TimeBasedPricingOption` (plus `TimeParameters`); reads new `parameters` keys (`event_type`, `custom_event_name`, `event_source_id`, `time_unit`, `min_duration`, `max_duration`) from the existing JSON column. No migration; no `create_media_buy` path touched.
+
+### Serialize push_notification_config as JSON at the MCP/A2A boundary
+
+[`#1464`](https://github.com/prebid/salesagent/pull/1464) · AdCP protocol & schema · **T2** · `wire`
+
+*Fixes a crash when persisting a media buy's push-notification config. The MCP and A2A `create_media_buy` wrappers serialized `push_notification_config` with `model_dump()`, leaving `AnyUrl` and enum fields as Python objects that the database string columns rejected at flush; `model_dump(mode="json")` emits plain strings.*
+
+- **No more flush crash** — `push_notification_config.url` and `authentication.schemes` are now plain strings at the boundary, so persistence no longer raises `StatementError`.
+
+**🛠 Engineering**
+- The MCP `create_media_buy` and A2A `create_media_buy_raw` wrappers (`media_buy_create.py`) use `model_dump(mode="json")` (A2A only re-serializes a `PushNotificationConfig` model; a plain dict passes through). The protobuf A2A path already emitted strings and is untouched. No schema/migration.
+
 ---
 
 ## 📈 Delivery & reporting
@@ -273,6 +299,29 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 
 **🛠 Engineering**
 - `_create_media_buy_impl` (`media_buy_create.py`) calls `ctx_manager.link_workflow_to_object(object_type="media_buy", ...)` before `update_workflow_step(..., status="completed")`, so the `ObjectWorkflowMapping` row exists when `_send_push_notifications` queries it (`context_manager.py` previously hit `if not mappings: return`). The manual path drops its inline `ObjectWorkflowMapping(...)` insert for the same helper. No schema/migration/wire-shape change.
+
+### Add by_device_type delivery breakdown and truncation flags
+
+[`#1475`](https://github.com/prebid/salesagent/pull/1475) · Delivery & reporting · **T2** · `schema` `wire`
+
+*Adds a device-type breakdown to `get_media_buy_delivery` responses, plus truncation flags on the geo, placement, and device-type breakdowns so a buyer can tell when a breakdown was capped. Breakdowns now sort by the requested metric before applying the limit.*
+
+- **Device-type breakdown** — `PackageDelivery` gains `by_device_type` plus `by_device_type_truncated` / `by_geo_truncated` / `by_placement_truncated` flags.
+- **Honest omission** — the device-type dimension is omitted when no adapter supplies data, rather than emitting an empty array that would falsely assert a complete zero-row breakdown.
+
+**🛠 Engineering**
+- `schemas/delivery.py` adds `DeviceTypeBreakdown` plus the four `PackageDelivery` fields; `media_buy_delivery.py` adds `_build_device_type_breakdown()` and a shared `_apply_breakdown_limit()` (sort-by-metric then limit, returning `(entries, truncated)`); the mock adapter simulates a deterministic device/geo split. Only the mock adapter populates real data — other adapters must supply `AdapterPackageDelivery.by_device_type` themselves. No migration.
+
+### Forward the typed account in the A2A get_media_buy_delivery skill
+
+[`#1438`](https://github.com/prebid/salesagent/pull/1438) · Delivery & reporting · **T2**
+
+*Fixes A2A `get_media_buy_delivery`, which forwarded the raw `account` dict and crashed downstream in `resolve_account` (which expects a typed `AccountReference`). It now forwards the validated `req.account`, so account scoping works over A2A for both the `account_id` and natural-key forms. A shared validation boundary replaces four hand-copied try/except blocks.*
+
+- **A2A delivery account scoping** — the skill forwards the validated `AccountReference` instead of the raw dict; a malformed `account` now returns a typed `VALIDATION_ERROR` envelope instead of leaking a raw `ValidationError`.
+
+**🛠 Engineering**
+- `_handle_get_media_buy_delivery_skill` (`adcp_a2a_server.py`) passes `account=req.account`; a new `adcp_validation_boundary()` in `validation_helpers.py` wraps `model_validate` across the create / update / delivery / update-performance-index skill handlers. No schema/migration.
 
 ---
 
@@ -339,6 +388,17 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 
 **🛠 Engineering**
 - `to_account_reference()` added to `src/core/schema_helpers.py`; removes the local `_coerce_account_reference` in `adcp_a2a_server.py` and the `LibraryAccountReference(**body.account)` field-unpack in `api_v1.py`. Regression tests added for both paths.
+
+### Match creative format IDs on the (agent_url, id) federation pair
+
+[`#1479`](https://github.com/prebid/salesagent/pull/1479) · Creatives · **T2** · `wire`
+
+*Makes `list_creative_formats` filtering match a `format_id` on the full `(agent_url, id)` pair rather than the bare `id`. A reference to a format hosted by a foreign agent no longer mis-resolves to a local format that happens to share the same id.*
+
+- **Federation-correct matching** — `format_ids` / `output_format_ids` / `input_format_ids` filters compare the canonicalized `(agent_url, id)` identity; a same-id / different-agent reference now matches nothing rather than the wrong local format.
+
+**🛠 Engineering**
+- `canonical_agent_url()` / `format_id_identity()` in `schemas/_base.py` (canonicalization via the SDK's `canonicalize_target_uri`); `_list_creative_formats_impl` filters by the identity pair; the creative-agent registry cache key shares the same canonical form. Also deletes a test-harness REST-body override that had been silently dropping all REST filter params. No schema/migration.
 
 ---
 
@@ -668,6 +728,20 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 **🛠 Engineering**
 - Adds `ci.yml` + composite `.github/actions/*`; `make quality-ci`; a coverage hard-gate via `.coverage-baseline`; merge-head-aware `migration_roundtrip.py`. Removes dead `[tool.black]`. The `src/core/tools/capabilities.py` change is comment-only.
 
+### Move the app virtualenv to /opt/venv
+
+[`#1488`](https://github.com/prebid/salesagent/pull/1488) · CI & build · **T2**
+
+*Moves the application virtualenv from `/app/.venv` to `/opt/venv` so a source bind-mount in docker-compose can't shadow it with stale dependencies. Infrastructure only — no application code changed.*
+
+- **No more stale-overlay venv** — the venv lives at `/opt/venv` and the anonymous `/app/.venv` compose volumes are dropped, so a compose source mount can't hide the installed dependencies.
+
+> [!IMPORTANT]
+> **Operational** — anyone with a custom `docker-compose.override.yml` must stop mounting a `/app/.venv` volume, and may need a `--no-cache` rebuild to clear a stale anonymous volume (documented in the troubleshooting guide).
+
+**🛠 Engineering**
+- `Dockerfile` / `docker-compose*.yml` set `UV_PROJECT_ENVIRONMENT=/opt/venv`, move the venv copy / PATH / chown / ENTRYPOINT, drop the `/app/.venv` volumes, and point dev `PYTHONPATH` at `/app`. A `python-socketio>=5.16.2` CVE bump rides along.
+
 ---
 
 ## 🧹 Admin UI & maintenance
@@ -711,5 +785,12 @@ Single-commit changes whose titles already match their diffs; listed for complet
 - [`#1463`](https://github.com/prebid/salesagent/pull/1463) — Wire the UC-005 `list_creative_formats` `format_id` object-shape BDD scenario across all four transports (xfail -> passing).
 - [`#1222`](https://github.com/prebid/salesagent/pull/1222) — Add BDD and admin-HTTP test coverage, four BDD structural guards, and architecture docs (test/docs only; no production change).
 - [`#1395`](https://github.com/prebid/salesagent/pull/1395) — Retarget the retroactive-creative-push mock to the use site so it actually intercepts (test-only; the handler was already correct).
+- **#1234 CI epic (remaining infrastructure PRs, no production change):** version anchors + Dockerfile hardening ([#1400](https://github.com/prebid/salesagent/pull/1400)), image supply-chain hardening ([#1401](https://github.com/prebid/salesagent/pull/1401)), guard-helper patterns ([#1457](https://github.com/prebid/salesagent/pull/1457), [#1458](https://github.com/prebid/salesagent/pull/1458), [#1459](https://github.com/prebid/salesagent/pull/1459), [#1460](https://github.com/prebid/salesagent/pull/1460)), and closure tails ([#1476](https://github.com/prebid/salesagent/pull/1476)).
+- [`#1478`](https://github.com/prebid/salesagent/pull/1478) — CI: #1233 prep (D9/D11 docs, remove requires_server tests, scorecard harden-runner).
+- [`#1485`](https://github.com/prebid/salesagent/pull/1485) — CI: nightly GAM regression workflow for requires_gam tests.
+- [`#1486`](https://github.com/prebid/salesagent/pull/1486) — Chore: #1400 review follow-ups (digest-guard honesty, docs).
+- [`#1491`](https://github.com/prebid/salesagent/pull/1491) — Docs: document the Code Quality path scope mirroring CodeQL.
+- [`#1465`](https://github.com/prebid/salesagent/pull/1465) — Repair the reference E2E lifecycle test (un-xfail, removes silent-pass hatches); test-only.
+- [`#1490`](https://github.com/prebid/salesagent/pull/1490) — Privatize four internal-only architecture test-helper exports (underscore renames); test-only.
 
-**Out of scope (not recorded):** dependency and security version bumps — authlib, aiohttp, lxml, python-dotenv, fastapi/starlette, uv, mako, python-multipart, urllib3 ([#1385](https://github.com/prebid/salesagent/pull/1385), [#1375](https://github.com/prebid/salesagent/pull/1375), [#1298](https://github.com/prebid/salesagent/pull/1298), [#1343](https://github.com/prebid/salesagent/pull/1343), [#1226](https://github.com/prebid/salesagent/pull/1226), [#1159](https://github.com/prebid/salesagent/pull/1159) and folded-in bumps). A PR whose only in-scope content is a dependency bump is listed here rather than as a record.
+**Out of scope (not recorded):** dependency and security version bumps — authlib, aiohttp, lxml, python-dotenv, fastapi/starlette, uv, mako, python-multipart, urllib3 ([#1385](https://github.com/prebid/salesagent/pull/1385), [#1375](https://github.com/prebid/salesagent/pull/1375), [#1298](https://github.com/prebid/salesagent/pull/1298), [#1343](https://github.com/prebid/salesagent/pull/1343), [#1226](https://github.com/prebid/salesagent/pull/1226), [#1159](https://github.com/prebid/salesagent/pull/1159), [#1412](https://github.com/prebid/salesagent/pull/1412) and folded-in bumps). A PR whose only in-scope content is a dependency bump is listed here rather than as a record.

--- a/docs/releases/1.8.0.md
+++ b/docs/releases/1.8.0.md
@@ -62,6 +62,28 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 - Format filtering/sorting is now structural via `asset_types`; `BrandManifest`→`Brand` extracts localized names; `DeliverTo` is flattened into `GetSignalsRequest`.
 - Migrations: `d40df2c92316` (add idempotency_key), `cf421634d3c8` (drop buyer_ref), `b4e2bffdd4f8` (data migration + `server_default` change; two-parent down_revision merges divergent alembic heads).
 
+### Idempotency success-cache replay for create_media_buy
+
+[`#1312`](https://github.com/prebid/salesagent/pull/1312) · AdCP protocol & schema · **T1** · `breaking` `schema` `migration` `wire`
+
+*Adds a success cache for `create_media_buy`: a keyed request stores its response envelope and a canonical hash of the payload, so a retry with the same key replays the stored response verbatim instead of booking again, while a same-key request with a different payload is rejected as a conflict. As part of this, `idempotency_key` becomes a required field on `CreateMediaBuyRequest`. Errors are never cached — only successful creates replay.*
+
+- **Verbatim replay** — a repeated `create_media_buy` with the same `idempotency_key` within 24h returns the original response envelope with `replayed: true`, instead of creating a duplicate.
+- **Conflict and expiry** — the same key with a different canonical payload is rejected with `IDEMPOTENCY_CONFLICT`; an expired key returns `IDEMPOTENCY_EXPIRED`. Both are correctable and carry `retry_after`.
+- **Required key** — `idempotency_key` is now required on `CreateMediaBuyRequest`; `update_media_buy` and `sync_*` keys stay optional (a deliberate create-first rollout).
+- **Captured as sent** — the payload hash is taken before normalization on MCP, REST, and A2A, so the conflict check reflects the client's actual request.
+
+> [!WARNING]
+> **Breaking change** — `CreateMediaBuyRequest.idempotency_key` is now required (string, 16–255 chars, pattern `[A-Za-z0-9_.:-]`). A `create_media_buy` without it is rejected as `VALIDATION_ERROR`.
+
+> [!IMPORTANT]
+> **Migration** — five Alembic migrations: a new `idempotency_attempts` table, a `media_buys.payload_hash` column, and a `CONCURRENTLY`-rebuilt backstop index (widened to include `account_id`). Existing media-buy rows have a null `payload_hash` (no backfill).
+
+**🛠 Engineering**
+- The cache lives in `idempotency_attempts` (`repositories/idempotency_attempt.py`), scoped `(tenant, principal, account, key)` with `NULLS NOT DISTINCT` and a 24h `DEFAULT_REPLAY_TTL` (now the source for the advertised `replay_ttl_seconds` capability); `_lookup_cached_replay` / `_replay_cached_success` in `media_buy_create.py`.
+- The payload hash is RFC 8785 JCS + SHA-256, captured pre-normalization (`mcp_auth_middleware` / `rest_compat_middleware` stash `raw_wire_payload`; A2A threads DataPart params), with a fail-closed `media_buys.payload_hash` backstop.
+- New `IDEMPOTENCY_CONFLICT` / `IDEMPOTENCY_EXPIRED` codes (forced `correctable`) and a `retry_after` field on `AdCPError`; `CreateMediaBuyResult.replayed` serializes to a top-level `replayed` only when true. Insert-rate and active-row ceilings live in `services/idempotency_policy.py`.
+
 ### Round-trip property_list and collection_list on media buys
 
 [`#1276`](https://github.com/prebid/salesagent/pull/1276) · AdCP protocol & schema · **T2** · `schema` `wire`
@@ -193,6 +215,21 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 
 **🛠 Engineering**
 - New `build_list_creative_formats_request()` in `creative_formats.py`; the MCP `list_creative_formats` wrapper and A2A `_handle_list_creative_formats_skill` both call it, reaching the shared `_list_creative_formats_impl`. Removes the now-passing MCP xfails for these filters (only `disclosure_positions` remains).
+
+### Consolidate account-reference coercion across A2A and REST
+
+[`#1439`](https://github.com/prebid/salesagent/pull/1439) · Creatives · **T2**
+
+*Replaces two duplicated dict-to-`AccountReference` coercion sites — the A2A `sync_creatives` path and the REST `get_media_buy_delivery` path — with one shared `to_account_reference()` helper. A side effect: a malformed `account` on the REST delivery endpoint now fails validation with a 400 instead of being mishandled downstream.*
+
+- **One coercion helper** — `to_account_reference()` validates a dict as an `AccountReference`, passing typed values and `None` through unchanged; both transports use it.
+- **Stricter REST validation** — a malformed `account` on `get_media_buy_delivery` now returns a 400 `VALIDATION_ERROR`.
+
+> [!NOTE]
+> **Behavioral change** — a malformed `account` object on the REST `get_media_buy_delivery` path now returns a 400 validation error rather than failing further downstream.
+
+**🛠 Engineering**
+- `to_account_reference()` added to `src/core/schema_helpers.py`; removes the local `_coerce_account_reference` in `adcp_a2a_server.py` and the `LibraryAccountReference(**body.account)` field-unpack in `api_v1.py`. Regression tests added for both paths.
 
 ---
 
@@ -442,6 +479,18 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 **🛠 Engineering**
 - Adds `env: GITHUB_TOKEN` to the pinact step in `.github/workflows/security.yml` (+2/-0).
 
+### Layer pre-commit hooks and replace grep hooks with AST guards
+
+[`#1390`](https://github.com/prebid/salesagent/pull/1390) · CI & build · **T3**
+
+*Reorganizes pre-commit into a commit-stage / pre-push / CI model and replaces five grep-based hooks with AST structural guards. Contributor-facing only — no production code changed.*
+
+- **Layered hooks** — ~12 commit-stage plus 11 pre-push hooks; `pre-commit install` now also installs a pre-push stage and requires pre-commit ≥ 3.2.0.
+- **AST guards over grep** — five grep hooks become AST guards (tenant-config, JSONType columns, defensive RootModel, import usage, hook count).
+
+**🛠 Engineering**
+- Rewrites `.pre-commit-config.yaml` (`default_install_hook_types: [pre-commit, pre-push]`); extends `make quality-ci`; adds an MCP-contract-validation CI step. New guards plus a shared `tests/unit/_architecture_helpers.py`; zero `src/` changes. (PR 4 of the #1234 CI refactor.)
+
 ---
 
 ## 🧹 Admin UI & maintenance
@@ -480,5 +529,7 @@ Single-commit changes whose titles already match their diffs; listed for complet
 - BDD parser/branch fixes — `67681ed`, `26540ea`, `9249071`, `0a9612c`, `ed9633f`, `2073994` (account-resolution branches, `reach_unit`, `status_filter`, `media_buy_ids`, `request_params`).
 - BDD step refactors — `bbbcda5`, `d2f1474`, `c5ef5c1`, `9c2fc60`, `c7a1527`, `1629369`, `f89201c` (helper extractions, webhook step move, shared error message, B905 zip fix).
 - `c05aa70`, `f4aa3ad` — Replace SUSPECT `auth_setup_mode` tests with endpoint-level coverage.
+- [`#1431`](https://github.com/prebid/salesagent/pull/1431) — Read BDD step files as UTF-8 in the `bdd-no-direct-call-impl` guard (fixes a Windows cp1252 decode crash).
+- [`#1443`](https://github.com/prebid/salesagent/pull/1443) — Resolve agent-db `PROJECT_DIR` to the worktree root so each worktree gets its own test Postgres; drops an accidentally-committed test env file.
 
 **Out of scope (not recorded):** dependency and security version bumps — authlib, aiohttp, uv, mako, python-multipart, urllib3 ([#1385](https://github.com/prebid/salesagent/pull/1385), [#1375](https://github.com/prebid/salesagent/pull/1375), [#1298](https://github.com/prebid/salesagent/pull/1298) and folded-in bumps).

--- a/docs/releases/1.8.0.md
+++ b/docs/releases/1.8.0.md
@@ -160,6 +160,23 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 **🛠 Engineering**
 - 16 citation edits across `docs/`, `media_buy_update.py`, `targeting_capabilities.py`, `schemas/_base.py`, `adapters/gam/managers/targeting.py`, and tests; the three enums switch to `StrEnum` in `schemas/_base.py`. A follow-up commit re-wraps a comment to keep a line-keyed guard allowlist stable.
 
+### REST returns AdCP error envelopes for invalid requests; enforce campaign attribution-window rule
+
+[`#1420`](https://github.com/prebid/salesagent/pull/1420) · AdCP protocol & schema · **T2** · `wire`
+
+*Ships two buyer-facing behavior changes behind a CI-infrastructure PR. The REST boundary now converts FastAPI's raw 422 into the AdCP two-layer error envelope, and `get_media_buy_delivery` now rejects a campaign-unit attribution window whose interval is not 1. The rest of the PR is test/CI infrastructure — an in-network Docker test runner and recovery of the opt-in e2e_rest BDD transport.*
+
+- **REST error envelopes** — malformed or invalid REST request bodies now return an AdCP envelope (`INVALID_REQUEST`, or `VALIDATION_ERROR` for `attribution_window.*`) instead of FastAPI's raw `422 {"detail": ...}`.
+- **Attribution-window rule** — `get_media_buy_delivery` rejects a campaign-unit `Duration` whose `interval` is not 1 (BR-RULE-092) with `VALIDATION_ERROR`.
+- **Agent-card scheme** — `X-Forwarded-Proto` now drives the advertised agent-card URL scheme, fixing an https card served behind an http reverse proxy.
+
+> [!NOTE]
+> **Behavioral change** — REST clients that parsed the old raw FastAPI `422 {"detail": ...}` now receive an AdCP error envelope; and a campaign attribution window with an interval other than 1 is now rejected where it was previously accepted.
+
+**🛠 Engineering**
+- `src/app.py` adds a `RequestValidationError` handler emitting the AdCP envelope (`INVALID_REQUEST` / `VALIDATION_ERROR`) plus the `X-Forwarded-Proto` scheme fix in `_create_dynamic_agent_card`.
+- `src/core/tools/media_buy_delivery.py` adds `_validate_attribution_window` (BR-RULE-092 INV-5). The bulk of the PR is CI/test infra: an in-network `run_all_tests.sh` (host runner kept as `run_all_tests_host.sh`), `Dockerfile.test`, e2e compose files, and the `RestE2EDispatcher` wiring the opt-in e2e_rest 5th BDD transport. No DB migration.
+
 ---
 
 ## 📈 Delivery & reporting
@@ -183,6 +200,21 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 - `media_buy_delivery.py`: `_internal_status_for_buy` / `_PERSISTED_STATUS_TO_INTERNAL`, `_resolve_attribution_window` (`PLATFORM_DEFAULT_ATTRIBUTION_MODEL = last_touch`), `_build_geo_breakdown`, reworked `_build_placement_breakdown`; `media_buy_list.py` mirrors with `_PERSISTED_STATUS_TO_ADCP` / `_compute_status`.
 - New core primitives — `async_utils.pin_task`, `thread_registry.ThreadRegistry`, `lifecycle.register_shutdown` / `run_all_shutdown_callbacks` — adopted across background services, the delivery simulator, and the GAM reporting manager.
 - `schemas/delivery.py` adds `GeoBreakdown` and the new request fields; `Account.model_dump` always includes `advertiser`/`rate_card`/`payment_terms`. No migration.
+
+### Fire the push-notification webhook on auto-approved media buys
+
+[`#1461`](https://github.com/prebid/salesagent/pull/1461) · Delivery & reporting · **T2**
+
+*Fixes a silent gap where auto-approved media buys never delivered the buyer's push-notification webhook. On the auto-approve path the workflow step was completed without an `ObjectWorkflowMapping` in place, so the notifier looked up the mapping, found none, and returned without sending. The fix links the workflow to the media buy before completing the step, so the webhook fires.*
+
+- **Webhook now delivered** — an auto-approved (`active`) media buy now sends the principal's registered push-notification webhook, which it previously never received. No payload-shape change — the delivery itself was missing.
+- **One mapping path** — the manual-approval path is consolidated onto the same `link_workflow_to_object` call, with consistent rollback handling.
+
+> [!NOTE]
+> **Behavioral change** — auto-approved media buys now fire the push-notification webhook on completion; integrations relying on that notification will start receiving it.
+
+**🛠 Engineering**
+- `_create_media_buy_impl` (`media_buy_create.py`) calls `ctx_manager.link_workflow_to_object(object_type="media_buy", ...)` before `update_workflow_step(..., status="completed")`, so the `ObjectWorkflowMapping` row exists when `_send_push_notifications` queries it (`context_manager.py` previously hit `if not mappings: return`). The manual path drops its inline `ObjectWorkflowMapping(...)` insert for the same helper. No schema/migration/wire-shape change.
 
 ---
 
@@ -498,6 +530,20 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 **🛠 Engineering**
 - Adds `env: GITHUB_TOKEN` to the pinact step in `.github/workflows/security.yml` (+2/-0).
 
+### Pre-build the pinned creative-agent image in GHCR for CI
+
+[`#1437`](https://github.com/prebid/salesagent/pull/1437) · CI & build · **T3**
+
+*Publishes the pinned creative-agent Docker image to GHCR on pushes to main, so CI pulls a prebuilt image keyed to the adcp pin instead of rebuilding it each run. (The title's "buildx GHA cache" describes an earlier approach; the final one is GHCR pin-keyed images.)*
+
+- **Prebuilt image** — a new workflow builds and pushes `adcp-creative-agent:<adcp-pin>` to GHCR on main; CI's creative integration leg pulls it (pull-only), with build/pull/push retries.
+
+> [!IMPORTANT]
+> **Operational** — a maintainer must run the publish workflow once and mark the GHCR package public; otherwise CI falls back to building the image locally everywhere (still green, just no speed-up).
+
+**🛠 Engineering**
+- Adds `.github/workflows/publish-creative-agent.yml`; grants the CI creative leg `packages: read` plus a `ghcr.io` login and `CREATIVE_AGENT_GHCR_IMAGE`; rewrites `scripts/creative-agent-stack.sh` with a `publish` subcommand and `_retry`/`_ensure_image` helpers. Zero `src/` changes.
+
 ### Layer pre-commit hooks and replace grep hooks with AST guards
 
 [`#1390`](https://github.com/prebid/salesagent/pull/1390) · CI & build · **T3**
@@ -550,5 +596,6 @@ Single-commit changes whose titles already match their diffs; listed for complet
 - `c05aa70`, `f4aa3ad` — Replace SUSPECT `auth_setup_mode` tests with endpoint-level coverage.
 - [`#1431`](https://github.com/prebid/salesagent/pull/1431) — Read BDD step files as UTF-8 in the `bdd-no-direct-call-impl` guard (fixes a Windows cp1252 decode crash).
 - [`#1443`](https://github.com/prebid/salesagent/pull/1443) — Resolve agent-db `PROJECT_DIR` to the worktree root so each worktree gets its own test Postgres; drops an accidentally-committed test env file.
+- [`#1463`](https://github.com/prebid/salesagent/pull/1463) — Wire the UC-005 `list_creative_formats` `format_id` object-shape BDD scenario across all four transports (xfail -> passing).
 
 **Out of scope (not recorded):** dependency and security version bumps — authlib, aiohttp, uv, mako, python-multipart, urllib3 ([#1385](https://github.com/prebid/salesagent/pull/1385), [#1375](https://github.com/prebid/salesagent/pull/1375), [#1298](https://github.com/prebid/salesagent/pull/1298) and folded-in bumps).

--- a/docs/releases/1.8.0.md
+++ b/docs/releases/1.8.0.md
@@ -25,7 +25,7 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 
 *Upgrades the two core protocol dependencies — adcp 3.12→4.3 and a2a-sdk 0.3.19→1.0 — and rewrites the A2A server onto the new protobuf API. The same release standardizes error codes across REST, MCP, and A2A, adds media-buy state-machine enforcement, and advertises idempotency support in capabilities. Several of these changes are breaking for existing clients.*
 
-- **Protocol versions** — adcp 4.3 (AdCP spec 3.0.1) and a2a-sdk 1.0; the A2A server is rewritten onto the protobuf API.
+- **Protocol versions** — adcp 4.3 (AdCP spec 3.0.1) and a2a-sdk 1.0; the A2A server is rewritten onto the protobuf API. (#1399 below advances the SDK further to 5.7.0 / spec 3.1.0-beta.3 — the release's final SDK state.)
 - **Standardized error codes** — REST, MCP, and A2A return the same UPPER_SNAKE_CASE codes from a single mapping layer.
 - **Media-buy lifecycle enforcement** — finished or canceled buys can no longer be modified, and illegal state transitions are rejected.
 - **Idempotency advertised** — capabilities now reports idempotency support with a 24-hour replay window.
@@ -38,6 +38,25 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 - Error emission is centralized in `exceptions.py` via `ERROR_CODE_MAPPING` / `translate_error_code()` / `to_adcp_error()`; `INTERNAL_CODES` stay server-side and map to spec codes on the wire.
 - MCP/A2A wrappers move from `Any`/`dict` to SDK Pydantic types with `Field(description=...)`, enforced by three new structural guards.
 - `_update_media_buy_impl` gains state-machine enforcement via `valid_actions_for_status`; status splits into `pending_start` vs `pending_creatives`. No Alembic migration in this PR.
+
+### Upgrade adcp SDK to 5.7.0 (AdCP spec 3.1.0-beta.3)
+
+[`#1399`](https://github.com/prebid/salesagent/pull/1399) · AdCP protocol & schema · **T1** · `breaking` `schema` `wire`
+
+*Advances the SDK to its final state for this release — `adcp` 5.7.0, targeting AdCP spec 3.1.0-beta.3 — superseding the intermediate 4.3.0 / spec 3.0.1 step from #1266. It is a dependency-and-types upgrade with response-contract reconciliation, not a 3.1 feature implementation: SDK 5.7 collapsed several success-response envelopes, so the dropped fields are re-declared locally, and creative assets move to the spec's discriminated-union shape. The new 3.1 features themselves remain stubbed.*
+
+- **Spec target** — `adcp==5.7.0`, AdCP spec `3.1.0-beta.3`, pinned in `pyproject.toml` and `docs/adcp-spec-version.md`.
+- **Discriminated-union assets** — creative asset slots are now `list[AssetVariant]` tagged by `asset_type` (a RootModel union), replacing the old flat single-asset shape.
+- **Tightened responses** — `accounts`, `creatives`, and `products` are now required on their success responses; fields the SDK dropped (`account`, `sandbox`, `valid_actions`, ...) are re-declared locally so behavior is preserved.
+- **Cleaner brandless handling** — a `sync_accounts` entry with no brand now returns a 400 `AdCPValidationError` instead of a 500.
+
+> [!WARNING]
+> **Breaking changes** — creatives must be built in the 3.1 discriminated-union asset shape (slot value = `list[AssetVariant]`), not the old flat dict; the webhook payload builder `create_mcp_webhook_payload` changed signature and return type; `sync_creatives`/`sync_accounts`/`get_products` success responses now strictly require their list fields.
+
+**🛠 Engineering**
+- Pins `adcp==5.7.0` (was 4.3.0); `EXPECTED_SPEC_VERSION` -> `3.1.0-beta.3`; bumps `mcp` 1.25->1.27, adds `tldextract`. Keeps the `generated_poc` import paths — the adcp server framework is not adopted.
+- Re-declares SDK-collapsed fields in `schemas/{account,creative,delivery,product,_base}.py`; `SyncCreativeResult.action` retyped enum->`str` with a normalizing validator; adds `enum_helpers.enum_value()` to stringify the SDK's plain-`Enum` values across schemas and tools.
+- `CreativeAsset` becomes a RootModel discriminated union, with shared `_extract_*_from_asset(s)` in `tools/creatives/_assets.py` unwrapping `.root`; `create_mcp_webhook_payload(task_type=...)` now returns `McpWebhookPayload`, and `validate_webhook_task_type()` coerces unknown task labels. No DB migration.
 
 ### Replace buyer_ref with media_buy_id and idempotency-keyed dedup (adcp 3.12)
 

--- a/docs/releases/1.8.0.md
+++ b/docs/releases/1.8.0.md
@@ -177,6 +177,64 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 - `src/app.py` adds a `RequestValidationError` handler emitting the AdCP envelope (`INVALID_REQUEST` / `VALIDATION_ERROR`) plus the `X-Forwarded-Proto` scheme fix in `_create_dynamic_agent_card`.
 - `src/core/tools/media_buy_delivery.py` adds `_validate_attribution_window` (BR-RULE-092 INV-5). The bulk of the PR is CI/test infra: an in-network `run_all_tests.sh` (host runner kept as `run_all_tests_host.sh`), `Dockerfile.test`, e2e compose files, and the `RestE2EDispatcher` wiring the opt-in e2e_rest 5th BDD transport. No DB migration.
 
+### Two-layer error envelope across all transports (error-emission architecture, PR 1 of 3)
+
+[`#1306`](https://github.com/prebid/salesagent/pull/1306) · AdCP protocol & schema · **T1** · `wire`
+
+*Establishes the AdCP two-layer error envelope as the single error substrate across REST, MCP, and A2A. Typed `AdCPError` subclasses now carry their wire identity (code, status, recovery) as class data, and one serializer emits both the `adcp_error` object and the `errors[]` array. This is the foundation the error-code drain (#1307) builds on — it adds the substrate and freezes the legacy sites with guards rather than draining them.*
+
+- **One envelope everywhere** — REST handlers, the A2A failure path, and the MCP error wrapper all run `build_two_layer_error_envelope()`; raw `ValueError`/`PermissionError` on REST now return 400/403 envelopes instead of 500s.
+- **A2A audit gap closed** — previously-silent A2A failures now hit the audit log and return a failed Task carrying the envelope; async push-notification subscribers receive the full envelope body.
+- **Typed error identity** — `AdCPError` subclasses pin code/status/recovery as class data, with a sanctioned `synthesize()` for overrides and seven new typed subclasses.
+
+> [!NOTE]
+> **Behavioral change** — REST error bodies move from a flat shape to the nested `{adcp_error, errors[], context?}` envelope; some codes are translated at the boundary (`NOT_FOUND` to `INVALID_REQUEST`, `INTERNAL_ERROR`/`CONFIGURATION_ERROR` to `SERVICE_UNAVAILABLE`). Clients parsing the old flat error shape must update.
+
+**🛠 Engineering**
+- `exceptions.py` gains `ClassVar` wire identity, `build_two_layer_error_envelope()`, `normalize_to_adcp_error()`, `synthesize()`; `app.py` adds REST handlers for `AdCPError`/`ValueError`/`PermissionError`/`ToolError`; `adcp_a2a_server.py` routes failures through `_build_error_envelope`; `context_manager.py` persists the same envelope to `workflow_step.response_data`. Adds 4 shrink-only guards (Pattern A `Error(code=)` capped at 82, `raise ValueError` at 126). No DB migration.
+
+### Drain error sites to typed errors and expand the taxonomy (error-emission, PR 2 of 3)
+
+[`#1307`](https://github.com/prebid/salesagent/pull/1307) · AdCP protocol & schema · **T1** · `wire`
+
+*The cleanup sweep on #1306's substrate: every `_impl` and adapter site that returned an inline `Error(code=...)` now raises a typed `AdCPError`, ~38 boundary `ValueError`s become typed raises, and the taxonomy expands to cover them. It also consolidates the repeated lookup-or-raise and require-principal/tenant guards into shared helpers.*
+
+- **Typed raises everywhere** — `_impl` functions and all adapters raise typed `AdCPError`s instead of returning error result objects; the Pattern A and boundary-`ValueError` guard caps drain to zero/internal-only.
+- **Expanded taxonomy** — adds entity not-found types (product/context/creative/format/task) and an adapter-error family (line-item, bulk-update, activation, GAM-update, inventory-unavailable), each pinning an internal code that maps to a standard wire code.
+- **DRY consolidation** — shared `resolve_principal_or_raise`/`require_*` (auth), `get_*_or_raise` (repositories), `_require_config` (adapters).
+
+> [!NOTE]
+> **Behavioral change** — buyer-visible error codes change at many sites: budget failures split into `BUDGET_TOO_LOW`/`BUDGET_EXCEEDED`; adapter config errors move from `VALIDATION_ERROR` to `SERVICE_UNAVAILABLE`; `AdCPConfigurationError` recovery flips correctable to terminal; GAM bulk partial-failure unifies on 502.
+
+**🛠 Engineering**
+- Drains `PATTERN_A_PER_FILE_CAP` to empty across `core/tools/*` and `adapters/*`; expands the `exceptions.py` taxonomy with `iter_concrete_subclasses()` sourcing the wire-code-to-HTTP-status table; renames `fail_workflow_step_for_exception` to `audit_workflow_step_failure`. No DB migration.
+
+### Echo account_id on sync_accounts responses
+
+[`#1299`](https://github.com/prebid/salesagent/pull/1299) · AdCP protocol & schema · **T2** · `wire`
+
+*Fixes a buyer-facing gap where `sync_accounts` responses always returned `account_id: null`, so buyers couldn't reference the seller-assigned account in follow-up calls. The bulk of the PR is test and infra stabilization (BDD strict-marker cleanup, ~16 test fixes, longer cold-start timeouts), but it threads `account_id` into every non-failure sync path.*
+
+- **account_id now returned** — created / updated / unchanged / closed (and dry-run) `sync_accounts` results echo the seller-assigned `account_id` (BR-UC-011 POST-S5).
+
+> [!NOTE]
+> **Behavioral change** — `sync_accounts` responses now carry `account_id`; integrations can reference the account in later calls instead of getting `null`.
+
+**🛠 Engineering**
+- `_build_sync_result` / `_sync_accounts_impl` (`tools/accounts.py`) thread `account_id` into all non-failure paths (the field already existed on `SyncResponseAccount`). Test/infra: BDD strict-marker cleanup, `test-stack.sh` readiness 120s to 360s, migration timeout to 300s. No schema/migration.
+
+### Pin the adcp SDK exactly and document the spec version
+
+[`#1355`](https://github.com/prebid/salesagent/pull/1355) · AdCP protocol & schema · **T3**
+
+*Establishes the SDK-version governance: an exact `adcp` pin (closing the open upper bound that allowed silent spec drift), a CI guard that fails on spec-version drift, and a docs page mapping SDK releases to AdCP spec versions. The values it set (4.3.0 / spec 3.0.1) have since been advanced by #1399 (5.7.0 / 3.1.0-beta.3), but the governance machinery persists.*
+
+- **Exact pin + drift guard** — `adcp` is pinned exactly, with `tests/unit/test_adcp_spec_version.py` asserting the targeted spec version so an unintended bump fails CI.
+- **Spec-version doc** — `docs/adcp-spec-version.md` maps SDK releases to AdCP spec versions and documents the bump procedure.
+
+**🛠 Engineering**
+- `pyproject.toml` exact pin; new `test_adcp_spec_version.py` guard (`EXPECTED_SPEC_VERSION`); `docs/adcp-spec-version.md` plus README/CLAUDE references. No `src/` change.
+
 ---
 
 ## 📈 Delivery & reporting
@@ -488,6 +546,17 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 **🛠 Engineering**
 - Drops the conditional strict-xfail in `test_pydantic_schema_alignment.py` and the `test_offline_mode` xfail in `test_schema_validation_standalone.py`; the underlying library-modeling gap (#1308) stays open and allowlisted.
 
+### Migrate BDD feature files to AdCP 3.1
+
+[`#1384`](https://github.com/prebid/salesagent/pull/1384) · Test suite (BDD & harness) · **T3**
+
+*Re-renders all 31 BDD feature files to the AdCP 3.1 storyboard contract — the test-layer counterpart to the SDK-5.7/spec-3.1 upgrade in #1399 — with wired use cases staying green and unwired scenarios auto-xfailing. Production code changes are mechanical only (import sorting, `StrEnum`); no behavior change.*
+
+- **3.1 feature files** — all feature files re-rendered from the 3.1 lockfile (3 net-new use cases); wired UCs are LLM-merged to preserve step wording, unwired UCs auto-xfail. Adds 6 BDD structural guards and a regression-diff tool.
+
+**🛠 Engineering**
+- `tests/bdd/features/**` (+11.6k lines) re-rendered; step/harness/guard additions; the ~24 `src/` edits are import-sorting and `class X(StrEnum)` rewrites only. CI now hard-gates ruff (drops `|| true`). Does not bump the `adcp` SDK pin (that is #1399).
+
 ---
 
 ## ⚙️ CI & build
@@ -556,6 +625,49 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 **🛠 Engineering**
 - Rewrites `.pre-commit-config.yaml` (`default_install_hook_types: [pre-commit, pre-push]`); extends `make quality-ci`; adds an MCP-contract-validation CI step. New guards plus a shared `tests/unit/_architecture_helpers.py`; zero `src/` changes. (PR 4 of the #1234 CI refactor.)
 
+### Supply-chain hardening — CI security baseline (PR 1 of #1234)
+
+[`#1338`](https://github.com/prebid/salesagent/pull/1338) · CI & build · **T3**
+
+*Adds the repository's security-scanning and supply-chain baseline: zizmor, pip-audit, gitleaks, pinact, actionlint, and CodeQL workflows; SHA-pinned Actions with least-privilege permissions; Dependabot, CODEOWNERS, SECURITY.md, and supporting ADRs. No production code.*
+
+- **Security CI** — new `security.yml` (zizmor / pip-audit / gitleaks / pinact / actionlint) and CodeQL (advisory), plus SHA-pinning and `permissions: {}` across workflows.
+
+> [!IMPORTANT]
+> **Operational** — adds new gating checks (zizmor gates from day one; CodeQL advisory, then meant to flip to gating) and starts weekly Dependabot PRs; CODEOWNERS routes review.
+
+**🛠 Engineering**
+- `.github/workflows/{security,codeql}.yml`, `dependabot.yml`, `CODEOWNERS`, `SECURITY.md`, three ADRs; CVE-suppression scaffolding in `scripts/`. The `pyproject.toml` change is metadata only; zero `src/`.
+
+### uv.lock as the single source of versions, plus CVE runtime upgrades (PR 2 of #1234)
+
+[`#1370`](https://github.com/prebid/salesagent/pull/1370) · CI & build · **T2**
+
+*Framed as a CI PR, but it ships production change. It moves tooling versions into uv.lock (the ADR-001 pre-commit overhaul) and upgrades runtime dependencies to patch CVEs — pydantic-ai to 1.99 (RCE), fastapi/starlette — which forces a real change to the AI-provider seam.*
+
+- **CVE runtime upgrades** — `pydantic-ai-slim>=1.99.0`, `fastapi>=0.133.0`, `starlette>=1.0.1` (CVE remediations), `fastmcp<3.3.0`.
+- **AI-provider seam** — provider names `gemini`/`google`/`google-gla` collapse to canonical `google`; new `DB_POOL_SIZE`/`DB_MAX_OVERFLOW` operational tunables.
+
+> [!NOTE]
+> **Behavioral change** — `AIModelFactory.create_model` for the Google provider with no resolved API key now raises `AdCPConfigurationError` instead of silently falling back to env-var key resolution.
+
+**🛠 Engineering**
+- `pyproject.toml` runtime upgrades + dev deps into `[dependency-groups].dev`; `services/ai/{config,factory}.py` add `canonicalize_google_provider()`; `database/{db_config,database_session}.py` add `int_env()` + pool tunables; ADR-001 pre-commit overhaul enforced by a new guard; pytest-randomly isolation fixes.
+
+### Authoritative CI pipeline with frozen required checks (PR 3 of #1234)
+
+[`#1372`](https://github.com/prebid/salesagent/pull/1372) · CI & build · **T3**
+
+*Replaces `test.yml` with an authoritative `ci.yml`: a static `quality-ci` gate split from unit tests, composite setup actions, 5-way integration sharding, and 18 frozen branch-protection check names guarded by a test. The lone `src/` touch is a comment.*
+
+- **One pipeline** — `ci.yml` replaces `test.yml`; `make quality-ci` (ruff + mypy + duplication, no pytest) splits the static gate from unit tests; new guards freeze the 18 required check names.
+
+> [!IMPORTANT]
+> **Operational** — requires a one-time maintainer branch-protection migration (swap the old required-check names for the 18 `CI / ...` names) before merge.
+
+**🛠 Engineering**
+- Adds `ci.yml` + composite `.github/actions/*`; `make quality-ci`; a coverage hard-gate via `.coverage-baseline`; merge-head-aware `migration_roundtrip.py`. Removes dead `[tool.black]`. The `src/core/tools/capabilities.py` change is comment-only.
+
 ---
 
 ## 🧹 Admin UI & maintenance
@@ -597,5 +709,7 @@ Single-commit changes whose titles already match their diffs; listed for complet
 - [`#1431`](https://github.com/prebid/salesagent/pull/1431) — Read BDD step files as UTF-8 in the `bdd-no-direct-call-impl` guard (fixes a Windows cp1252 decode crash).
 - [`#1443`](https://github.com/prebid/salesagent/pull/1443) — Resolve agent-db `PROJECT_DIR` to the worktree root so each worktree gets its own test Postgres; drops an accidentally-committed test env file.
 - [`#1463`](https://github.com/prebid/salesagent/pull/1463) — Wire the UC-005 `list_creative_formats` `format_id` object-shape BDD scenario across all four transports (xfail -> passing).
+- [`#1222`](https://github.com/prebid/salesagent/pull/1222) — Add BDD and admin-HTTP test coverage, four BDD structural guards, and architecture docs (test/docs only; no production change).
+- [`#1395`](https://github.com/prebid/salesagent/pull/1395) — Retarget the retroactive-creative-push mock to the use site so it actually intercepts (test-only; the handler was already correct).
 
-**Out of scope (not recorded):** dependency and security version bumps — authlib, aiohttp, uv, mako, python-multipart, urllib3 ([#1385](https://github.com/prebid/salesagent/pull/1385), [#1375](https://github.com/prebid/salesagent/pull/1375), [#1298](https://github.com/prebid/salesagent/pull/1298) and folded-in bumps).
+**Out of scope (not recorded):** dependency and security version bumps — authlib, aiohttp, lxml, python-dotenv, fastapi/starlette, uv, mako, python-multipart, urllib3 ([#1385](https://github.com/prebid/salesagent/pull/1385), [#1375](https://github.com/prebid/salesagent/pull/1375), [#1298](https://github.com/prebid/salesagent/pull/1298), [#1343](https://github.com/prebid/salesagent/pull/1343), [#1226](https://github.com/prebid/salesagent/pull/1226), [#1159](https://github.com/prebid/salesagent/pull/1159) and folded-in bumps). A PR whose only in-scope content is a dependency bump is listed here rather than as a record.

--- a/docs/releases/1.8.0.md
+++ b/docs/releases/1.8.0.md
@@ -1,0 +1,540 @@
+# Release 1.8.0 — change records
+
+A readable, accurate account of everything that shipped in 1.8.0, reconstructed from the final
+merged code. Each entry leads with the impact, lays out what changed and why it matters, and
+ends with an engineering breakout for the people maintaining the code.
+
+**How to read** — the byline shows the PR, the **area** it touches, a **tier**
+(`T1` headline · `T2` notable · `T3` internal), and **flags** (`breaking` · `schema` ·
+`migration` · `wire`). Where a change needs a stop-and-read flag, it gets a callout between
+the summary and the engineering breakout — **Breaking changes** (existing usage stops working),
+**Migration / operational** (something to run or set when deploying), or **Behavioral change**
+(runtime behavior shifts without breaking the contract). Most entries have none.
+
+**Out of scope** — dependency version bumps (including dependabot/CVE upgrades) and security
+changes that don't alter the code's behavior; a consequential security fix is covered under its
+parent change, never as a bump entry. Atomic single-commit changes are collected in the appendix.
+
+---
+
+## 🔌 AdCP protocol & schema
+
+### Upgrade to adcp 4.3 + a2a-sdk 1.0 (protobuf API rewrite)
+
+[`#1266`](https://github.com/prebid/salesagent/pull/1266) · AdCP protocol & schema · **T1** · `breaking` `wire`
+
+*Upgrades the two core protocol dependencies — adcp 3.12→4.3 and a2a-sdk 0.3.19→1.0 — and rewrites the A2A server onto the new protobuf API. The same release standardizes error codes across REST, MCP, and A2A, adds media-buy state-machine enforcement, and advertises idempotency support in capabilities. Several of these changes are breaking for existing clients.*
+
+- **Protocol versions** — adcp 4.3 (AdCP spec 3.0.1) and a2a-sdk 1.0; the A2A server is rewritten onto the protobuf API.
+- **Standardized error codes** — REST, MCP, and A2A return the same UPPER_SNAKE_CASE codes from a single mapping layer.
+- **Media-buy lifecycle enforcement** — finished or canceled buys can no longer be modified, and illegal state transitions are rejected.
+- **Idempotency advertised** — capabilities now reports idempotency support with a 24-hour replay window.
+
+> [!WARNING]
+> **Breaking changes** — agent card moved to `/.well-known/agent-card.json`; wire error codes are now UPPER_SNAKE_CASE (`AUTHORIZATION_ERROR` → `AUTH_REQUIRED`); ~13 non-spec parameters removed from `create_media_buy`/`get_products`; `webhook_url` removed from `list_creatives`/`list_authorized_properties`; `pending_activation` renamed `pending_start`.
+
+**🛠 Engineering**
+- The a2a-sdk 1.0 jump is a full protobuf-API rewrite of `adcp_a2a_server.py` — TaskState enums, `MessageToDict`, protobuf `Part`/`AuthenticationInfo`, `scheme`→`schemes` push translation.
+- Error emission is centralized in `exceptions.py` via `ERROR_CODE_MAPPING` / `translate_error_code()` / `to_adcp_error()`; `INTERNAL_CODES` stay server-side and map to spec codes on the wire.
+- MCP/A2A wrappers move from `Any`/`dict` to SDK Pydantic types with `Field(description=...)`, enforced by three new structural guards.
+- `_update_media_buy_impl` gains state-machine enforcement via `valid_actions_for_status`; status splits into `pending_start` vs `pending_creatives`. No Alembic migration in this PR.
+
+<sub>Verified against the final diff.</sub>
+
+### Replace buyer_ref with media_buy_id and idempotency-keyed dedup (adcp 3.12)
+
+[`#1217`](https://github.com/prebid/salesagent/pull/1217) · AdCP protocol & schema · **T1** · `breaking` `schema` `migration` `wire`
+
+*Migrates the adcp library 3.10→3.12, and the central change replaces the buyer-supplied `buyer_ref` with a seller-assigned `media_buy_id` plus an `idempotency_key` that de-duplicates retried create requests. It also drops several types the spec removed — format `type` categorization, `BrandManifest`, the `DeliverTo` wrapper, and `PromotedProducts`. The identifier swap and the column drop are breaking and require a destructive migration.*
+
+- **Media-buy identity** — `buyer_ref` is replaced everywhere by a seller-assigned `media_buy_id`; `UpdateMediaBuyRequest.media_buy_id` is now required.
+- **Idempotent creates** — a new `idempotency_key` de-duplicates retried create requests, short-circuiting duplicate ad-server bookings and recovering from race conditions.
+- **Spec type removals** — format `type`/`FormatCategory`, `BrandManifest` (→ `Brand`), the `DeliverTo` wrapper, and `PromotedProducts` (→ `Catalog`) are gone, tracking the 3.12 spec.
+- **Order naming** — the `order_name_template` default changes from `{buyer_ref}` to `{media_buy_id}`, with a `{buyer_ref}` alias kept populated for back-compat.
+
+> [!WARNING]
+> **Breaking changes** — `buyer_ref` removed from all requests, responses, and the `media_buys` table; `UpdateMediaBuyRequest.media_buy_id` now required and `budget` dropped; `buyer_refs`/`media_buy_buyer_refs` delivery filters removed; `DeliverTo`, `BrandManifest`, `PromotedProducts`, and format `type` removed; GovernanceAgent `authentication` field dropped.
+
+> [!IMPORTANT]
+> **Migration** — three Alembic migrations, one of which drops the `buyer_ref` column, its unique constraint, and index (destructive, not data-reversible). A data migration rewrites `{buyer_ref}` → `{media_buy_id}` in existing tenants' order-name templates.
+
+**🛠 Engineering**
+- New `media_buys.idempotency_key` column with a partial unique index on `(tenant_id, principal_id, idempotency_key)` (migration `d40df2c92316`); `find_by_idempotency_key()` / `get_by_id_or_idempotency_key()` replace the `buyer_ref` repository lookups.
+- `_create_media_buy_impl` short-circuits on an idempotency hit and recovers from TOCTOU races by catching `IntegrityError` and re-querying the winner via a shared `_build_idempotency_hit_result`.
+- Format filtering/sorting is now structural via `asset_types`; `BrandManifest`→`Brand` extracts localized names; `DeliverTo` is flattened into `GetSignalsRequest`.
+- Migrations: `d40df2c92316` (add idempotency_key), `cf421634d3c8` (drop buyer_ref), `b4e2bffdd4f8` (data migration + `server_default` change; two-parent down_revision merges divergent alembic heads).
+
+<sub>Verified against the final diff.</sub>
+
+### Round-trip property_list and collection_list on media buys
+
+[`#1276`](https://github.com/prebid/salesagent/pull/1276) · AdCP protocol & schema · **T2** · `schema` `wire`
+
+*Lets buyers round-trip `property_list` and `collection_list` targeting on media buys — the references attached at create or update are now typed at the request boundary and read back on `get_media_buys`. Because no adapter yet compiles `property_list`, create/update responses carry per-package advisories, and the capability flags for property-list filtering and catalog management now report false. There are no database changes; the targeting rides the existing package config.*
+
+- **Targeting round-trip** — `targeting_overlay` is added to media-buy packages and rehydrated from stored package config on read, so attached `property_list`/`collection_list` references come back.
+- **Typed collection_list** — `collection_list`/`collection_list_exclude` are typed at the request boundary (re-exported from adcp 4.3) so they survive validation.
+- **Honest capabilities** — `property_list_filtering` and `catalog_management` now report `false`, and `specialisms` is declared, reflecting what adapters actually support.
+- **Per-package advisories** — create/update success responses include `UNSUPPORTED_FEATURE` advisories when `property_list` targeting is requested, since no adapter compiles it yet.
+
+> [!NOTE]
+> **Behavioral change** — discovery now reports `property_list_filtering` and `catalog_management` as `false` (previously `true`), and `get_media_buys` returns non-fatal error rows for corrupt stored targeting rather than silently dropping it.
+
+**🛠 Engineering**
+- `targeting_overlay` rehydrated from the untyped `package_config` JSON in `media_buy_list.py` (no new column/migration); `CollectionListReference` re-exported from adcp 4.3; `Targeting`/`AdCPPackageUpdate` overridden in `schemas/_base.py`.
+- `property_list` enforcement in `services/targeting_capabilities.py`: create/update reject `property_targeting_allowed=False` products (even in dry-run); success envelopes gain an `errors: list[Error]` field.
+- `_update_media_buy_impl` is wrapped with `ContextManager.fail_workflow_step_for_exception`, writing spec-shaped `errors[]` into `response_data` so async push subscribers get the same envelope as sync callers; create's overlay validators now run on update; `MediaBuyUoW` gains a products repository.
+
+<sub>Verified against the final diff.</sub>
+
+### Add push_notification_config to GetProductsRequest
+
+[`#1393`](https://github.com/prebid/salesagent/pull/1393) · AdCP protocol & schema · **T2** · `schema`
+
+*Adds the optional `push_notification_config` field to `GetProductsRequest` for AdCP contract alignment. The field is accepted but not yet wired to any behavior — `get_products` neither reads nor acts on it — so this is a forward-compatible schema addition only.*
+
+- **Contract alignment** — `GetProductsRequest` now carries an optional `push_notification_config`, declared as a local extension over the library base.
+- **Inert for now** — no webhook or async behavior is wired; the field exists purely for parity.
+
+**🛠 Engineering**
+- Optional `push_notification_config: LibraryPushNotificationConfig | None` on `GetProductsRequest` (`src/core/schemas/product.py`), over the `GetProductsWholesaleRequest` base; `test_adcp_contract.py` adds it to `local_extensions`. No impl/tool wiring (`git grep` confirms).
+
+<sub>Verified against the final diff.</sub>
+
+### Remove invoice_recipient from UpdateMediaBuyRequest
+
+[`717f5a7`](https://github.com/prebid/salesagent/commit/717f5a7) · AdCP protocol & schema · **T2** · `breaking` `schema`
+
+*Removes the `invoice_recipient` field from `UpdateMediaBuyRequest`. The field let a buyer override the billing entity per buy, but its `BusinessEntity` type isn't yet modeled in the adcp library, so it was an untyped `dict` that bypassed validation. No replacement was added; the schema gap is tracked in the alignment known-mismatches list.*
+
+- **Field removed** — `invoice_recipient` is gone from `UpdateMediaBuyRequest`, with nothing replacing it yet.
+
+> [!WARNING]
+> **Breaking change** — `update_media_buy` requests that include `invoice_recipient` are now rejected under strict (dev/CI) validation and silently dropped in production. There is no replacement field.
+
+**🛠 Engineering**
+- Field + docstring removed from `UpdateMediaBuyRequest` (`src/core/schemas/_base.py`); zero `invoice_recipient` references remain in `src/`; the gap is parked in `test_pydantic_schema_alignment.py` known-mismatches. An unrelated aiohttp floor bump rode along in the same commit.
+
+<sub>Verified against the final diff.</sub>
+
+### Correct AdCP spec-version citations in docs and comments
+
+[`#1356`](https://github.com/prebid/salesagent/pull/1356) · AdCP protocol & schema · **T3**
+
+*Corrects 16 AdCP spec-version citations across docs, source comments, docstrings, and tests (e.g. `property_list` 3.0.6→3.0.0). Also modernizes three protocol-facing enums to `StrEnum`, which is runtime-equivalent for string comparison and serialization on Python 3.11+.*
+
+- **Citation fixes** — spec-version references corrected throughout docs, comments, and tests; no behavior change.
+- **Enum modernization** — `TaskStatus`, `SnapshotUnavailableReason`, and `ApprovalStatus` move from `(str, Enum)` to `StrEnum`.
+
+**🛠 Engineering**
+- 16 citation edits across `docs/`, `media_buy_update.py`, `targeting_capabilities.py`, `schemas/_base.py`, `adapters/gam/managers/targeting.py`, and tests; the three enums switch to `StrEnum` in `schemas/_base.py`. A follow-up commit re-wraps a comment to keep a line-keyed guard allowlist stable.
+
+<sub>Verified against the final diff.</sub>
+
+---
+
+## 📈 Delivery & reporting
+
+### Delivery-status accuracy, attribution echo, and the #1264 memory-leak follow-ups
+
+[`#1334`](https://github.com/prebid/salesagent/pull/1334) · Delivery & reporting · **T2** · `schema` `wire`
+
+*Bundles three streams under one PR. The largest is new delivery-reporting behavior: media-buy status now comes from the persisted column rather than being re-derived from flight dates, and responses gain an attribution-window echo and a geo breakdown. It also lands the #1264 memory-leak follow-ups (a shared thread registry, task pinning, and shutdown primitives) and a broad test-suite hardening pass.*
+
+- **Status from the persisted column** — `get_media_buy_delivery` and `list_media_buys` report status from `MediaBuy.status` (adding `rejected`/`canceled`/`pending_creatives`) instead of deriving it from flight dates.
+- **Richer delivery responses** — adds an `attribution_window` echo (default `last_touch`), a `by_geo` breakdown, and request fields `time_granularity`/`include_window_breakdown`.
+- **A2A boundary fixes** — the A2A delivery path now forwards `reporting_dimensions`/`attribution_window`/`account` (previously dropped) and stops mis-validating `push_notification_config` on create.
+- **Memory-leak consolidation (#1264)** — a shared `ThreadRegistry` reaper, `pin_task`, and shutdown primitives replace five duplicated reaper implementations; Prometheus label cardinality is bounded.
+- **Test-suite hardening** — ~45 test files plus new architecture guards (CI-suite coverage, no-raw-thread-registry, lazy app-lifespan import).
+
+> [!NOTE]
+> **Behavioral change** — delivery and list endpoints now filter by persisted media-buy status rather than date-derived status, so which buys appear under a given `status_filter` (and the status echoed back) can change.
+
+**🛠 Engineering**
+- `media_buy_delivery.py`: `_internal_status_for_buy` / `_PERSISTED_STATUS_TO_INTERNAL`, `_resolve_attribution_window` (`PLATFORM_DEFAULT_ATTRIBUTION_MODEL = last_touch`), `_build_geo_breakdown`, reworked `_build_placement_breakdown`; `media_buy_list.py` mirrors with `_PERSISTED_STATUS_TO_ADCP` / `_compute_status`.
+- New core primitives — `async_utils.pin_task`, `thread_registry.ThreadRegistry`, `lifecycle.register_shutdown` / `run_all_shutdown_callbacks` — adopted across background services, the delivery simulator, and the GAM reporting manager.
+- `schemas/delivery.py` adds `GeoBreakdown` and the new request fields; `Account.model_dump` always includes `advertiser`/`rate_card`/`payment_terms`. No migration.
+
+<sub>Verified against the final diff.</sub>
+
+---
+
+## 🎨 Creatives
+
+### Retroactively push approved creatives to live buys
+
+[`#1337`](https://github.com/prebid/salesagent/pull/1337) · Creatives · **T2**
+
+*Creatives still pending review are now held back from the initial ad-server upload — in both the manual-approval and auto-approval paths — and pushed to the live buy once approved. The push is adapter-generic, dispatched through the configured adapter's creatives manager rather than being GAM-specific. To make retroactive lookup possible, the platform order ID is now persisted on every package.*
+
+- **Held back, then pushed** — `pending_review` creatives are withheld from the first upload and pushed to the buy after approval, for buys that are active, scheduled, or paused.
+- **Both creation paths** — applies to manual approval (`execute_approved_media_buy`) and auto-approval (`_create_media_buy_impl`).
+- **Adapter-generic** — the push dispatches through `get_adapter().creatives_manager`; GAM is the motivating case, not a hard dependency.
+- **Order IDs persisted** — `platform_order_id` is now stored on every package, which is what makes retroactive push possible.
+
+> [!IMPORTANT]
+> **Operational** — buys created before this change lack the stored `platform_order_id` and may need a one-time backfill for retroactive creative push to find them; that backfill is out of scope here.
+
+**🛠 Engineering**
+- New `push_creative_to_existing_buy()` wired into the admin `approve_creative` hook for `_LIVE_BUY_STATUSES = {active, scheduled, paused}`; push failures are non-fatal and returned as a `warnings[]` array on the approve response.
+- `_persist_adapter_package_ids()` now writes `platform_order_id` to all packages whenever the adapter returns a `media_buy_id` (previously only `platform_line_item_id`, and only when supplied).
+- `_build_adapter_asset_from_creative()` consolidates creative→adapter-asset construction across three call sites; the raw-MediaPackage-select guard allowlist shrank by one.
+
+<sub>Verified against the final diff.</sub>
+
+### Apply spec-compliant account and assignment forms in A2A sync_creatives
+
+[`#1251`](https://github.com/prebid/salesagent/pull/1251) · Creatives · **T2**
+
+*Fixes two ways `sync_creatives` silently mishandled valid input. Over A2A, a raw `account` dict is now coerced to an `AccountReference` before resolution instead of raising an attribute error. And spec-compliant list-form assignments are now normalised and applied rather than being dropped.*
+
+- **A2A account handling** — a raw `account` dict is coerced to `AccountReference` before resolution, fixing an attribute error on the A2A `sync_creatives` path.
+- **List-form assignments** — spec-compliant `[{creative_id, package_id}]` assignments are normalised to the internal shape and applied.
+
+> [!NOTE]
+> **Behavioral change** — creative assignments sent in the spec's list form now take effect; before this change they were accepted and silently dropped.
+
+**🛠 Engineering**
+- `_handle_sync_creatives_skill` wraps the dict with `LibraryAccountReference.model_validate()` before forwarding (`adcp_a2a_server.py`).
+- `_process_assignments` (`creatives/_assignments.py`) now accepts `dict | list | None` and normalises list-form input; dict-form, `None`, and already-typed `AccountReference` inputs are unchanged.
+
+<sub>Verified against the final diff.</sub>
+
+### Forward creative-format filters consistently across MCP and A2A
+
+[`#1331`](https://github.com/prebid/salesagent/pull/1331) · Creatives · **T2** · `wire`
+
+*Routes both the MCP wrapper and the A2A skill handler for `list_creative_formats` through one shared request-builder, so both transports apply the same filters. The MCP tool gains `output_format_ids`, `input_format_ids`, and `wcag_level` parameters, and A2A now forwards `wcag_level` as well.*
+
+- **Shared request building** — MCP and A2A build the `list_creative_formats` request through one helper instead of two divergent paths.
+- **New filter params** — the MCP tool accepts `output_format_ids`, `input_format_ids`, and `wcag_level` (all optional); A2A forwards `wcag_level`.
+
+**🛠 Engineering**
+- New `build_list_creative_formats_request()` in `creative_formats.py`; the MCP `list_creative_formats` wrapper and A2A `_handle_list_creative_formats_skill` both call it, reaching the shared `_list_creative_formats_impl`. Removes the now-passing MCP xfails for these filters (only `disclosure_positions` remains).
+
+<sub>Verified against the final diff.</sub>
+
+---
+
+## 📺 Google Ad Manager (GAM)
+
+### Rewrite the GAM inventory tree as a lazy-loading API
+
+[`#1176`](https://github.com/prebid/salesagent/pull/1176) · Google Ad Manager · **T2** · `migration` `wire`
+
+*Replaces the inventory tree's single all-at-once query with a lazy-loading API that serves the root, a node's children, or search results separately, so large GAM networks no longer load every ad unit into memory at once. The frontend is consolidated from several duplicated tree implementations into one shared component, and a Playwright UI suite is added.*
+
+- **Lazy 3-mode tree** — the endpoint serves root-only, children-of-a-node, or search results, each bounded with a `truncated` flag, replacing the unbounded full-tree load.
+- **Search without N+1** — search resolves ancestors with a single batched `IN()` query instead of per-level lookups.
+- **Shared frontend** — four to five duplicated inline tree implementations collapse into one `initInventoryTree` component across the consuming templates.
+- **Sizes endpoint fixes** — `/inventory/sizes` now normalises GAM dict-format sizes and resolves placement IDs to their ad units.
+- **UI tests** — a new Playwright `ui` suite covers the tree.
+
+> [!NOTE]
+> **Behavioral change** — the inventory-tree endpoint's response shape now varies by mode (root/children/search) and carries a `truncated` flag; its cache key was bumped, so caches repopulate after deploy.
+
+**🛠 Engineering**
+- `get_inventory_tree()` dispatches on query params; all four list/tree modes route through `execute_limited()` / `LimitedResult` in `admin/utils/helpers.py`.
+- Adds composite index `idx_gam_inventory_tenant_type_status` on `(tenant_id, inventory_type, status)` (migration `13b5e73b6983` + matching ORM `Index`); two empty merge-head migrations reconcile divergent chains.
+- Shared `initInventoryTree(config)` in `templates/partials/hierarchical_tree_scripts.html` exposes `{search, expandAll, collapseAll, getSelectedIds, refresh}` with `onSelect`/`onRender`/`onStatsLoaded` callbacks; ~310 lines of dead JS removed from `add_product_gam.html`.
+
+<sub>Verified against the final diff.</sub>
+
+### GAM test-connection reports failure when no network is reachable
+
+[`#1219`](https://github.com/prebid/salesagent/pull/1219) · Google Ad Manager · **T2**
+
+*The GAM connection test previously reported success even when no network was accessible. It now returns a failure result — with an auth-method-specific message — when no networks come back after all fetch attempts.*
+
+- **No more false success** — an unreachable or unauthorized GAM connection now reports `success: false` instead of `success: true` with an empty network list.
+
+> [!NOTE]
+> **Behavioral change** — the admin connection-test endpoint now returns `success: false` (HTTP 200) for the no-network case that previously reported success; the admin UI already branches on this.
+
+**🛠 Engineering**
+- `test_gam_connection` (`src/admin/blueprints/gam.py`) captures the swallowed `getCurrentNetwork`/`getAllNetworks` error and returns a failure result when `networks` is empty, with a service-account-specific hint.
+
+<sub>Verified against the final diff.</sub>
+
+### Correct GAM service-account authorization instructions
+
+[`#1218`](https://github.com/prebid/salesagent/pull/1218) · Google Ad Manager · **T3**
+
+*Corrects the GAM service-account setup guidance to point at the API-access flow (Admin → Global Settings → API access → add a service-account user) instead of the incorrect "add as a Trafficker user" instructions.*
+
+- **Accurate setup steps** — fixes the service-account authorization instructions in the docs, settings templates, and JS alerts.
+
+**🛠 Engineering**
+- Prose, template, and JS-string edits across `docs/adapters/gam/service-account-setup.md`, `templates/tenant_settings.html`, the GAM connection-config template, and `static/js/tenant_settings.js`. No logic change.
+
+<sub>Verified against the final diff.</sub>
+
+---
+
+## 📦 Inventory & property discovery
+
+### Fix get_products crash on inventory profiles missing a selection_type
+
+[`#1174`](https://github.com/prebid/salesagent/pull/1174) · Inventory & property discovery · **T2**
+
+*Fixes `get_products` failing on inventory-profile publisher properties that omit a `selection_type`, by inferring the discriminator (`by_id`/`by_tag`/`all`) when it's missing. The inference is extracted into one shared helper used by both code paths that build a product's effective properties, replacing inline logic that only covered one of them.*
+
+- **Crash fix** — `get_products` no longer fails when inventory-profile `publisher_properties` lack a `selection_type`; the discriminator is inferred on read.
+- **One shared path** — both branches of `Product.effective_properties` route through `ensure_selection_type()` instead of duplicating the logic.
+- **Field-preserving** — the legacy path now keeps extra property fields (e.g. `property_name`) instead of stripping them.
+
+**🛠 Engineering**
+- New `ensure_selection_type()` in `src/core/helpers/publisher_property_helpers.py`, called from both branches of `Product.effective_properties` (`models.py`); reaches `get_products` via `product_conversion.py`. Normalization is on-read — no migration, no schema/model change. Most of the diff is tests; two unrelated dependency bumps rode along in merge.
+
+<sub>Verified against the final diff.</sub>
+
+### Decompose the property discovery service and delete dead code
+
+[`#1206`](https://github.com/prebid/salesagent/pull/1206) · Inventory & property discovery · **T3**
+
+*Internal refactor of the property discovery service: the large `sync_properties_from_adagents()` method is broken into focused helpers, and never-called unbatched create/update methods are removed in favor of the batched versions. Public signatures and behavior are unchanged.*
+
+- **Decomposed sync** — `sync_properties_from_adagents()` is split into module-level helpers and batched instance methods.
+- **Dead code removed** — the unused unbatched `_create_or_update_property`/`_create_or_update_tag` are deleted; the batched versions take their canonical names.
+
+**🛠 Engineering**
+- Extracts `_make_stats`/`_log_fetch_error`/`_extract_properties`/`_filter_properties_by_domain`/`_finalize_session` plus `_batch_sync_properties`/`_batch_sync_tags` in `property_discovery_service.py`; hoists `hashlib`/`re`/`Select` to module top; updates the `no_raw_select` guard allowlist (net −1). Public methods and return shape unchanged.
+
+<sub>Verified against the final diff.</sub>
+
+### Match publisher domains across www/m/mobile prefixes
+
+[`#1207`](https://github.com/prebid/salesagent/pull/1207) · Inventory & property discovery · **T3**
+
+*Matches publisher domains regardless of common subdomain prefixes (`www`, `m`, `mobile`) and case when filtering properties from an adagents.json file. A publisher registered as `www.example.com` now matches an identifier of `example.com`, and vice versa.*
+
+- **Subdomain-tolerant matching** — comparison strips one `www`/`m`/`mobile` prefix and lowercases before comparing.
+- **Both directions** — works whether the prefix is on the publisher domain or the adagents identifier.
+
+**🛠 Engineering**
+- `_normalize_domain()` + `_domains_match()` in `property_discovery_service.py`; `_filter_properties_by_domain` swaps the exact `in` check for the normalized comparison. Adds a 15-case unit test.
+
+<sub>Verified against the final diff.</sub>
+
+---
+
+## 🛡️ Reliability: errors & memory
+
+### Fix silent error-swallowing data-loss bugs and guard against recurrence
+
+[`#1212`](https://github.com/prebid/salesagent/pull/1212) · Reliability · **T2**
+
+*Fixes a class of bugs where errors were swallowed and data was quietly dropped, and adds a structural guard that bans `except Exception: pass` in the source tree so they can't return. The fixes span the GAM and Xandr adapters, reporting, and credential handling, including an on-disk credential leak.*
+
+- **No more silent data loss** — GAM reporting keeps zero-impression rows that have clicks or revenue; GAM/Xandr parse dates tolerantly instead of dropping unparseable rows; the mock adapter writes the correct field.
+- **Failures surface** — decryption errors raise `AdCPConfigurationError` (a 500) instead of returning `None` and being treated as "not configured"; ~15 silent catches now log.
+- **Credential-leak fix** — GAM service-account credentials load from an in-memory dict, removing a temp keyfile written to disk.
+- **Guard against recurrence** — a new AST guard bans `except Exception: pass`/`continue` in `src/`, with an empty allowlist.
+
+> [!NOTE]
+> **Behavioral change** — code paths that previously swallowed errors now raise or log; broken or rotated encryption returns a `CONFIGURATION_ERROR` (500) instead of silently behaving as "not configured."
+
+**🛠 Engineering**
+- Decrypt getters in `models.py` raise the new `AdCPConfigurationError` (`exceptions.py`, code `CONFIGURATION_ERROR`); `mock_ad_server.py` `.formats`→`.format_ids`; `gam_reporting_service.py` zero-row filter narrowed; `google_ad_manager.py`/`xandr.py` use `dateutil` for API dates; `background_sync_service.py` loads creds via `from_service_account_info(dict)`.
+- New guard `tests/unit/test_architecture_no_silent_except.py` (empty allowlist); an `authlib` security bump and `types-python-dateutil` rode along.
+
+<sub>Verified against the final diff.</sub>
+
+### Memory-leak triage: session shutdown, dead-thread reapers, task pinning
+
+[`#1264`](https://github.com/prebid/salesagent/pull/1264) · Reliability · **T3**
+
+*A batch of four memory-leak fixes from the production OOM investigation: the webhook HTTP session is closed on shutdown, fire-and-forget webhook tasks are pinned so they aren't garbage-collected mid-flight, and three thread registries prune dead entries on read.*
+
+- **Session cleanup** — `_webhook_service.close()` runs on app shutdown, releasing the shared connection pool.
+- **Task pinning** — webhook `create_task` calls hold a strong reference until done, preventing mid-flight GC.
+- **Dead-thread reapers** — the background-sync, order-approval, and background-approval registries prune dead threads when queried.
+
+**🛠 Engineering**
+- `app_lifespan` shutdown hook in `src/app.py`; a `_pending_webhook_tasks` strong-ref set in `context_manager.py`; an identical `_reap_dead_*()` helper added to each of the three services' accessors under the existing lock. A `run_all_tests.sh` exit-code fix rode along. (The per-service reapers were later consolidated into a shared `ThreadRegistry` in #1334.)
+
+<sub>Verified against the final diff.</sub>
+
+---
+
+## 🏢 Tenant configuration
+
+### Persist billing policy and account approval mode as tenant columns
+
+[`#1186`](https://github.com/prebid/salesagent/pull/1186) · Tenant configuration · **T2** · `schema` `migration`
+
+*Moves seller billing policy and account approval mode out of request-time identity and into persisted tenant columns. The practical effect is that billing rejection and approval-mode gating now take effect on the live MCP and A2A transports, where they were previously skipped because nothing populated those fields outside the test harness.*
+
+- **Persisted as tenant config** — `supported_billing` and `account_approval_mode` are now columns on the tenant, read from tenant context.
+- **Policies actually enforce** — billing rejection and approval gating fire on the real MCP/A2A auth chain, not just under test injection.
+- **Distinct approval modes** — account approval mode is kept separate from the existing creative approval mode.
+
+> [!IMPORTANT]
+> **Migration** — two reversible migrations add `tenants.supported_billing` (JSON) and `tenants.account_approval_mode`; one also sets a `server_default` on `created_at`/`updated_at`. No data backfill.
+
+> [!NOTE]
+> **Behavioral change** — billing-policy rejection and account-approval gating now take effect on the MCP and A2A transports; before this they were silently skipped outside the test harness.
+
+**🛠 Engineering**
+- New `tenants.supported_billing` (JSONType) and `account_approval_mode` (String(50)) in `models.py`; read via `TenantContext.from_orm_model`, surfaced in `serialize_tenant_to_dict`; `_sync_accounts_impl`/`_check_billing_policy` (`accounts.py`) read `identity.tenant` instead of removed `ResolvedIdentity` fields.
+- Migrations `4ccbe6f82b4b` (supported_billing + created_at/updated_at `server_default`) and `c612d0326eb0` (account_approval_mode), both with real downgrades. No admin UI in this PR.
+
+<sub>Verified against the final diff.</sub>
+
+---
+
+## 🧪 Test suite (BDD & harness)
+
+### Behavioral test harness across the agent's transports
+
+[`#1335`](https://github.com/prebid/salesagent/pull/1335) · Test suite (BDD & harness) · **T1** · `wire` `migration`
+
+*Adds a behavioral test harness that compiles the AdCP specification's use cases into Gherkin features and runs them across the agent's transports, establishing a safety net for refactoring. Wired alongside it are real production changes the tests demanded: more specific spec-compliant error codes, REST filter forwarding, and tenant-scoped principal lookups.*
+
+- **Spec-driven BDD harness** — 29 feature files compile 27 spec use cases; 10 are fully wired to step definitions and test environments.
+- **Four transports by default** — scenarios run across IMPL, A2A, REST, and MCP (the harness also defines E2E modes, opt-in via `BDD_E2E_ENABLED`).
+- **Spec-compliant error codes** — auth/validation/product/budget failures now return specific codes (`AUTH_TOKEN_INVALID`, `BUDGET_TOO_LOW`, `PRODUCT_NOT_FOUND`, `INVALID_REQUEST`) instead of generic ones.
+- **REST filter forwarding** — `list_creative_formats`/`list_authorized_properties` REST bodies forward ~15 filter fields; `list_media_buys` honors explicit `media_buy_ids` over the default active-only filter.
+
+> [!NOTE]
+> **Behavioral change** — several auth and validation failures now return more specific spec error codes than the previous generic ones; clients keying on the old strings should re-check.
+
+**🛠 Engineering**
+- New `tests/bdd/` + `tests/harness/`: 29 feature files, 7 domain step files (UC-002/003/004/006/011/019/026) plus UC-005/COMPAT/GET-PRODUCTS via shared steps; the `Transport` enum has 7 modes, conftest parametrizes 4 by default.
+- Production delta is ~36 `src/` files (+346/-149; the +45k headline is mostly merge-from-main churn): new `AdCPAuthRequiredError`/`_StructuredValidationError`; REST filter forwarding; `list_media_buys` status-filter fix; tenant-scoped `get_principal_object`; attribution-window echo; SDK imports migrated `generated_poc.*`→`adcp.types` (~92 files).
+- Migrations: `529ae3fa444b` (`server_default now()` across ~20 tables) plus two empty head-merge migrations.
+
+<sub>Verified against the final diff.</sub>
+
+### Implement MediaBuyCreateEnv test-harness setup helpers
+
+[`#1382`](https://github.com/prebid/salesagent/pull/1382) · Test suite (BDD & harness) · **T3**
+
+*Implements two referenced-but-missing methods on the `MediaBuyCreateEnv` test environment so the media-buy-create scenarios can seed real data and run end to end.*
+
+- **Harness completion** — adds `setup_product_chain()` (seeds a PropertyTag/Product/PricingOption via factories) and a mock context-manager builder, plus an integration smoke test.
+
+**🛠 Engineering**
+- `setup_product_chain()` and `_build_mock_context_manager()` in `tests/harness/media_buy_create.py`; an integration smoke test and a unit method-presence guard. A pyjwt floor bump rode along.
+
+<sub>Verified against the final diff.</sub>
+
+### Implement empty BDD Given step bodies
+
+[`#1185`](https://github.com/prebid/salesagent/pull/1185) · Test suite (BDD & harness) · **T3**
+
+*Gives real bodies to BDD Given steps the assertion guard flagged as empty, wiring them to production code (e.g. driving `resolve_account` and asserting the not-found error). One small production change rides along: the A2A handler now translates `PermissionError` into a structured authorization error.*
+
+- **Real Given bodies** — flagged steps now seed tenants or drive production `resolve_account`, and the empty-step allowlist is cleared.
+- **A2A error translation** — a `PermissionError` on an A2A skill now surfaces as a structured `AUTHORIZATION_ERROR` instead of a generic internal error.
+
+**🛠 Engineering**
+- `given_tenant_exists` calls a new `env._ensure_tenant_for_id`; a dual-decorator step splits into `given_account_id_not_found`/`given_natural_key_not_found` driving `env.call_impl`; `_EMPTY_GIVEN_WHEN_ALLOWLIST` is emptied. Production change: a `PermissionError`→`InvalidRequestError` handler in `_handle_explicit_skill` (`adcp_a2a_server.py`).
+
+<sub>Verified against the final diff.</sub>
+
+### Remove stale strict xfails on get-products schema drift
+
+[`#1336`](https://github.com/prebid/salesagent/pull/1336) · Test suite (BDD & harness) · **T3**
+
+*Removes two `xfail(strict=True)` markers that began xpassing — and so failing CI under strict — once #1276 added allowlist coverage for the get-products schema drift.*
+
+- **Stale markers removed** — the get-products-request drift xfail and a standalone offline-mode xfail are dropped; the same tests now run unmarked.
+
+**🛠 Engineering**
+- Drops the conditional strict-xfail in `test_pydantic_schema_alignment.py` and the `test_offline_mode` xfail in `test_schema_validation_standalone.py`; the underlying library-modeling gap (#1308) stays open and allowlisted.
+
+<sub>Verified against the final diff.</sub>
+
+---
+
+## ⚙️ CI & build
+
+### Split BDD CI into parallel shards with merged coverage
+
+[`#1379`](https://github.com/prebid/salesagent/pull/1379) · CI & build · **T3**
+
+*Splits the BDD CI job into two scenario-balanced shards that run in parallel, with per-shard coverage merged afterward. A greedy splitter assigns BDD test files to shards by Gherkin scenario count.*
+
+- **Parallel BDD shards** — the single BDD job becomes a 2-shard matrix plus an aggregate gate; coverage is combined from per-shard artifacts.
+- **Scenario-balanced split** — `shard_split.py` distributes the 13 BDD test files by scenario count.
+
+> [!IMPORTANT]
+> **Operational** — branch-protection required checks change from 18 to 20 (two shard checks added; "BDD Tests" becomes an aggregate), which needs a manual settings update on merge.
+
+**🛠 Engineering**
+- `bdd-tests-shard` matrix + `if: always()` aggregate in `ci.yml`; `scripts/ci/shard_split.py` / `shard_paths.py`; the Coverage job requires all per-shard `.coverage.bdd-N` files; `migration_roundtrip.py` now asserts alembic heads after up/down/up; new guard `test_architecture_ci_bdd_shard_manifest.py`.
+
+<sub>Verified against the final diff.</sub>
+
+### Move CI helpers into scripts/ci and tighten guards
+
+[`#1424`](https://github.com/prebid/salesagent/pull/1424) · CI & build · **T3**
+
+*Relocates migration and workflow helper modules out of `tests/` into `scripts/ci/` so operational scripts no longer import from the test tree, and tightens several CI guards. The opaque "operational helper layering" title covers a real `git mv` plus layering and CI/local-parity fixes.*
+
+- **Helpers relocated** — `_migration_helpers.py` and `workflow_helpers.py` move to `scripts/ci/`, with importers and the migration-completeness hook updated to the shared copies.
+- **CI/local parity** — the type-check job runs `make typecheck`, the env-setup action is simplified, and new guards require every job to be gated and the type-check to use the make target.
+
+**🛠 Engineering**
+- `git mv` of the two helper modules (real renames + edits); `check_migration_completeness.py` imports the shared helper and raises `MigrationParseError` instead of swallowing; `port_scan_start` now raises `TypeError` on a non-int pid (test-facing). Minor NIT in merged code: a duplicated `@pytest.mark.arch_guard` decorator on one guard test.
+
+<sub>Verified against the final diff.</sub>
+
+### Authenticate pinact with GITHUB_TOKEN
+
+[`#1344`](https://github.com/prebid/salesagent/pull/1344) · CI & build · **T3**
+
+*Passes `GITHUB_TOKEN` to the `pinact` step in the security workflow so its GitHub-API SHA resolution uses the authenticated rate limit instead of hitting anonymous 403s.*
+
+- **Fixes pinact rate-limiting** — the `pinact run --check` step is now authenticated.
+
+**🛠 Engineering**
+- Adds `env: GITHUB_TOKEN` to the pinact step in `.github/workflows/security.yml` (+2/-0).
+
+<sub>Verified against the final diff.</sub>
+
+---
+
+## 🧹 Admin UI & maintenance
+
+### Cache-bust the favicon preview on re-upload
+
+[`#1255`](https://github.com/prebid/salesagent/pull/1255) · Admin UI & maintenance · **T3**
+
+*Appends a version query string (the tenant's `updated_at` timestamp) to the favicon preview image so a re-uploaded favicon shows immediately instead of being served from browser cache.*
+
+- **Fresh favicon** — the preview `<img>` src carries `?v=<updated_at>`, bypassing the stale cache after re-upload.
+
+**🛠 Engineering**
+- Single-line template change in the Branding section of `templates/tenant_settings.html`.
+
+<sub>Verified against the final diff.</sub>
+
+### Replace broken auth-setup guide link
+
+[`#1253`](https://github.com/prebid/salesagent/pull/1253) · Admin UI & maintenance · **T3**
+
+*Replaces the non-resolving adcontextprotocol.org authentication-guide link on the login page with the in-repo GitHub doc.*
+
+- **Working link** — both login-page links now point to the repo's `docs/deployment/environment-variables.md#authentication`.
+
+**🛠 Engineering**
+- Two `href` swaps in `templates/login.html`.
+
+<sub>Verified against the final diff.</sub>
+
+---
+
+## Appendix — atomic commits
+
+Single-commit changes whose titles already match their diffs; listed for completeness.
+
+- `78be790` — Strengthen 131 weak BDD Then-step assertions with production-value checks.
+- `4e9c183` — Render UC-011/019/026 feature files to AdCP 3.1 (merge mode).
+- `af39e87` — Restore the `AdCPValidationError` import lost in a merge auto-resolution.
+- BDD parser/branch fixes — `67681ed`, `26540ea`, `9249071`, `0a9612c`, `ed9633f`, `2073994` (account-resolution branches, `reach_unit`, `status_filter`, `media_buy_ids`, `request_params`).
+- BDD step refactors — `bbbcda5`, `d2f1474`, `c5ef5c1`, `9c2fc60`, `c7a1527`, `1629369`, `f89201c` (helper extractions, webhook step move, shared error message, B905 zip fix).
+- `c05aa70`, `f4aa3ad` — Replace SUSPECT `auth_setup_mode` tests with endpoint-level coverage.
+
+**Out of scope (not recorded):** dependency and security version bumps — authlib, aiohttp, uv, mako, python-multipart, urllib3 ([#1385](https://github.com/prebid/salesagent/pull/1385), [#1375](https://github.com/prebid/salesagent/pull/1375), [#1298](https://github.com/prebid/salesagent/pull/1298) and folded-in bumps).

--- a/docs/releases/1.8.0.md
+++ b/docs/releases/1.8.0.md
@@ -39,8 +39,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 - MCP/A2A wrappers move from `Any`/`dict` to SDK Pydantic types with `Field(description=...)`, enforced by three new structural guards.
 - `_update_media_buy_impl` gains state-machine enforcement via `valid_actions_for_status`; status splits into `pending_start` vs `pending_creatives`. No Alembic migration in this PR.
 
-<sub>Verified against the final diff.</sub>
-
 ### Replace buyer_ref with media_buy_id and idempotency-keyed dedup (adcp 3.12)
 
 [`#1217`](https://github.com/prebid/salesagent/pull/1217) · AdCP protocol & schema · **T1** · `breaking` `schema` `migration` `wire`
@@ -64,8 +62,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 - Format filtering/sorting is now structural via `asset_types`; `BrandManifest`→`Brand` extracts localized names; `DeliverTo` is flattened into `GetSignalsRequest`.
 - Migrations: `d40df2c92316` (add idempotency_key), `cf421634d3c8` (drop buyer_ref), `b4e2bffdd4f8` (data migration + `server_default` change; two-parent down_revision merges divergent alembic heads).
 
-<sub>Verified against the final diff.</sub>
-
 ### Round-trip property_list and collection_list on media buys
 
 [`#1276`](https://github.com/prebid/salesagent/pull/1276) · AdCP protocol & schema · **T2** · `schema` `wire`
@@ -85,8 +81,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 - `property_list` enforcement in `services/targeting_capabilities.py`: create/update reject `property_targeting_allowed=False` products (even in dry-run); success envelopes gain an `errors: list[Error]` field.
 - `_update_media_buy_impl` is wrapped with `ContextManager.fail_workflow_step_for_exception`, writing spec-shaped `errors[]` into `response_data` so async push subscribers get the same envelope as sync callers; create's overlay validators now run on update; `MediaBuyUoW` gains a products repository.
 
-<sub>Verified against the final diff.</sub>
-
 ### Add push_notification_config to GetProductsRequest
 
 [`#1393`](https://github.com/prebid/salesagent/pull/1393) · AdCP protocol & schema · **T2** · `schema`
@@ -98,8 +92,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 
 **🛠 Engineering**
 - Optional `push_notification_config: LibraryPushNotificationConfig | None` on `GetProductsRequest` (`src/core/schemas/product.py`), over the `GetProductsWholesaleRequest` base; `test_adcp_contract.py` adds it to `local_extensions`. No impl/tool wiring (`git grep` confirms).
-
-<sub>Verified against the final diff.</sub>
 
 ### Remove invoice_recipient from UpdateMediaBuyRequest
 
@@ -115,8 +107,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 **🛠 Engineering**
 - Field + docstring removed from `UpdateMediaBuyRequest` (`src/core/schemas/_base.py`); zero `invoice_recipient` references remain in `src/`; the gap is parked in `test_pydantic_schema_alignment.py` known-mismatches. An unrelated aiohttp floor bump rode along in the same commit.
 
-<sub>Verified against the final diff.</sub>
-
 ### Correct AdCP spec-version citations in docs and comments
 
 [`#1356`](https://github.com/prebid/salesagent/pull/1356) · AdCP protocol & schema · **T3**
@@ -128,8 +118,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 
 **🛠 Engineering**
 - 16 citation edits across `docs/`, `media_buy_update.py`, `targeting_capabilities.py`, `schemas/_base.py`, `adapters/gam/managers/targeting.py`, and tests; the three enums switch to `StrEnum` in `schemas/_base.py`. A follow-up commit re-wraps a comment to keep a line-keyed guard allowlist stable.
-
-<sub>Verified against the final diff.</sub>
 
 ---
 
@@ -155,8 +143,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 - New core primitives — `async_utils.pin_task`, `thread_registry.ThreadRegistry`, `lifecycle.register_shutdown` / `run_all_shutdown_callbacks` — adopted across background services, the delivery simulator, and the GAM reporting manager.
 - `schemas/delivery.py` adds `GeoBreakdown` and the new request fields; `Account.model_dump` always includes `advertiser`/`rate_card`/`payment_terms`. No migration.
 
-<sub>Verified against the final diff.</sub>
-
 ---
 
 ## 🎨 Creatives
@@ -180,8 +166,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 - `_persist_adapter_package_ids()` now writes `platform_order_id` to all packages whenever the adapter returns a `media_buy_id` (previously only `platform_line_item_id`, and only when supplied).
 - `_build_adapter_asset_from_creative()` consolidates creative→adapter-asset construction across three call sites; the raw-MediaPackage-select guard allowlist shrank by one.
 
-<sub>Verified against the final diff.</sub>
-
 ### Apply spec-compliant account and assignment forms in A2A sync_creatives
 
 [`#1251`](https://github.com/prebid/salesagent/pull/1251) · Creatives · **T2**
@@ -198,8 +182,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 - `_handle_sync_creatives_skill` wraps the dict with `LibraryAccountReference.model_validate()` before forwarding (`adcp_a2a_server.py`).
 - `_process_assignments` (`creatives/_assignments.py`) now accepts `dict | list | None` and normalises list-form input; dict-form, `None`, and already-typed `AccountReference` inputs are unchanged.
 
-<sub>Verified against the final diff.</sub>
-
 ### Forward creative-format filters consistently across MCP and A2A
 
 [`#1331`](https://github.com/prebid/salesagent/pull/1331) · Creatives · **T2** · `wire`
@@ -211,8 +193,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 
 **🛠 Engineering**
 - New `build_list_creative_formats_request()` in `creative_formats.py`; the MCP `list_creative_formats` wrapper and A2A `_handle_list_creative_formats_skill` both call it, reaching the shared `_list_creative_formats_impl`. Removes the now-passing MCP xfails for these filters (only `disclosure_positions` remains).
-
-<sub>Verified against the final diff.</sub>
 
 ---
 
@@ -238,8 +218,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 - Adds composite index `idx_gam_inventory_tenant_type_status` on `(tenant_id, inventory_type, status)` (migration `13b5e73b6983` + matching ORM `Index`); two empty merge-head migrations reconcile divergent chains.
 - Shared `initInventoryTree(config)` in `templates/partials/hierarchical_tree_scripts.html` exposes `{search, expandAll, collapseAll, getSelectedIds, refresh}` with `onSelect`/`onRender`/`onStatsLoaded` callbacks; ~310 lines of dead JS removed from `add_product_gam.html`.
 
-<sub>Verified against the final diff.</sub>
-
 ### GAM test-connection reports failure when no network is reachable
 
 [`#1219`](https://github.com/prebid/salesagent/pull/1219) · Google Ad Manager · **T2**
@@ -254,8 +232,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 **🛠 Engineering**
 - `test_gam_connection` (`src/admin/blueprints/gam.py`) captures the swallowed `getCurrentNetwork`/`getAllNetworks` error and returns a failure result when `networks` is empty, with a service-account-specific hint.
 
-<sub>Verified against the final diff.</sub>
-
 ### Correct GAM service-account authorization instructions
 
 [`#1218`](https://github.com/prebid/salesagent/pull/1218) · Google Ad Manager · **T3**
@@ -266,8 +242,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 
 **🛠 Engineering**
 - Prose, template, and JS-string edits across `docs/adapters/gam/service-account-setup.md`, `templates/tenant_settings.html`, the GAM connection-config template, and `static/js/tenant_settings.js`. No logic change.
-
-<sub>Verified against the final diff.</sub>
 
 ---
 
@@ -286,8 +260,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 **🛠 Engineering**
 - New `ensure_selection_type()` in `src/core/helpers/publisher_property_helpers.py`, called from both branches of `Product.effective_properties` (`models.py`); reaches `get_products` via `product_conversion.py`. Normalization is on-read — no migration, no schema/model change. Most of the diff is tests; two unrelated dependency bumps rode along in merge.
 
-<sub>Verified against the final diff.</sub>
-
 ### Decompose the property discovery service and delete dead code
 
 [`#1206`](https://github.com/prebid/salesagent/pull/1206) · Inventory & property discovery · **T3**
@@ -300,8 +272,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 **🛠 Engineering**
 - Extracts `_make_stats`/`_log_fetch_error`/`_extract_properties`/`_filter_properties_by_domain`/`_finalize_session` plus `_batch_sync_properties`/`_batch_sync_tags` in `property_discovery_service.py`; hoists `hashlib`/`re`/`Select` to module top; updates the `no_raw_select` guard allowlist (net −1). Public methods and return shape unchanged.
 
-<sub>Verified against the final diff.</sub>
-
 ### Match publisher domains across www/m/mobile prefixes
 
 [`#1207`](https://github.com/prebid/salesagent/pull/1207) · Inventory & property discovery · **T3**
@@ -313,8 +283,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 
 **🛠 Engineering**
 - `_normalize_domain()` + `_domains_match()` in `property_discovery_service.py`; `_filter_properties_by_domain` swaps the exact `in` check for the normalized comparison. Adds a 15-case unit test.
-
-<sub>Verified against the final diff.</sub>
 
 ---
 
@@ -338,8 +306,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 - Decrypt getters in `models.py` raise the new `AdCPConfigurationError` (`exceptions.py`, code `CONFIGURATION_ERROR`); `mock_ad_server.py` `.formats`→`.format_ids`; `gam_reporting_service.py` zero-row filter narrowed; `google_ad_manager.py`/`xandr.py` use `dateutil` for API dates; `background_sync_service.py` loads creds via `from_service_account_info(dict)`.
 - New guard `tests/unit/test_architecture_no_silent_except.py` (empty allowlist); an `authlib` security bump and `types-python-dateutil` rode along.
 
-<sub>Verified against the final diff.</sub>
-
 ### Memory-leak triage: session shutdown, dead-thread reapers, task pinning
 
 [`#1264`](https://github.com/prebid/salesagent/pull/1264) · Reliability · **T3**
@@ -352,8 +318,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 
 **🛠 Engineering**
 - `app_lifespan` shutdown hook in `src/app.py`; a `_pending_webhook_tasks` strong-ref set in `context_manager.py`; an identical `_reap_dead_*()` helper added to each of the three services' accessors under the existing lock. A `run_all_tests.sh` exit-code fix rode along. (The per-service reapers were later consolidated into a shared `ThreadRegistry` in #1334.)
-
-<sub>Verified against the final diff.</sub>
 
 ---
 
@@ -379,8 +343,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 - New `tenants.supported_billing` (JSONType) and `account_approval_mode` (String(50)) in `models.py`; read via `TenantContext.from_orm_model`, surfaced in `serialize_tenant_to_dict`; `_sync_accounts_impl`/`_check_billing_policy` (`accounts.py`) read `identity.tenant` instead of removed `ResolvedIdentity` fields.
 - Migrations `4ccbe6f82b4b` (supported_billing + created_at/updated_at `server_default`) and `c612d0326eb0` (account_approval_mode), both with real downgrades. No admin UI in this PR.
 
-<sub>Verified against the final diff.</sub>
-
 ---
 
 ## 🧪 Test suite (BDD & harness)
@@ -404,8 +366,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 - Production delta is ~36 `src/` files (+346/-149; the +45k headline is mostly merge-from-main churn): new `AdCPAuthRequiredError`/`_StructuredValidationError`; REST filter forwarding; `list_media_buys` status-filter fix; tenant-scoped `get_principal_object`; attribution-window echo; SDK imports migrated `generated_poc.*`→`adcp.types` (~92 files).
 - Migrations: `529ae3fa444b` (`server_default now()` across ~20 tables) plus two empty head-merge migrations.
 
-<sub>Verified against the final diff.</sub>
-
 ### Implement MediaBuyCreateEnv test-harness setup helpers
 
 [`#1382`](https://github.com/prebid/salesagent/pull/1382) · Test suite (BDD & harness) · **T3**
@@ -416,8 +376,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 
 **🛠 Engineering**
 - `setup_product_chain()` and `_build_mock_context_manager()` in `tests/harness/media_buy_create.py`; an integration smoke test and a unit method-presence guard. A pyjwt floor bump rode along.
-
-<sub>Verified against the final diff.</sub>
 
 ### Implement empty BDD Given step bodies
 
@@ -431,8 +389,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 **🛠 Engineering**
 - `given_tenant_exists` calls a new `env._ensure_tenant_for_id`; a dual-decorator step splits into `given_account_id_not_found`/`given_natural_key_not_found` driving `env.call_impl`; `_EMPTY_GIVEN_WHEN_ALLOWLIST` is emptied. Production change: a `PermissionError`→`InvalidRequestError` handler in `_handle_explicit_skill` (`adcp_a2a_server.py`).
 
-<sub>Verified against the final diff.</sub>
-
 ### Remove stale strict xfails on get-products schema drift
 
 [`#1336`](https://github.com/prebid/salesagent/pull/1336) · Test suite (BDD & harness) · **T3**
@@ -443,8 +399,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 
 **🛠 Engineering**
 - Drops the conditional strict-xfail in `test_pydantic_schema_alignment.py` and the `test_offline_mode` xfail in `test_schema_validation_standalone.py`; the underlying library-modeling gap (#1308) stays open and allowlisted.
-
-<sub>Verified against the final diff.</sub>
 
 ---
 
@@ -465,8 +419,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 **🛠 Engineering**
 - `bdd-tests-shard` matrix + `if: always()` aggregate in `ci.yml`; `scripts/ci/shard_split.py` / `shard_paths.py`; the Coverage job requires all per-shard `.coverage.bdd-N` files; `migration_roundtrip.py` now asserts alembic heads after up/down/up; new guard `test_architecture_ci_bdd_shard_manifest.py`.
 
-<sub>Verified against the final diff.</sub>
-
 ### Move CI helpers into scripts/ci and tighten guards
 
 [`#1424`](https://github.com/prebid/salesagent/pull/1424) · CI & build · **T3**
@@ -479,8 +431,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 **🛠 Engineering**
 - `git mv` of the two helper modules (real renames + edits); `check_migration_completeness.py` imports the shared helper and raises `MigrationParseError` instead of swallowing; `port_scan_start` now raises `TypeError` on a non-int pid (test-facing). Minor NIT in merged code: a duplicated `@pytest.mark.arch_guard` decorator on one guard test.
 
-<sub>Verified against the final diff.</sub>
-
 ### Authenticate pinact with GITHUB_TOKEN
 
 [`#1344`](https://github.com/prebid/salesagent/pull/1344) · CI & build · **T3**
@@ -491,8 +441,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 
 **🛠 Engineering**
 - Adds `env: GITHUB_TOKEN` to the pinact step in `.github/workflows/security.yml` (+2/-0).
-
-<sub>Verified against the final diff.</sub>
 
 ---
 
@@ -509,8 +457,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 **🛠 Engineering**
 - Single-line template change in the Branding section of `templates/tenant_settings.html`.
 
-<sub>Verified against the final diff.</sub>
-
 ### Replace broken auth-setup guide link
 
 [`#1253`](https://github.com/prebid/salesagent/pull/1253) · Admin UI & maintenance · **T3**
@@ -521,8 +467,6 @@ parent change, never as a bump entry. Atomic single-commit changes are collected
 
 **🛠 Engineering**
 - Two `href` swaps in `templates/login.html`.
-
-<sub>Verified against the final diff.</sub>
 
 ---
 

--- a/docs/releases/2.0.0.md
+++ b/docs/releases/2.0.0.md
@@ -1,6 +1,6 @@
-# Release 1.8.0 — change records
+# Release 2.0.0 — change records
 
-A readable, accurate account of everything that shipped in 1.8.0, reconstructed from the final
+A readable, accurate account of everything that shipped in 2.0.0, reconstructed from the final
 merged code. Each entry leads with the impact, lays out what changed and why it matters, and
 ends with an engineering breakout for the people maintaining the code.
 

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -1,0 +1,39 @@
+# Release notes
+
+Human-readable, audience-framed notes for each release. These complement the
+auto-generated [`CHANGELOG.md`](../../CHANGELOG.md) (produced by release-please from
+conventional commits): the changelog is the complete commit-level record; these notes
+explain what actually shipped and why it matters.
+
+## Convention
+
+- One file per release: `docs/releases/<MAJOR.MINOR.PATCH>.md` (e.g. `1.8.0.md`).
+- Notes are reconstructed from the **final merged diffs**, not PR titles or descriptions
+  (which drift as scope grows during review).
+- Dependency and security version bumps are out of scope; a consequential security fix is
+  covered under its parent change.
+
+## Entry format
+
+Each PR or notable commit gets:
+
+- A byline: `[#PR] · area · tier · flags`
+  - **tier** — `T1` headline (user/integrator-visible) · `T2` notable · `T3` internal
+  - **flags** — `breaking` · `schema` · `migration` · `wire` (omit when none)
+- An italic 2–3 sentence lead summarizing what shipped.
+- Bold-lead bullets for the specifics.
+- A callout where a reader needs a stop-and-read flag (most entries have none):
+  - `> [!WARNING]` **Breaking change** — existing usage stops working
+  - `> [!IMPORTANT]` **Migration / operational** — something to run or set when deploying
+  - `> [!NOTE]` **Behavioral change** — runtime behavior shifts without breaking the contract
+- A `🛠 Engineering` breakout with the implementation detail.
+
+Group entries by area (AdCP protocol & schema, Delivery & reporting, Creatives, GAM,
+Inventory & property discovery, Reliability, Tenant configuration, Test suite, CI & build,
+Admin UI & maintenance). Atomic single-commit changes go in an appendix.
+
+## Voice
+
+Factual and neutral. State what changed and its concrete effect. No marketing adjectives,
+no self-congratulation, no editorializing. Where significance matters, state it as a fact
+(e.g. a spec version), not a claim.

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -7,7 +7,7 @@ explain what actually shipped and why it matters.
 
 ## Convention
 
-- One file per release: `docs/releases/<MAJOR.MINOR.PATCH>.md` (e.g. `1.8.0.md`).
+- One file per release: `docs/releases/<MAJOR.MINOR.PATCH>.md` (e.g. `2.0.0.md`).
 - Notes are reconstructed from the **final merged diffs**, not PR titles or descriptions
   (which drift as scope grows during review).
 - Dependency and security version bumps are out of scope; a consequential security fix is


### PR DESCRIPTION
## Summary

Adds a human-readable home for release notes under `docs/releases/`, complementing the auto-generated `CHANGELOG.md`.

- `docs/releases/2.0.0.md` — notes for the 2.0.0 release, reconstructed from the **final merged diffs** of each in-scope PR (not the original PR titles, which drifted as scope grew during review). Grouped by area, ranked by impact (T1/T2/T3), with breaking / migration / behavioral callouts. Every PR in the `v1.7.0..main` window is accounted for — as a record, an appendix entry, or the out-of-scope dependency note.
- `docs/releases/README.md` — the convention and template so future releases follow the same shape and voice.

Draft for review of structure, voice, and convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)