### PR TITLE
refactor(test): adopt iter_call_expressions in architecture guards (Pattern 1b, #1234)

### DIFF
--- a/tests/unit/_architecture_helpers.py
+++ b/tests/unit/_architecture_helpers.py
@@ -161,7 +161,7 @@ def find_plain_json_column_violations(tree: ast.Module) -> list[int]:
     return lines
 
 
-def iter_call_expressions(tree: ast.Module, name: str | None = None) -> Iterator[ast.Call]:
+def iter_call_expressions(tree: ast.AST, name: str | None = None) -> Iterator[ast.Call]:
     """Yield Call nodes, optionally filtered by callable name."""
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
@@ -179,16 +179,18 @@ def iter_call_expressions(tree: ast.Module, name: str | None = None) -> Iterator
 def iter_architecture_guard_trees(
     *,
     exempt: Iterable[Path] | None = None,
-) -> Iterator[tuple[Path, ast.Module]]:
-    """Yield ``(repo_relative_path, parsed_tree)`` for each ``test_architecture_*.py`` module."""
+) -> Iterator[tuple[ast.Module, Path]]:
+    """Yield ``(parsed_tree, repo_relative_path)`` for each ``test_architecture_*.py`` module."""
     repo = repo_root()
     skip = set(exempt or ())
     for path in sorted((repo / "tests" / "unit").glob("test_architecture_*.py")):
         rel = path.relative_to(repo)
         if rel in skip:
             continue
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-        yield rel, tree
+        tree = safe_parse(path)
+        if tree is None:
+            continue
+        yield tree, rel
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/_architecture_helpers.py
+++ b/tests/unit/_architecture_helpers.py
@@ -176,6 +176,21 @@ def iter_call_expressions(tree: ast.Module, name: str | None = None) -> Iterator
             yield node
 
 
+def iter_architecture_guard_trees(
+    *,
+    exempt: Iterable[Path] | None = None,
+) -> Iterator[tuple[Path, ast.Module]]:
+    """Yield ``(repo_relative_path, parsed_tree)`` for each ``test_architecture_*.py`` module."""
+    repo = repo_root()
+    skip = set(exempt or ())
+    for path in sorted((repo / "tests" / "unit").glob("test_architecture_*.py")):
+        rel = path.relative_to(repo)
+        if rel in skip:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        yield rel, tree
+
+
 # ---------------------------------------------------------------------------
 # File iteration
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_architecture_a2a_test_uses_factory.py
+++ b/tests/unit/test_architecture_a2a_test_uses_factory.py
@@ -19,6 +19,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.unit._architecture_helpers import iter_call_expressions
+
 
 def _a2a_test_files() -> list[Path]:
     repo_root = Path(__file__).resolve().parents[2]
@@ -31,13 +33,12 @@ def _a2a_test_files() -> list[Path]:
 def _find_resolved_identity_calls(path: Path) -> list[int]:
     tree = ast.parse(path.read_text(), filename=str(path))
     lines: list[int] = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Call):
-            func = node.func
-            if isinstance(func, ast.Name) and func.id == "ResolvedIdentity":
-                lines.append(node.lineno)
-            elif isinstance(func, ast.Attribute) and func.attr == "ResolvedIdentity":
-                lines.append(node.lineno)
+    for node in iter_call_expressions(tree):
+        func = node.func
+        if isinstance(func, ast.Name) and func.id == "ResolvedIdentity":
+            lines.append(node.lineno)
+        elif isinstance(func, ast.Attribute) and func.attr == "ResolvedIdentity":
+            lines.append(node.lineno)
     return lines
 
 

--- a/tests/unit/test_architecture_adapter_raise_site_coverage.py
+++ b/tests/unit/test_architecture_adapter_raise_site_coverage.py
@@ -92,9 +92,7 @@ def collect_pytest_raises_classes() -> set[str]:
         if tree is None:
             continue
         for node in iter_call_expressions(tree, name="raises"):
-            func = node.func
-            is_raises = isinstance(func, ast.Attribute) or isinstance(func, ast.Name)
-            if not is_raises or not node.args:
+            if not node.args:
                 continue
             first = node.args[0]
             candidates = first.elts if isinstance(first, ast.Tuple) else [first]

--- a/tests/unit/test_architecture_adapter_raise_site_coverage.py
+++ b/tests/unit/test_architecture_adapter_raise_site_coverage.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 
 import ast
 
-from tests.unit._architecture_helpers import REPO_ROOT, safe_parse
+from tests.unit._architecture_helpers import REPO_ROOT, iter_call_expressions, safe_parse
 
 # Adapter-raised typed errors with no raise-site ``pytest.raises`` test. MUST stay
 # empty — a new uncovered adapter raise fails the guard immediately. Do not add
@@ -91,13 +91,9 @@ def collect_pytest_raises_classes() -> set[str]:
         tree = safe_parse(filepath)
         if tree is None:
             continue
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
+        for node in iter_call_expressions(tree, name="raises"):
             func = node.func
-            is_raises = (isinstance(func, ast.Attribute) and func.attr == "raises") or (
-                isinstance(func, ast.Name) and func.id == "raises"
-            )
+            is_raises = isinstance(func, ast.Attribute) or isinstance(func, ast.Name)
             if not is_raises or not node.args:
                 continue
             first = node.args[0]

--- a/tests/unit/test_architecture_bdd_no_dict_registry.py
+++ b/tests/unit/test_architecture_bdd_no_dict_registry.py
@@ -16,6 +16,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.unit._architecture_helpers import iter_call_expressions
+
 _BDD_STEPS_DIR = Path(__file__).resolve().parents[1] / "bdd" / "steps"
 
 # Files that contain Given steps populating registry_formats
@@ -53,10 +55,11 @@ def _body_appends_dict_to_registry(func: ast.FunctionDef | ast.AsyncFunctionDef)
                     return True
 
         # .append({...}) or .extend([{...}])
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
-            if node.func.attr in ("append", "extend") and node.args:
-                if _value_contains_dict(node.args[0]):
-                    return True
+        for node in iter_call_expressions(func):
+            if isinstance(node.func, ast.Attribute):
+                if node.func.attr in ("append", "extend") and node.args:
+                    if _value_contains_dict(node.args[0]):
+                        return True
 
     return False
 

--- a/tests/unit/test_architecture_bdd_no_dict_registry.py
+++ b/tests/unit/test_architecture_bdd_no_dict_registry.py
@@ -47,19 +47,19 @@ def _body_appends_dict_to_registry(func: ast.FunctionDef | ast.AsyncFunctionDef)
         ctx.setdefault("registry_formats", []).append({"name": ...})
         ctx.setdefault("registry_formats", []).extend([{"name": ...}])
     """
-    for node in ast.walk(func):
+    for walk_node in ast.walk(func):
         # Assignment: ctx["registry_formats"] = [{...}, ...]
-        if isinstance(node, ast.Assign):
-            for target in node.targets:
-                if _is_registry_formats_access(target) and _value_contains_dict(node.value):
+        if isinstance(walk_node, ast.Assign):
+            for target in walk_node.targets:
+                if _is_registry_formats_access(target) and _value_contains_dict(walk_node.value):
                     return True
 
+    for call_node in iter_call_expressions(func):
         # .append({...}) or .extend([{...}])
-        for node in iter_call_expressions(func):
-            if isinstance(node.func, ast.Attribute):
-                if node.func.attr in ("append", "extend") and node.args:
-                    if _value_contains_dict(node.args[0]):
-                        return True
+        if isinstance(call_node.func, ast.Attribute):
+            if call_node.func.attr in ("append", "extend") and call_node.args:
+                if _value_contains_dict(call_node.args[0]):
+                    return True
 
     return False
 

--- a/tests/unit/test_architecture_bdd_no_direct_call_impl.py
+++ b/tests/unit/test_architecture_bdd_no_direct_call_impl.py
@@ -21,6 +21,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.unit._architecture_helpers import iter_call_expressions
+
 _BDD_STEPS_DIR = Path(__file__).resolve().parents[1] / "bdd" / "steps"
 
 # Functions that legitimately bypass transport dispatch.
@@ -48,14 +50,11 @@ def _is_when_or_given_decorated(func: ast.FunctionDef | ast.AsyncFunctionDef) ->
 
 def _has_direct_impl_call(func: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
     """Check if function body calls .call_impl() or any _impl() function directly."""
-    for node in ast.walk(func):
-        if isinstance(node, ast.Call):
-            # Check for env.call_impl(...)
-            if isinstance(node.func, ast.Attribute) and node.func.attr == "call_impl":
-                return True
-            # Check for _xxx_impl(...)
-            if isinstance(node.func, ast.Name) and node.func.id.endswith("_impl"):
-                return True
+    for node in iter_call_expressions(func):
+        if isinstance(node.func, ast.Attribute) and node.func.attr == "call_impl":
+            return True
+        if isinstance(node.func, ast.Name) and node.func.id.endswith("_impl"):
+            return True
     return False
 
 

--- a/tests/unit/test_architecture_bdd_no_pass_steps.py
+++ b/tests/unit/test_architecture_bdd_no_pass_steps.py
@@ -20,6 +20,8 @@ from typing import Literal
 
 import pytest
 
+from tests.unit._architecture_helpers import iter_call_expressions
+
 _BDD_STEPS_DIR = Path(__file__).resolve().parents[1] / "bdd" / "steps"
 
 # Allowlist for empty Given/When steps. Must only shrink — never add entries.
@@ -85,11 +87,8 @@ def _body_has_assert_or_call(func: ast.FunctionDef | ast.AsyncFunctionDef) -> bo
 
 def _contains_placeholder_call(func: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
     """Check if the function delegates to a known placeholder helper like _pending()."""
-    for node in ast.walk(func):
-        if not isinstance(node, ast.Call):
-            continue
-        if isinstance(node.func, ast.Name) and node.func.id == "_pending":
-            return True
+    for _node in iter_call_expressions(func, name="_pending"):
+        return True
     return False
 
 

--- a/tests/unit/test_architecture_bdd_no_request_in_then.py
+++ b/tests/unit/test_architecture_bdd_no_request_in_then.py
@@ -55,7 +55,7 @@ import ast
 
 import pytest
 
-from tests.unit._architecture_helpers import assert_violations_match_allowlist
+from tests.unit._architecture_helpers import assert_violations_match_allowlist, iter_call_expressions
 from tests.unit._bdd_guard_helpers import iter_then_functions
 
 # ── Dispatch methods that indicate a When action ────────────────────────
@@ -149,10 +149,7 @@ def _find_dispatch_call(
     ``dispatch_request(...)``, and ``client.post(...)`` — all of which
     perform actions rather than verify outcomes.
     """
-    for node in ast.walk(func):
-        if not isinstance(node, ast.Call):
-            continue
-        # method call: obj.method(...)
+    for node in iter_call_expressions(func):  # method call: obj.method(...)
         if isinstance(node.func, ast.Attribute):
             if node.func.attr in _DISPATCH_METHODS:
                 return True

--- a/tests/unit/test_architecture_bdd_no_silent_env.py
+++ b/tests/unit/test_architecture_bdd_no_silent_env.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.unit._architecture_helpers import assert_violations_match_allowlist
+from tests.unit._architecture_helpers import assert_violations_match_allowlist, iter_call_expressions
 
 _BDD_STEPS_DIR = Path(__file__).resolve().parents[1] / "bdd" / "steps"
 
@@ -50,11 +50,9 @@ def _is_step_decorated(func: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
 
 def _has_ctx_get_env(func: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
     """Check if function calls ctx.get("env")."""
-    for node in ast.walk(func):
+    for node in iter_call_expressions(func, name="get"):
         if (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Attribute)
-            and node.func.attr == "get"
+            isinstance(node.func, ast.Attribute)
             and isinstance(node.func.value, ast.Name)
             and node.func.value.id == "ctx"
             and node.args
@@ -67,15 +65,8 @@ def _has_ctx_get_env(func: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
 
 def _has_hasattr_env(func: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
     """Check if function calls hasattr(env, ...)."""
-    for node in ast.walk(func):
-        if (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id == "hasattr"
-            and len(node.args) >= 1
-            and isinstance(node.args[0], ast.Name)
-            and node.args[0].id == "env"
-        ):
+    for node in iter_call_expressions(func, name="hasattr"):
+        if len(node.args) >= 1 and isinstance(node.args[0], ast.Name) and node.args[0].id == "env":
             return True
     return False
 

--- a/tests/unit/test_architecture_bdd_no_trivial_assertions.py
+++ b/tests/unit/test_architecture_bdd_no_trivial_assertions.py
@@ -24,6 +24,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.unit._architecture_helpers import iter_call_expressions
+
 _BDD_STEPS_DIR = Path(__file__).resolve().parents[1] / "bdd" / "steps"
 
 
@@ -83,32 +85,31 @@ def _has_meaningful_assertion_or_delegation(func: ast.FunctionDef | ast.AsyncFun
             has_any_assert = True
             if _assert_is_meaningful(node):
                 return True
-        # Function call (delegation to helper) counts as meaningful
-        if isinstance(node, ast.Call):
-            func_node = node.func
-            # Placeholder helpers do not implement assertions.
-            if isinstance(func_node, ast.Name) and func_node.id == "_pending":
-                continue
-            # Exclude ctx.get(), ctx.setdefault() etc — these are data access, not assertions
-            if isinstance(func_node, ast.Attribute) and isinstance(func_node.value, ast.Name):
-                if func_node.value.id == "ctx":
-                    continue
-            # Exclude getattr, str, type, etc — builtins used for data extraction
-            if isinstance(func_node, ast.Name) and func_node.id in (
-                "getattr",
-                "str",
-                "type",
-                "len",
-                "list",
-                "dict",
-                "set",
-                "print",
-            ):
-                continue
-            return True
-        # Raise counts as meaningful (explicit failure path)
         if isinstance(node, ast.Raise):
             return True
+
+    for node in iter_call_expressions(func):
+        func_node = node.func
+        # Placeholder helpers do not implement assertions.
+        if isinstance(func_node, ast.Name) and func_node.id == "_pending":
+            continue
+        # Exclude ctx.get(), ctx.setdefault() etc — these are data access, not assertions
+        if isinstance(func_node, ast.Attribute) and isinstance(func_node.value, ast.Name):
+            if func_node.value.id == "ctx":
+                continue
+        # Exclude getattr, str, type, etc — builtins used for data extraction
+        if isinstance(func_node, ast.Name) and func_node.id in (
+            "getattr",
+            "str",
+            "type",
+            "len",
+            "list",
+            "dict",
+            "set",
+            "print",
+        ):
+            continue
+        return True
 
     # If we found asserts but none were meaningful, it's trivial
     if has_any_assert:

--- a/tests/unit/test_architecture_behavioral_mock_cap.py
+++ b/tests/unit/test_architecture_behavioral_mock_cap.py
@@ -28,6 +28,8 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+from tests.unit._architecture_helpers import iter_call_expressions
+
 # Per-file cap on hand-rolled mock constructions in behavioral test files.
 # Frozen at the current count; can only shrink. New behavioral files with mock
 # constructions fail immediately (force a deliberate cap entry or harness use).
@@ -70,13 +72,12 @@ def _count_mock_constructions(filepath: Path) -> list[int]:
     except (OSError, SyntaxError):
         return []
     lines: list[int] = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Call):
-            func = node.func
-            if isinstance(func, ast.Name) and func.id in _MOCK_CALLABLES:
-                lines.append(node.lineno)
-            elif isinstance(func, ast.Attribute) and func.attr in _MOCK_CALLABLES:
-                lines.append(node.lineno)
+    for node in iter_call_expressions(tree):
+        func = node.func
+        if isinstance(func, ast.Name) and func.id in _MOCK_CALLABLES:
+            lines.append(node.lineno)
+        elif isinstance(func, ast.Attribute) and func.attr in _MOCK_CALLABLES:
+            lines.append(node.lineno)
     return lines
 
 

--- a/tests/unit/test_architecture_boundary_completeness.py
+++ b/tests/unit/test_architecture_boundary_completeness.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.unit._architecture_helpers import assert_violations_match_allowlist
+from tests.unit._architecture_helpers import assert_violations_match_allowlist, iter_call_expressions
 
 TOOLS_DIR = Path("src/core/tools")
 
@@ -124,10 +124,7 @@ def _find_impl_call_args_in_function(file_path: Path, wrapper_name: str, impl_na
 
     # Find _impl calls within the wrapper function body
     results = []
-    for node in ast.walk(wrapper_node):
-        if not isinstance(node, ast.Call):
-            continue
-
+    for node in iter_call_expressions(wrapper_node):
         func = node.func
         called_name = None
         if isinstance(func, ast.Name):

--- a/tests/unit/test_architecture_capability_constant_parity.py
+++ b/tests/unit/test_architecture_capability_constant_parity.py
@@ -17,6 +17,8 @@ The non-AST-detectable slice (one invariant computed two ways) stays a review co
 import ast
 from pathlib import Path
 
+from tests.unit._architecture_helpers import iter_call_expressions
+
 # Capability keywords whose value must be derived from an enforced constant, not a literal.
 _DERIVED_CAPABILITY_KEYWORDS = {"replay_ttl_seconds"}
 
@@ -25,9 +27,7 @@ def _literal_capability_sites_in(source: str) -> list[str]:
     """Return ``keyword@line`` for capability keywords assigned a bare numeric literal."""
     tree = ast.parse(source)
     out: list[str] = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
+    for node in iter_call_expressions(tree):
         for kw in node.keywords:
             if (
                 kw.arg in _DERIVED_CAPABILITY_KEYWORDS

--- a/tests/unit/test_architecture_error_code_compliance.py
+++ b/tests/unit/test_architecture_error_code_compliance.py
@@ -43,6 +43,7 @@ _SCAN_DIRS = [
 
 
 from tests.unit._architecture_helpers import collect_error_aliases as _collect_error_aliases  # noqa: E402
+from tests.unit._architecture_helpers import iter_call_expressions  # noqa: E402
 
 
 def _collect_error_code_literals() -> list[tuple[str, int, str]]:
@@ -65,10 +66,7 @@ def _collect_error_code_literals() -> list[tuple[str, int, str]]:
 
             error_aliases = _collect_error_aliases(tree)
 
-            for node in ast.walk(tree):
-                if not isinstance(node, ast.Call):
-                    continue
-                # Match calls to Error(...) / <alias>(...) / adcp.types.Error(...)
+            for node in iter_call_expressions(tree):  # Match calls to Error(...) / <alias>(...) / adcp.types.Error(...)
                 func = node.func
                 matched = False
                 if isinstance(func, ast.Name) and func.id in error_aliases:

--- a/tests/unit/test_architecture_error_envelope_two_layer.py
+++ b/tests/unit/test_architecture_error_envelope_two_layer.py
@@ -24,6 +24,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.unit._architecture_helpers import iter_call_expressions
+
 # Anchor scan paths on this file's location so guards work regardless of pytest's
 # working directory (CI runs from repo root; agents/IDEs may launch from a subdir).
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -70,9 +72,7 @@ def _body_contains_builder_call(
     defeating the guard without weakening its actual intent — every boundary's
     wire response must reach the builder somewhere in its call chain.
     """
-    for child in ast.walk(body_node):
-        if not isinstance(child, ast.Call):
-            continue
+    for child in iter_call_expressions(body_node):
         f = child.func
         if isinstance(f, ast.Name) and f.id == ENVELOPE_BUILDER:
             return True

--- a/tests/unit/test_architecture_helpers_contract.py
+++ b/tests/unit/test_architecture_helpers_contract.py
@@ -45,6 +45,13 @@ def test_iter_call_expressions_filters_by_name() -> None:
 
 
 @pytest.mark.arch_guard
+def test_iter_call_expressions_name_matches_bare_and_attribute() -> None:
+    tree = ast.parse("h()\nx.h()")
+    h_calls = list(iter_call_expressions(tree, name="h"))
+    assert len(h_calls) == 2
+
+
+@pytest.mark.arch_guard
 def test_iter_call_expressions_subtree_scope() -> None:
     tree = ast.parse(_ITER_CALL_SOURCE)
     inner_func = next(node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef))

--- a/tests/unit/test_architecture_helpers_contract.py
+++ b/tests/unit/test_architecture_helpers_contract.py
@@ -2,11 +2,56 @@
 
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 
 import pytest
 
-from tests.unit._architecture_helpers import assert_anchor_consistency, assert_violations_match_allowlist
+from tests.unit._architecture_helpers import (
+    assert_anchor_consistency,
+    assert_violations_match_allowlist,
+    iter_call_expressions,
+)
+
+_ITER_CALL_SOURCE = """
+f()
+g.h()
+other.i()
+
+def inner():
+    inner_call()
+"""
+
+
+@pytest.mark.arch_guard
+def test_iter_call_expressions_yields_all_calls_unfiltered() -> None:
+    tree = ast.parse(_ITER_CALL_SOURCE)
+    calls = list(iter_call_expressions(tree))
+    assert len(calls) == 4
+
+
+@pytest.mark.arch_guard
+def test_iter_call_expressions_filters_by_name() -> None:
+    tree = ast.parse(_ITER_CALL_SOURCE)
+    f_calls = list(iter_call_expressions(tree, name="f"))
+    assert len(f_calls) == 1
+    assert isinstance(f_calls[0].func, ast.Name)
+    assert f_calls[0].func.id == "f"
+
+    h_calls = list(iter_call_expressions(tree, name="h"))
+    assert len(h_calls) == 1
+    assert isinstance(h_calls[0].func, ast.Attribute)
+    assert h_calls[0].func.attr == "h"
+
+
+@pytest.mark.arch_guard
+def test_iter_call_expressions_subtree_scope() -> None:
+    tree = ast.parse(_ITER_CALL_SOURCE)
+    inner_func = next(node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef))
+    calls = list(iter_call_expressions(inner_func))
+    assert len(calls) == 1
+    assert isinstance(calls[0].func, ast.Name)
+    assert calls[0].func.id == "inner_call"
 
 
 @pytest.mark.arch_guard

--- a/tests/unit/test_architecture_migration_completeness.py
+++ b/tests/unit/test_architecture_migration_completeness.py
@@ -24,6 +24,7 @@ from scripts.ci.migration_helpers import (
     iter_migration_trees,
     parse_function,
 )
+from tests.unit._architecture_helpers import iter_call_expressions
 
 # Alembic operations that modify schema structure
 SCHEMA_OPS = {
@@ -63,9 +64,7 @@ KNOWN_DOWNGRADE_COVERAGE_GAPS = {
 def _extract_table_names(node: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
     """Extract table names referenced in op.XXX() calls."""
     tables = set()
-    for child in ast.walk(node):
-        if not isinstance(child, ast.Call):
-            continue
+    for child in iter_call_expressions(node):
         func = child.func
         if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
             if func.value.id == "op" and func.attr in SCHEMA_OPS:

--- a/tests/unit/test_architecture_no_error_code_kwarg_in_impl.py
+++ b/tests/unit/test_architecture_no_error_code_kwarg_in_impl.py
@@ -16,7 +16,7 @@ import ast
 from collections.abc import Iterator
 from pathlib import Path
 
-from tests.unit._architecture_helpers import assert_violations_match_allowlist
+from tests.unit._architecture_helpers import assert_violations_match_allowlist, iter_call_expressions
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCAN_DIRS = [REPO_ROOT / "src" / "core", REPO_ROOT / "src" / "adapters"]
@@ -70,8 +70,8 @@ def _iter_adcp_error_calls() -> Iterator[tuple[str, str, ast.Call]]:
             for node in ast.walk(tree):
                 if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                     continue
-                for child in ast.walk(node):
-                    if isinstance(child, ast.Call) and _func_targets_adcp_error_or_synthesize(child.func):
+                for child in iter_call_expressions(node):
+                    if _func_targets_adcp_error_or_synthesize(child.func):
                         yield rel_path, node.name, child
 
 

--- a/tests/unit/test_architecture_no_error_construction_in_impl.py
+++ b/tests/unit/test_architecture_no_error_construction_in_impl.py
@@ -39,7 +39,7 @@ PATTERN_A_PER_FILE_CAP: dict[str, int] = {}
 
 _SKIP_MARKER = "# structural-guard:"
 
-from tests.unit._architecture_helpers import REPO_ROOT, SCAN_DIRS, safe_parse
+from tests.unit._architecture_helpers import REPO_ROOT, SCAN_DIRS, iter_call_expressions, safe_parse
 from tests.unit._architecture_helpers import rel as _rel
 
 
@@ -59,9 +59,7 @@ def _count_pattern_a_sites(filepath: Path) -> list[int]:
     source_lines = filepath.read_text().splitlines()
     aliases = collect_error_aliases(tree)
     lines: list[int] = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
+    for node in iter_call_expressions(tree):
         func = node.func
         matched = False
         if isinstance(func, ast.Name) and func.id in aliases:

--- a/tests/unit/test_architecture_no_handrolled_allowlist_diff.py
+++ b/tests/unit/test_architecture_no_handrolled_allowlist_diff.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.unit._architecture_helpers import repo_root
+from tests.unit._architecture_helpers import iter_architecture_guard_trees, repo_root
 
 _EXEMPT = {
     Path("tests/unit/_architecture_helpers.py"),
@@ -52,14 +52,8 @@ def _assigns_handrolled_allowlist_diff(node: ast.AST) -> bool:
 
 
 def _find_handrolled_allowlist_diffs() -> list[str]:
-    repo = repo_root()
     violations: list[str] = []
-    for path in sorted((repo / "tests" / "unit").glob("test_architecture_*.py")):
-        rel = path.relative_to(repo)
-        if rel in _EXEMPT:
-            continue
-        source = path.read_text(encoding="utf-8")
-        tree = ast.parse(source, filename=str(path))
+    for rel, tree in iter_architecture_guard_trees(exempt=_EXEMPT):
         for node in ast.walk(tree):
             if _assigns_handrolled_allowlist_diff(node):
                 lineno = getattr(node, "lineno", "?")
@@ -68,11 +62,8 @@ def _find_handrolled_allowlist_diffs() -> list[str]:
 
 
 def _find_ast_helpers_imports() -> list[str]:
-    repo = repo_root()
     violations: list[str] = []
-    for path in sorted((repo / "tests" / "unit").glob("test_architecture_*.py")):
-        rel = path.relative_to(repo)
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for rel, tree in iter_architecture_guard_trees():
         for node in ast.walk(tree):
             if isinstance(node, ast.ImportFrom) and node.module == "tests.unit._ast_helpers":
                 violations.append(f"{rel}:{node.lineno}: imports tests.unit._ast_helpers")

--- a/tests/unit/test_architecture_no_handrolled_allowlist_diff.py
+++ b/tests/unit/test_architecture_no_handrolled_allowlist_diff.py
@@ -53,7 +53,7 @@ def _assigns_handrolled_allowlist_diff(node: ast.AST) -> bool:
 
 def _find_handrolled_allowlist_diffs() -> list[str]:
     violations: list[str] = []
-    for rel, tree in iter_architecture_guard_trees(exempt=_EXEMPT):
+    for tree, rel in iter_architecture_guard_trees(exempt=_EXEMPT):
         for node in ast.walk(tree):
             if _assigns_handrolled_allowlist_diff(node):
                 lineno = getattr(node, "lineno", "?")
@@ -63,7 +63,7 @@ def _find_handrolled_allowlist_diffs() -> list[str]:
 
 def _find_ast_helpers_imports() -> list[str]:
     violations: list[str] = []
-    for rel, tree in iter_architecture_guard_trees():
+    for tree, rel in iter_architecture_guard_trees():
         for node in ast.walk(tree):
             if isinstance(node, ast.ImportFrom) and node.module == "tests.unit._ast_helpers":
                 violations.append(f"{rel}:{node.lineno}: imports tests.unit._ast_helpers")

--- a/tests/unit/test_architecture_no_handrolled_call_walk.py
+++ b/tests/unit/test_architecture_no_handrolled_call_walk.py
@@ -1,0 +1,183 @@
+"""Guard: Call-detection loops must use iter_call_expressions.
+
+Hand-rolled ``for node in ast.walk(...): if not isinstance(node, ast.Call)``
+loops duplicate the helper and drift when one copy is updated. All guard
+Call-detection loops route through ``tests.unit._architecture_helpers.iter_call_expressions``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from tests.unit._architecture_helpers import iter_architecture_guard_trees, repo_root
+
+_EXEMPT = {
+    Path("tests/unit/_architecture_helpers.py"),
+    Path("tests/unit/test_architecture_helpers_contract.py"),
+    Path("tests/unit/test_architecture_no_handrolled_call_walk.py"),
+}
+
+
+def _is_ast_walk_iter(for_node: ast.For) -> bool:
+    """True when the For loop iterates ``ast.walk(...)``."""
+    iter_node = for_node.iter
+    return (
+        isinstance(iter_node, ast.Call)
+        and isinstance(iter_node.func, ast.Attribute)
+        and iter_node.func.attr == "walk"
+        and isinstance(iter_node.func.value, ast.Name)
+        and iter_node.func.value.id == "ast"
+    )
+
+
+def _for_target_name(for_node: ast.For) -> str | None:
+    target = for_node.target
+    if isinstance(target, ast.Name):
+        return target.id
+    return None
+
+
+def _is_continue_only(body: list[ast.stmt]) -> bool:
+    return len(body) == 1 and isinstance(body[0], ast.Continue)
+
+
+def _is_handrolled_call_continue(for_node: ast.For) -> bool:
+    """True when body starts with ``if not isinstance(<target>, ast.Call): continue``."""
+    target_name = _for_target_name(for_node)
+    if target_name is None or not for_node.body:
+        return False
+    first = for_node.body[0]
+    if not isinstance(first, ast.If):
+        return False
+    test = first.test
+    if not (
+        isinstance(test, ast.UnaryOp)
+        and isinstance(test.op, ast.Not)
+        and isinstance(test.operand, ast.Call)
+        and isinstance(test.operand.func, ast.Name)
+        and test.operand.func.id == "isinstance"
+        and len(test.operand.args) == 2
+        and isinstance(test.operand.args[0], ast.Name)
+        and test.operand.args[0].id == target_name
+        and isinstance(test.operand.args[1], ast.Attribute)
+        and test.operand.args[1].value.id == "ast"
+        and test.operand.args[1].attr == "Call"
+    ):
+        return False
+    return _is_continue_only(first.body)
+
+
+def _is_handrolled_call_positive(for_node: ast.For) -> bool:
+    """True when body starts with ``if isinstance(<target>, ast.Call):`` and processes it."""
+    target_name = _for_target_name(for_node)
+    if target_name is None or not for_node.body:
+        return False
+    first = for_node.body[0]
+    if not isinstance(first, ast.If):
+        return False
+    test = first.test
+    if not (
+        isinstance(test, ast.Call)
+        and isinstance(test.func, ast.Name)
+        and test.func.id == "isinstance"
+        and len(test.args) == 2
+        and isinstance(test.args[0], ast.Name)
+        and test.args[0].id == target_name
+        and isinstance(test.args[1], ast.Attribute)
+        and test.args[1].value.id == "ast"
+        and test.args[1].attr == "Call"
+    ):
+        return False
+    if _is_continue_only(first.orelse):
+        return False
+    if not first.body or (len(first.body) == 1 and isinstance(first.body[0], ast.Pass)):
+        return False
+    return True
+
+
+def _for_is_handrolled_call_walk(for_node: ast.For) -> bool:
+    if not _is_ast_walk_iter(for_node):
+        return False
+    return _is_handrolled_call_continue(for_node) or _is_handrolled_call_positive(for_node)
+
+
+def _find_handrolled_call_walks() -> list[str]:
+    violations: list[str] = []
+    for rel, tree in iter_architecture_guard_trees(exempt=_EXEMPT):
+        for node in ast.walk(tree):
+            if isinstance(node, ast.For) and _for_is_handrolled_call_walk(node):
+                lineno = getattr(node, "lineno", "?")
+                violations.append(f"{rel}:{lineno}: hand-rolled ast.walk Call loop")
+    return violations
+
+
+@pytest.mark.arch_guard
+def test_no_handrolled_call_walk() -> None:
+    """Guard tests must not inline ast.walk + isinstance(ast.Call) Call-detection loops."""
+    violations = _find_handrolled_call_walks()
+    assert not violations, "Hand-rolled Call walk found — use iter_call_expressions():\n" + "\n".join(
+        f"  {v}" for v in violations
+    )
+
+
+@pytest.mark.arch_guard
+def test_call_walk_guard_catches_negative_continue_pattern() -> None:
+    """Self-test: the scanner flags ``if not isinstance(node, ast.Call): continue``."""
+    repo = repo_root()
+    probe = repo / "tests" / "unit" / "test_architecture_probe_handrolled_call_walk.py"
+    probe.write_text(
+        "import ast\n"
+        "tree = ast.parse('x()')\n"
+        "for node in ast.walk(tree):\n"
+        "    if not isinstance(node, ast.Call):\n"
+        "        continue\n",
+        encoding="utf-8",
+    )
+    try:
+        violations = _find_handrolled_call_walks()
+        assert any("test_architecture_probe_handrolled_call_walk.py" in v for v in violations)
+    finally:
+        probe.unlink(missing_ok=True)
+
+
+@pytest.mark.arch_guard
+def test_call_walk_guard_catches_positive_isinstance_pattern() -> None:
+    """Self-test: the scanner flags ``if isinstance(node, ast.Call):`` processing."""
+    repo = repo_root()
+    probe = repo / "tests" / "unit" / "test_architecture_probe_handrolled_call_walk.py"
+    probe.write_text(
+        "import ast\n"
+        "tree = ast.parse('x()')\n"
+        "for node in ast.walk(tree):\n"
+        "    if isinstance(node, ast.Call):\n"
+        "        _ = node.func\n",
+        encoding="utf-8",
+    )
+    try:
+        violations = _find_handrolled_call_walks()
+        assert any("test_architecture_probe_handrolled_call_walk.py" in v for v in violations)
+    finally:
+        probe.unlink(missing_ok=True)
+
+
+@pytest.mark.arch_guard
+def test_call_walk_guard_allows_iter_call_expressions() -> None:
+    """Self-test: iter_call_expressions() is not flagged."""
+    repo = repo_root()
+    probe = repo / "tests" / "unit" / "test_architecture_probe_handrolled_call_walk.py"
+    probe.write_text(
+        "import ast\n"
+        "from tests.unit._architecture_helpers import iter_call_expressions\n"
+        "tree = ast.parse('x()')\n"
+        "for node in iter_call_expressions(tree):\n"
+        "    _ = node.func\n",
+        encoding="utf-8",
+    )
+    try:
+        violations = _find_handrolled_call_walks()
+        assert not any("test_architecture_probe_handrolled_call_walk.py" in v for v in violations)
+    finally:
+        probe.unlink(missing_ok=True)

--- a/tests/unit/test_architecture_no_handrolled_call_walk.py
+++ b/tests/unit/test_architecture_no_handrolled_call_walk.py
@@ -3,6 +3,15 @@
 Hand-rolled ``for node in ast.walk(...): if not isinstance(node, ast.Call)``
 loops duplicate the helper and drift when one copy is updated. All guard
 Call-detection loops route through ``tests.unit._architecture_helpers.iter_call_expressions``.
+
+Deliberately out of scope (not flagged by this guard):
+
+- Pre-collected nodes, e.g. ``nodes = list(ast.walk(t))`` then loop over ``nodes``
+- A statement before the ``if`` guard in the loop body (not ``body[0]``)
+- ``from ast import walk`` instead of ``ast.walk``
+- Compound conditions, e.g. ``if isinstance(n, ast.Call) and ...:``
+- ``type(n) is not ast.Call`` instead of ``isinstance``
+- Dotted ``ast.Call`` references, e.g. ``isinstance(node, mod.ast.Call)``
 """
 
 from __future__ import annotations
@@ -12,7 +21,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.unit._architecture_helpers import iter_architecture_guard_trees, repo_root
+from tests.unit._architecture_helpers import iter_architecture_guard_trees
 
 _EXEMPT = {
     Path("tests/unit/_architecture_helpers.py"),
@@ -63,6 +72,7 @@ def _is_handrolled_call_continue(for_node: ast.For) -> bool:
         and isinstance(test.operand.args[0], ast.Name)
         and test.operand.args[0].id == target_name
         and isinstance(test.operand.args[1], ast.Attribute)
+        and isinstance(test.operand.args[1].value, ast.Name)
         and test.operand.args[1].value.id == "ast"
         and test.operand.args[1].attr == "Call"
     ):
@@ -87,6 +97,7 @@ def _is_handrolled_call_positive(for_node: ast.For) -> bool:
         and isinstance(test.args[0], ast.Name)
         and test.args[0].id == target_name
         and isinstance(test.args[1], ast.Attribute)
+        and isinstance(test.args[1].value, ast.Name)
         and test.args[1].value.id == "ast"
         and test.args[1].attr == "Call"
     ):
@@ -104,9 +115,14 @@ def _for_is_handrolled_call_walk(for_node: ast.For) -> bool:
     return _is_handrolled_call_continue(for_node) or _is_handrolled_call_positive(for_node)
 
 
+def _for_nodes_from_source(source: str) -> list[ast.For]:
+    tree = ast.parse(source)
+    return [node for node in ast.walk(tree) if isinstance(node, ast.For)]
+
+
 def _find_handrolled_call_walks() -> list[str]:
     violations: list[str] = []
-    for rel, tree in iter_architecture_guard_trees(exempt=_EXEMPT):
+    for tree, rel in iter_architecture_guard_trees(exempt=_EXEMPT):
         for node in ast.walk(tree):
             if isinstance(node, ast.For) and _for_is_handrolled_call_walk(node):
                 lineno = getattr(node, "lineno", "?")
@@ -126,58 +142,69 @@ def test_no_handrolled_call_walk() -> None:
 @pytest.mark.arch_guard
 def test_call_walk_guard_catches_negative_continue_pattern() -> None:
     """Self-test: the scanner flags ``if not isinstance(node, ast.Call): continue``."""
-    repo = repo_root()
-    probe = repo / "tests" / "unit" / "test_architecture_probe_handrolled_call_walk.py"
-    probe.write_text(
+    for_nodes = _for_nodes_from_source(
         "import ast\n"
         "tree = ast.parse('x()')\n"
         "for node in ast.walk(tree):\n"
         "    if not isinstance(node, ast.Call):\n"
-        "        continue\n",
-        encoding="utf-8",
+        "        continue\n"
     )
-    try:
-        violations = _find_handrolled_call_walks()
-        assert any("test_architecture_probe_handrolled_call_walk.py" in v for v in violations)
-    finally:
-        probe.unlink(missing_ok=True)
+    assert any(_for_is_handrolled_call_walk(node) for node in for_nodes)
 
 
 @pytest.mark.arch_guard
 def test_call_walk_guard_catches_positive_isinstance_pattern() -> None:
     """Self-test: the scanner flags ``if isinstance(node, ast.Call):`` processing."""
-    repo = repo_root()
-    probe = repo / "tests" / "unit" / "test_architecture_probe_handrolled_call_walk.py"
-    probe.write_text(
+    for_nodes = _for_nodes_from_source(
         "import ast\n"
         "tree = ast.parse('x()')\n"
         "for node in ast.walk(tree):\n"
         "    if isinstance(node, ast.Call):\n"
-        "        _ = node.func\n",
-        encoding="utf-8",
+        "        _ = node.func\n"
     )
-    try:
-        violations = _find_handrolled_call_walks()
-        assert any("test_architecture_probe_handrolled_call_walk.py" in v for v in violations)
-    finally:
-        probe.unlink(missing_ok=True)
+    assert any(_for_is_handrolled_call_walk(node) for node in for_nodes)
 
 
 @pytest.mark.arch_guard
 def test_call_walk_guard_allows_iter_call_expressions() -> None:
     """Self-test: iter_call_expressions() is not flagged."""
-    repo = repo_root()
-    probe = repo / "tests" / "unit" / "test_architecture_probe_handrolled_call_walk.py"
-    probe.write_text(
+    for_nodes = _for_nodes_from_source(
         "import ast\n"
         "from tests.unit._architecture_helpers import iter_call_expressions\n"
         "tree = ast.parse('x()')\n"
         "for node in iter_call_expressions(tree):\n"
-        "    _ = node.func\n",
-        encoding="utf-8",
+        "    _ = node.func\n"
     )
-    try:
-        violations = _find_handrolled_call_walks()
-        assert not any("test_architecture_probe_handrolled_call_walk.py" in v for v in violations)
-    finally:
-        probe.unlink(missing_ok=True)
+    assert not any(_for_is_handrolled_call_walk(node) for node in for_nodes)
+
+
+@pytest.mark.arch_guard
+def test_call_walk_guard_allows_out_of_scope_shapes() -> None:
+    """Self-test: documented out-of-scope shapes are not flagged (empty scan != total coverage)."""
+    out_of_scope_sources = [
+        "import ast\n"
+        "tree = ast.parse('x()')\n"
+        "nodes = list(ast.walk(tree))\n"
+        "for node in nodes:\n"
+        "    if not isinstance(node, ast.Call):\n"
+        "        continue\n",
+        "import ast\n"
+        "tree = ast.parse('x()')\n"
+        "for node in ast.walk(tree):\n"
+        "    _ = node\n"
+        "    if not isinstance(node, ast.Call):\n"
+        "        continue\n",
+        "import ast\n"
+        "tree = ast.parse('x()')\n"
+        "for node in ast.walk(tree):\n"
+        "    if type(node) is not ast.Call:\n"
+        "        continue\n",
+        "import ast\n"
+        "tree = ast.parse('x()')\n"
+        "for node in ast.walk(tree):\n"
+        "    if not isinstance(node, mod.ast.Call):\n"
+        "        continue\n",
+    ]
+    for source in out_of_scope_sources:
+        for_nodes = _for_nodes_from_source(source)
+        assert not any(_for_is_handrolled_call_walk(node) for node in for_nodes)

--- a/tests/unit/test_architecture_no_model_dump_in_impl.py
+++ b/tests/unit/test_architecture_no_model_dump_in_impl.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.unit._architecture_helpers import assert_violations_match_allowlist
+from tests.unit._architecture_helpers import assert_violations_match_allowlist, iter_call_expressions
 
 TOOLS_DIR = Path(__file__).resolve().parents[2] / "src" / "core" / "tools"
 
@@ -56,9 +56,7 @@ def _find_model_dump_in_impl() -> list[tuple[str, int, str, str]]:
             if not node.name.endswith("_impl"):
                 continue
 
-            for child in ast.walk(node):
-                if not isinstance(child, ast.Call):
-                    continue
+            for child in iter_call_expressions(node):
                 func = child.func
                 if isinstance(func, ast.Attribute) and func.attr in BANNED_METHODS:
                     rel_path = str(py_file.relative_to(TOOLS_DIR))

--- a/tests/unit/test_architecture_no_raw_media_package_select.py
+++ b/tests/unit/test_architecture_no_raw_media_package_select.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.unit._architecture_helpers import assert_violations_match_allowlist
+from tests.unit._architecture_helpers import assert_violations_match_allowlist, iter_call_expressions
 
 ROOT = Path(__file__).resolve().parents[2]
 
@@ -60,10 +60,7 @@ def _find_raw_media_package_selects() -> list[tuple[str, str, int]]:
             if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 continue
 
-            for child in ast.walk(node):
-                if not isinstance(child, ast.Call):
-                    continue
-
+            for child in iter_call_expressions(node):
                 func = child.func
                 if not (isinstance(func, ast.Name) and func.id == "select"):
                     continue

--- a/tests/unit/test_architecture_no_raw_select.py
+++ b/tests/unit/test_architecture_no_raw_select.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.unit._architecture_helpers import assert_violations_match_allowlist
+from tests.unit._architecture_helpers import assert_violations_match_allowlist, iter_call_expressions
 
 ROOT = Path(__file__).resolve().parents[2]
 
@@ -408,10 +408,7 @@ def _find_raw_selects() -> list[tuple[str, str, str, int]]:
             if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 continue
 
-            for child in ast.walk(node):
-                if not isinstance(child, ast.Call):
-                    continue
-
+            for child in iter_call_expressions(node):
                 func = child.func
                 if not (isinstance(func, ast.Name) and func.id == "select"):
                     continue

--- a/tests/unit/test_architecture_obligation_test_quality.py
+++ b/tests/unit/test_architecture_obligation_test_quality.py
@@ -32,7 +32,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.unit._architecture_helpers import assert_violations_match_allowlist
+from tests.unit._architecture_helpers import assert_violations_match_allowlist, iter_call_expressions
 
 _OBLIGATION_ID_RE = re.compile(r"[A-Z][A-Z0-9]+-[\w-]+-\d{2}")
 _COVERS_RE = re.compile(r"Covers:\s+([\w-]+)")
@@ -161,10 +161,7 @@ def _function_body_calls_names(func_node: ast.FunctionDef, names: set[str]) -> b
     This catches the gaming pattern: ``import _get_products_impl  # noqa: F401``
     passes the old "references" check but fails this "calls" check.
     """
-    for node in ast.walk(func_node):
-        if not isinstance(node, ast.Call):
-            continue
-
+    for node in iter_call_expressions(func_node):
         func = node.func
 
         # Direct call: name(...)

--- a/tests/unit/test_architecture_query_type_safety.py
+++ b/tests/unit/test_architecture_query_type_safety.py
@@ -84,6 +84,8 @@ def _find_in_queries_on_integer_columns(filepath: str) -> list[tuple[int, str, s
 
     results = []
     for node in iter_call_expressions(tree, name="in_"):
+        if not isinstance(node.func, ast.Attribute):
+            continue
         # The value should be Model.column (another Attribute node)
         value = node.func.value
         if not isinstance(value, ast.Attribute):

--- a/tests/unit/test_architecture_query_type_safety.py
+++ b/tests/unit/test_architecture_query_type_safety.py
@@ -17,7 +17,12 @@ from pathlib import Path
 
 import pytest
 
-from tests.unit._architecture_helpers import assert_violations_match_allowlist, repo_root, src_python_files
+from tests.unit._architecture_helpers import (
+    assert_violations_match_allowlist,
+    iter_call_expressions,
+    repo_root,
+    src_python_files,
+)
 
 # Files to scan for database queries
 QUERY_FILES = [
@@ -78,17 +83,9 @@ def _find_in_queries_on_integer_columns(filepath: str) -> list[tuple[int, str, s
         return []
 
     results = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-
-        # Match pattern: Model.column.in_(args)
-        func = node.func
-        if not isinstance(func, ast.Attribute) or func.attr != "in_":
-            continue
-
+    for node in iter_call_expressions(tree, name="in_"):
         # The value should be Model.column (another Attribute node)
-        value = func.value
+        value = node.func.value
         if not isinstance(value, ast.Attribute):
             continue
 
@@ -128,14 +125,7 @@ def _find_filter_by_on_integer_columns(filepath: str) -> list[tuple[int, str, st
         return []
 
     results = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-
-        func = node.func
-        if not isinstance(func, ast.Attribute) or func.attr != "filter_by":
-            continue
-
+    for node in iter_call_expressions(tree, name="filter_by"):
         # Check keyword arguments for Integer PK column names
         for kw in node.keywords:
             if kw.arg is None:

--- a/tests/unit/test_architecture_repository_pattern.py
+++ b/tests/unit/test_architecture_repository_pattern.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.unit._architecture_helpers import assert_violations_match_allowlist
+from tests.unit._architecture_helpers import assert_violations_match_allowlist, iter_call_expressions
 
 ROOT = Path(__file__).resolve().parents[2]
 
@@ -523,17 +523,16 @@ def _find_impl_functions_with_db_session(file_path: str) -> list[tuple[str, str,
             continue
 
         # Check all calls inside this function for get_db_session
-        for child in ast.walk(node):
-            if isinstance(child, ast.Call):
-                func = child.func
-                # Match: get_db_session()
-                if isinstance(func, ast.Name) and func.id == "get_db_session":
-                    violations.append((file_path, node.name, child.lineno))
-                    break  # One violation per function is enough
-                # Match: database_session.get_db_session()
-                if isinstance(func, ast.Attribute) and func.attr == "get_db_session":
-                    violations.append((file_path, node.name, child.lineno))
-                    break
+        for child in iter_call_expressions(node):
+            func = child.func
+            # Match: get_db_session()
+            if isinstance(func, ast.Name) and func.id == "get_db_session":
+                violations.append((file_path, node.name, child.lineno))
+                break  # One violation per function is enough
+            # Match: database_session.get_db_session()
+            if isinstance(func, ast.Attribute) and func.attr == "get_db_session":
+                violations.append((file_path, node.name, child.lineno))
+                break
 
     return violations
 
@@ -554,20 +553,19 @@ def _find_session_add_in_tests(file_path: str) -> list[tuple[str, str, int]]:
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
 
-        for child in ast.walk(node):
-            if isinstance(child, ast.Call):
-                func = child.func
-                # Match: session.add(...) or *.add(...)
-                if isinstance(func, ast.Attribute) and func.attr == "add":
-                    # Check it's likely a session (common var names)
-                    if isinstance(func.value, ast.Name) and func.value.id in (
-                        "session",
-                        "db_session",
-                        "mock_session",
-                        "s",
-                    ):
-                        violations.append((file_path, node.name, child.lineno))
-                        break  # One violation per function is enough
+        for child in iter_call_expressions(node):
+            func = child.func
+            # Match: session.add(...) or *.add(...)
+            if isinstance(func, ast.Attribute) and func.attr == "add":
+                # Check it's likely a session (common var names)
+                if isinstance(func.value, ast.Name) and func.value.id in (
+                    "session",
+                    "db_session",
+                    "mock_session",
+                    "s",
+                ):
+                    violations.append((file_path, node.name, child.lineno))
+                    break  # One violation per function is enough
 
     return violations
 

--- a/tests/unit/test_architecture_resolved_identity_inline_cap.py
+++ b/tests/unit/test_architecture_resolved_identity_inline_cap.py
@@ -28,6 +28,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.unit._architecture_helpers import iter_call_expressions
+
 # Per-file caps for inline ``ResolvedIdentity(...)`` constructions in
 # ``tests/`` (excluding ``test_a2a*.py`` files — those are zero-tolerance
 # under ``test_architecture_a2a_test_uses_factory``). Caps frozen at the
@@ -121,13 +123,12 @@ def _count_inline_resolved_identity(filepath: Path) -> list[int]:
     except (OSError, SyntaxError):
         return []
     lines: list[int] = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Call):
-            func = node.func
-            if isinstance(func, ast.Name) and func.id == "ResolvedIdentity":
-                lines.append(node.lineno)
-            elif isinstance(func, ast.Attribute) and func.attr == "ResolvedIdentity":
-                lines.append(node.lineno)
+    for node in iter_call_expressions(tree):
+        func = node.func
+        if isinstance(func, ast.Name) and func.id == "ResolvedIdentity":
+            lines.append(node.lineno)
+        elif isinstance(func, ast.Attribute) and func.attr == "ResolvedIdentity":
+            lines.append(node.lineno)
     return lines
 
 

--- a/tests/unit/test_architecture_weak_mock_assertions.py
+++ b/tests/unit/test_architecture_weak_mock_assertions.py
@@ -30,7 +30,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.unit._architecture_helpers import assert_violations_match_allowlist
+from tests.unit._architecture_helpers import assert_violations_match_allowlist, iter_call_expressions
 
 ROOT = Path(__file__).resolve().parents[2]
 SCAN_DIRS = (ROOT / "tests",)
@@ -123,19 +123,17 @@ def _find_split_assertions(file_path: str) -> list[tuple[str, str, int]]:
         has_bare_called_once = False
         has_call_args = False
 
-        for child in ast.walk(node):
-            # Bare assert_called()/assert_called_once() — exactly zero arguments
-            if isinstance(child, ast.Call):
-                func = child.func
-                if (
-                    isinstance(func, ast.Attribute)
-                    and func.attr in {"assert_called", "assert_called_once"}
-                    and len(child.args) == 0
-                    and len(child.keywords) == 0
-                ):
-                    has_bare_called_once = True
+        for child in iter_call_expressions(node):
+            func = child.func
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr in {"assert_called", "assert_called_once"}
+                and len(child.args) == 0
+                and len(child.keywords) == 0
+            ):
+                has_bare_called_once = True
 
-            # .call_args attribute access (any object)
+        for child in ast.walk(node):
             if isinstance(child, ast.Attribute) and child.attr == "call_args":
                 has_call_args = True
 
@@ -264,19 +262,17 @@ def _find_bare_assertions(file_path: str) -> list[tuple[str, str, int]]:
         has_bare_called_once = False
         has_call_args = False
 
-        for child in ast.walk(node):
-            # Bare assert_called()/assert_called_once() — exactly zero arguments
-            if isinstance(child, ast.Call):
-                func = child.func
-                if (
-                    isinstance(func, ast.Attribute)
-                    and func.attr in {"assert_called", "assert_called_once"}
-                    and len(child.args) == 0
-                    and len(child.keywords) == 0
-                ):
-                    has_bare_called_once = True
+        for child in iter_call_expressions(node):
+            func = child.func
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr in {"assert_called", "assert_called_once"}
+                and len(child.args) == 0
+                and len(child.keywords) == 0
+            ):
+                has_bare_called_once = True
 
-            # .call_args attribute access (any object)
+        for child in ast.walk(node):
             if isinstance(child, ast.Attribute) and child.attr == "call_args":
                 has_call_args = True
 


### PR DESCRIPTION
## Summary
- Migrate architecture guards from hand-rolled `ast.walk` + `isinstance(..., ast.Call)` loops to the shared `iter_call_expressions()` helper.
- Add self-closing regression guard `test_architecture_no_handrolled_call_walk.py`.
- Extend helper contract tests for filtered/unfiltered/subtree `iter_call_expressions`.
- Extract `iter_architecture_guard_trees()` to share guard file scanning with the allowlist-diff guard (DRY).

Closes #1453

## Documented non-detection `isinstance(ast.Call)` uses (intentionally kept)
- Decorator checks: `isinstance(dec, ast.Call)` in BDD guards
- Raise.exc checks: `no_value_error_in_impl`, `adapter_raise_site_coverage`, `no_error_flattening`, `no_base_notfound_raise`
- Type checks on assert/compare nodes: `bdd_assertion_strength`, `bdd_no_request_in_then`, `bdd_no_trivial_assertions`
- Multi-type scanners: `sdk_idempotency_seam`, `auth_helper_context_wiring`, `no_raw_thread_registry`
- Allowlist guard helper: `no_handrolled_allowlist_diff` (`sorted(...)` detection)

## Test plan
- [x] `uv run pytest tests/unit/test_architecture_no_handrolled_call_walk.py -v`
- [x] `uv run pytest tests/unit/test_architecture_helpers_contract.py -k iter_call -v`
- [x] grep done-check (documented exceptions only)
- [x] `make quality`