### PR TITLE
ci: move pre-push-only checks to make quality-ci (Pattern 2, #1234)

### DIFF
--- a/.pre-commit-coverage-map.yml
+++ b/.pre-commit-coverage-map.yml
@@ -39,14 +39,17 @@ mcp-contract-validation:
   enforced_by: ci
   location: .github/workflows/ci.yml::schema-contract
 check-docs-links:
-  enforced_by: pre-push
-  location: stages_prepush
+  enforced_by: pre-push + ci-step
+  location: stages_prepush + Makefile::quality-ci
 check-route-conflicts:
-  enforced_by: pre-push
-  location: stages_prepush
+  enforced_by: pre-push + ci-step
+  location: stages_prepush + Makefile::quality-ci
 type-ignore-no-regression:
-  enforced_by: pre-push
-  location: stages_prepush
+  enforced_by: pre-push + ci-step
+  location: stages_prepush + Makefile::quality-ci
+no-hardcoded-urls:
+  enforced_by: pre-push + ci-step
+  location: stages_prepush + Makefile::quality-ci
 no-skip-integration-v2:
   enforced_by: deleted
   location: dead-code (tests/integration_v2/ does not exist)

--- a/.pre-commit-hooks/check_hardcoded_urls.py
+++ b/.pre-commit-hooks/check_hardcoded_urls.py
@@ -68,8 +68,12 @@ def main(filenames: list[str]) -> int:
     Check all provided files for hardcoded URLs.
 
     Returns:
-        0 if no violations, 1 if violations found
+        0 if no violations, 1 if violations found or no files provided
     """
+    if not filenames:
+        print("check_hardcoded_urls: no files provided", file=sys.stderr)
+        return 1
+
     all_violations = []
 
     for filename in filenames:

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ quality-ci:
 	uv run python .pre-commit-hooks/check-gam-auth-support.py
 	uv run python scripts/hooks/check_response_attribute_access.py $$(find src -name '*.py')
 	uv run python .pre-commit-hooks/check_roundtrip_tests.py
+	uv run python .pre-commit-hooks/check_route_conflicts.py
+	uv run python .pre-commit-hooks/check_type_ignore_count.py
+	uv run python .pre-commit-hooks/check_docs_links.py
+	uv run python .pre-commit-hooks/check_hardcoded_urls.py $$(find templates static -type f \( -name '*.html' -o -name '*.js' \) 2>/dev/null)
 
 quality:
 	$(MAKE) quality-ci

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,9 @@ quality-ci:
 	uv run python .pre-commit-hooks/check_route_conflicts.py
 	uv run python .pre-commit-hooks/check_type_ignore_count.py
 	uv run python .pre-commit-hooks/check_docs_links.py
-	uv run python .pre-commit-hooks/check_hardcoded_urls.py $$(find templates static -type f \( -name '*.html' -o -name '*.js' \) 2>/dev/null)
+	@files=$$(find templates static -type f \( -name '*.html' -o -name '*.js' \) 2>/dev/null); \
+	test -n "$$files" || { echo "check_hardcoded_urls: no files matched find glob"; exit 1; }; \
+	uv run python .pre-commit-hooks/check_hardcoded_urls.py $$files
 
 quality:
 	$(MAKE) quality-ci

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,7 @@ quality-ci:
 	uv run python .pre-commit-hooks/check_route_conflicts.py
 	uv run python .pre-commit-hooks/check_type_ignore_count.py
 	uv run python .pre-commit-hooks/check_docs_links.py
-	@files=$$(find templates static -type f \( -name '*.html' -o -name '*.js' \) 2>/dev/null); \
-	test -n "$$files" || { echo "check_hardcoded_urls: no files matched find glob"; exit 1; }; \
-	uv run python .pre-commit-hooks/check_hardcoded_urls.py $$files
+	uv run python .pre-commit-hooks/check_hardcoded_urls.py $$(find templates static -type f \( -name '*.html' -o -name '*.js' \) 2>/dev/null)
 
 quality:
 	$(MAKE) quality-ci

--- a/docs/development/ci-pipeline.md
+++ b/docs/development/ci-pipeline.md
@@ -242,7 +242,8 @@ required (or stay blocked on stale `Test Suite / …` names).
 Requires pre-commit ≥3.2.0. Run `pre-commit install` once per clone (installs both commit and pre-push hooks).
 
 CI-only checks absorbed into `make quality-ci` (not re-run via `pre-commit run --all-files` in Quality Gate):
-`check_code_duplication`, `check-gam-auth-support`, `check_response_attribute_access`, `check_roundtrip_tests`.
+`check_code_duplication`, `check-gam-auth-support`, `check_response_attribute_access`, `check_roundtrip_tests`,
+`check_route_conflicts`, `check_type_ignore_count`, `check_docs_links`, `check_hardcoded_urls`.
 
 See [`.pre-commit-coverage-map.yml`](../../.pre-commit-coverage-map.yml) for hook migration mapping.
 

--- a/docs/development/ci-pipeline.md
+++ b/docs/development/ci-pipeline.md
@@ -245,8 +245,8 @@ Checks invoked directly by `make quality-ci` (not via `pre-commit run --all-file
 
 - **CI-only** (no commit/pre-push stage): `check_code_duplication`, `check-gam-auth-support`,
   `check_response_attribute_access`, `check_roundtrip_tests`.
-- **Dual-stage** (`pre-push + ci-step` in the coverage map): `check_route_conflicts`,
-  `check_type_ignore_count`, `check_docs_links`, `check_hardcoded_urls`.
+- **Dual-stage** (`pre-push + ci-step` in the coverage map): `check-route-conflicts`,
+  `type-ignore-no-regression`, `check-docs-links`, `no-hardcoded-urls`.
 
 See [`.pre-commit-coverage-map.yml`](../../.pre-commit-coverage-map.yml) for hook migration mapping.
 

--- a/docs/development/ci-pipeline.md
+++ b/docs/development/ci-pipeline.md
@@ -241,9 +241,12 @@ required (or stay blocked on stale `Test Suite / …` names).
 
 Requires pre-commit ≥3.2.0. Run `pre-commit install` once per clone (installs both commit and pre-push hooks).
 
-CI-only checks absorbed into `make quality-ci` (not re-run via `pre-commit run --all-files` in Quality Gate):
-`check_code_duplication`, `check-gam-auth-support`, `check_response_attribute_access`, `check_roundtrip_tests`,
-`check_route_conflicts`, `check_type_ignore_count`, `check_docs_links`, `check_hardcoded_urls`.
+Checks invoked directly by `make quality-ci` (not via `pre-commit run --all-files` in the Quality Gate):
+
+- **CI-only** (no commit/pre-push stage): `check_code_duplication`, `check-gam-auth-support`,
+  `check_response_attribute_access`, `check_roundtrip_tests`.
+- **Dual-stage** (`pre-push + ci-step` in the coverage map): `check_route_conflicts`,
+  `check_type_ignore_count`, `check_docs_links`, `check_hardcoded_urls`.
 
 See [`.pre-commit-coverage-map.yml`](../../.pre-commit-coverage-map.yml) for hook migration mapping.
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -458,6 +458,10 @@ errors with a version-too-old `FatalError`, run `uv tool install pre-commit` (pr
 
 Manual/on-demand: `pre-commit run smoke-tests --hook-stage manual`
 
+Running `make quality` or `make quality-ci` may update tracked ratchet baselines
+(`.duplication-baseline`, `.type-ignore-baseline`) when counts decrease. Commit those
+updates intentionally; CI runs are ephemeral and do not persist baseline writes.
+
 **Contract Validation Prevention:**
 The system automatically prevents validation errors like `'brief' is a required property` through:
 - Pre-push hooks that test minimal parameter calls (`adcp-contract-tests`, `mcp-contract-validation`)

--- a/scripts/hooks/check_response_attribute_access.py
+++ b/scripts/hooks/check_response_attribute_access.py
@@ -125,8 +125,8 @@ def main() -> int:
         Exit code: 0 if no issues, 1 if issues found
     """
     if len(sys.argv) < 2:
-        print("Usage: check_response_attribute_access.py [files...]")
-        return 0
+        print("check_response_attribute_access: no files provided", file=sys.stderr)
+        return 1
 
     files_to_check = [Path(f) for f in sys.argv[1:]]
     all_errors = []

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -3335,16 +3335,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.12.0"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/43/4b/ac7e0aae12027748076d72a8764ff1c9d82ca75a7a52622e67ed3f765c54/pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0", size = 194184, upload-time = "2025-11-10T14:25:47.013Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809", size = 51880, upload-time = "2025-11-10T14:25:45.546Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]
@@ -4859,21 +4859,20 @@ wheels = [
 
 [[package]]
 name = "zeep"
-version = "4.3.2"
+version = "4.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "isodate" },
     { name = "lxml" },
     { name = "platformdirs" },
-    { name = "pytz" },
     { name = "requests" },
     { name = "requests-file" },
     { name = "requests-toolbelt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/06/4f1d3ff61e930163565fb73616c6251e412a4d2fc7ed18214e1c2107258d/zeep-4.3.2.tar.gz", hash = "sha256:1a23a667ce9d73a0dbfdf15745bfa2b7ab0b6402135c0cd5067574838398e0e6", size = 166687, upload-time = "2025-09-15T10:26:03.4Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/c2/e06e5f177d818d0fc34fcbe2f98c175af2cba63b7d90f4bfcb6fe360d343/zeep-4.3.3.tar.gz", hash = "sha256:99d5059f92f721020998695fd9c85289ccb03ec5a2398ad49c6dbe43f19cfb94", size = 167372, upload-time = "2026-06-18T17:17:58.994Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/78/f43f3feb70d67cbe260ec5b682ecc3c1850c8f437f1df707495126e51817/zeep-4.3.2-py3-none-any.whl", hash = "sha256:ed08c3179709172bfaaa9b76a6a545f8a57043ec6218e64e9deb81ff1e0ff79b", size = 101853, upload-time = "2025-09-15T10:26:02.12Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/87/5c1d29f52fc32da98b75dc8a681cd0de78c9cfd5c10493cd7fb730e1d4b0/zeep-4.3.3-py3-none-any.whl", hash = "sha256:5adfae35582848819f8bb97b6ea9f1a34a2d4851a539f830e14dbab09961dd18", size = 102054, upload-time = "2026-06-18T17:17:57.223Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add four pre-push-only checks to `make quality-ci`: route conflicts, type-ignore ratchet, docs links, hardcoded URLs
- Update `.pre-commit-coverage-map.yml` (`pre-push + ci-step` for all four; add missing `no-hardcoded-urls`)
- Document new checks in `docs/development/ci-pipeline.md`

Closes #1454

## Test plan
- [x] `make quality-ci` passes locally
- [x] CI Quality Gate green on PR