### PR TITLE
test: add coverage-map parser + trim unused guard helpers (Pattern 3, #1234)

### DIFF
--- a/.pre-commit-coverage-map.yml
+++ b/.pre-commit-coverage-map.yml
@@ -37,7 +37,7 @@ adcp-contract-tests:
   location: stages_prepush + .github/workflows/ci.yml::schema-contract
 mcp-contract-validation:
   enforced_by: ci
-  location: .github/workflows/ci.yml::schema-contract
+  location: .github/workflows/ci.yml::schema-contract -> tests/integration/test_mcp_contract_validation.py
 check-docs-links:
   enforced_by: pre-push + ci-step
   location: stages_prepush + Makefile::quality-ci

--- a/.pre-commit-coverage-map.yml
+++ b/.pre-commit-coverage-map.yml
@@ -1,4 +1,5 @@
 # Map of pre-commit hooks deleted/moved in PR 4 → replacement enforcement.
+# location may append " -> tests/path.py" for ci-only hooks (explicit schema-contract test path).
 no-tenant-config:
   enforced_by: guard
   location: tests/unit/test_architecture_no_tenant_config.py

--- a/tests/unit/_architecture_helpers.py
+++ b/tests/unit/_architecture_helpers.py
@@ -219,11 +219,6 @@ def iter_workflow_files(repo: Path) -> Iterator[Path]:
     yield from sorted([*wf_dir.glob("*.yml"), *wf_dir.glob("*.yaml")])
 
 
-def iter_compose_files(repo: Path) -> Iterator[Path]:
-    """docker-compose*.yml and compose.yaml at repo root."""
-    yield from sorted([*repo.glob("docker-compose*.yml"), *repo.glob("compose.yaml")])
-
-
 def iter_git_tracked_files(repo: Path) -> Iterator[Path]:
     """Yield git-tracked files that exist on disk (hermetic; ignores untracked local files)."""
     try:

--- a/tests/unit/_architecture_helpers.py
+++ b/tests/unit/_architecture_helpers.py
@@ -21,6 +21,9 @@ import re
 import subprocess
 from collections.abc import Callable, Iterable, Iterator
 from pathlib import Path
+from typing import Any
+
+import yaml
 
 # ---------------------------------------------------------------------------
 # Repo-root anchor
@@ -214,6 +217,11 @@ def iter_workflow_files(repo: Path) -> Iterator[Path]:
     if not wf_dir.exists():
         return
     yield from sorted([*wf_dir.glob("*.yml"), *wf_dir.glob("*.yaml")])
+
+
+def iter_compose_files(repo: Path) -> Iterator[Path]:
+    """docker-compose*.yml and compose.yaml at repo root."""
+    yield from sorted([*repo.glob("docker-compose*.yml"), *repo.glob("compose.yaml")])
 
 
 def iter_git_tracked_files(repo: Path) -> Iterator[Path]:
@@ -608,6 +616,38 @@ def runtime_user_directives(lines: Iterable[str]) -> list[str]:
         return []
     runtime_stage = line_list[from_indices[-1] :]
     return [line.strip() for line in runtime_stage if line.strip().upper().startswith("USER ")]
+
+
+# ---------------------------------------------------------------------------
+# Pre-commit config helpers
+# ---------------------------------------------------------------------------
+
+PRE_COMMIT_CONFIG_PATH = Path(".pre-commit-config.yaml")
+
+
+def load_pre_commit_config(path: Path | None = None, repo: Path | None = None) -> dict[str, Any]:
+    """Load ``.pre-commit-config.yaml`` anchored to *repo* (default: repo root)."""
+    root = repo or repo_root()
+    cfg_path = path or (root / PRE_COMMIT_CONFIG_PATH)
+    return yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+
+
+def iter_pre_commit_hooks(
+    cfg: dict[str, Any] | None = None,
+    *,
+    path: Path | None = None,
+    repo: Path | None = None,
+) -> Iterator[dict[str, Any]]:
+    """Yield hook records with ``id``, ``entry``, and ``stages`` from pre-commit config."""
+    config = cfg if cfg is not None else load_pre_commit_config(path=path, repo=repo)
+    default_stages = config.get("default_stages", ["pre-commit", "commit"])
+    for repo_entry in config["repos"]:
+        for hook in repo_entry["hooks"]:
+            yield {
+                "id": hook["id"],
+                "entry": hook.get("entry", ""),
+                "stages": hook.get("stages", default_stages),
+            }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_architecture_pre_commit_coverage_map.py
+++ b/tests/unit/test_architecture_pre_commit_coverage_map.py
@@ -6,19 +6,23 @@ loudly instead of silently (Pattern 3, #1455).
 
 from __future__ import annotations
 
-import re
+import ast
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import pytest
 import yaml
 
-from tests.unit._architecture_helpers import repo_root
+from scripts.ci.workflow_helpers import load_ci_workflow
+from tests.unit._architecture_helpers import (
+    iter_pre_commit_hooks,
+    parse_module,
+    repo_root,
+)
 
 COVERAGE_MAP_PATH = Path(".pre-commit-coverage-map.yml")
-PRE_COMMIT_CONFIG_PATH = Path(".pre-commit-config.yaml")
 MAKEFILE_PATH = Path("Makefile")
-CI_WORKFLOW_PATH = Path(".github/workflows/ci.yml")
 
 ALLOWED_ENFORCED_BY = frozenset(
     {
@@ -37,29 +41,36 @@ ALLOWED_ENFORCED_BY = frozenset(
 _REQUIRED_KEYS = frozenset({"enforced_by", "location"})
 
 
-def _load_coverage_map(path: Path = COVERAGE_MAP_PATH) -> dict[str, Any]:
-    return yaml.safe_load(path.read_text(encoding="utf-8"))
+def _load_coverage_map(path: Path | None = None) -> dict[str, Any]:
+    map_path = path or (repo_root() / COVERAGE_MAP_PATH)
+    return yaml.safe_load(map_path.read_text(encoding="utf-8"))
 
 
-def _pre_commit_hook_ids(cfg_path: Path = PRE_COMMIT_CONFIG_PATH) -> set[str]:
-    cfg = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
-    return {hook["id"] for repo in cfg["repos"] for hook in repo["hooks"]}
+def _pre_commit_hook_ids(cfg_path: Path | None = None) -> set[str]:
+    return {hook["id"] for hook in iter_pre_commit_hooks(path=cfg_path)}
 
 
-def _pre_commit_hook_scripts(cfg_path: Path = PRE_COMMIT_CONFIG_PATH) -> dict[str, list[str]]:
+def _pre_commit_hook_entries(cfg_path: Path | None = None) -> dict[str, str]:
+    return {hook["id"]: hook["entry"] for hook in iter_pre_commit_hooks(path=cfg_path)}
+
+
+def _pre_commit_hook_scripts(cfg_path: Path | None = None) -> dict[str, list[str]]:
     """Map hook id → script basenames referenced by the hook entry command."""
-    cfg = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
     scripts: dict[str, list[str]] = {}
-    for repo in cfg["repos"]:
-        for hook in repo["hooks"]:
-            entry = hook.get("entry", "")
-            basenames = [Path(part).name for part in entry.split() if part.endswith(".py")]
-            scripts[hook["id"]] = basenames
+    for hook in iter_pre_commit_hooks(path=cfg_path):
+        entry = hook["entry"]
+        basenames = [Path(part).name for part in entry.split() if part.endswith(".py")]
+        scripts[hook["id"]] = basenames
     return scripts
 
 
-def _makefile_quality_ci_body(makefile_path: Path = MAKEFILE_PATH) -> str:
-    lines = makefile_path.read_text(encoding="utf-8").splitlines()
+def _pre_commit_hook_stages(cfg_path: Path | None = None) -> dict[str, list[str]]:
+    return {hook["id"]: hook["stages"] for hook in iter_pre_commit_hooks(path=cfg_path)}
+
+
+def _makefile_quality_ci_body(makefile_path: Path | None = None) -> str:
+    path = makefile_path or (repo_root() / MAKEFILE_PATH)
+    lines = path.read_text(encoding="utf-8").splitlines()
     body: list[str] = []
     in_target = False
     for line in lines:
@@ -73,17 +84,40 @@ def _makefile_quality_ci_body(makefile_path: Path = MAKEFILE_PATH) -> str:
     return "\n".join(body)
 
 
-def _schema_contract_job_text(ci_path: Path = CI_WORKFLOW_PATH) -> str:
-    text = ci_path.read_text(encoding="utf-8")
-    match = re.search(r"^  schema-contract:\n(.*?)(?=^  \w|\Z)", text, flags=re.MULTILINE | re.DOTALL)
-    assert match, "schema-contract job not found in ci.yml"
-    return match.group(1)
+def _schema_contract_pytest_paths(workflow: dict[str, Any] | None = None) -> list[str]:
+    jobs = (workflow or load_ci_workflow())["jobs"]
+    job = jobs["schema-contract"]
+    paths: list[str] = []
+    for step in job.get("steps", []):
+        uses = step.get("uses", "")
+        if not str(uses).endswith("_pytest"):
+            continue
+        path = step.get("with", {}).get("paths")
+        if path:
+            paths.append(str(path))
+    assert paths, "schema-contract job must declare pytest paths"
+    return paths
 
 
-def _guard_location_path(location: str) -> Path:
-    """Strip ``::test_name`` suffix and return repo-relative guard file path."""
-    file_part = location.split("::", 1)[0]
-    return Path(file_part)
+def _guard_location_parts(location: str) -> tuple[Path, str | None]:
+    """Return repo-relative guard file path and optional ``::test_name`` suffix."""
+    if "::" in location:
+        file_part, test_name = location.split("::", 1)
+        return Path(file_part), test_name
+    return Path(location), None
+
+
+def _guard_test_exists(repo: Path, location: str) -> bool:
+    path, test_name = _guard_location_parts(location)
+    if test_name is None:
+        return True
+    guard_file = repo / path
+    if not guard_file.is_file():
+        return False
+    tree = parse_module(guard_file)
+    return any(
+        isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == test_name for node in ast.walk(tree)
+    )
 
 
 def _hook_script_names(hook_id: str, hook_scripts: dict[str, list[str]]) -> list[str]:
@@ -95,6 +129,13 @@ def _hook_script_names(hook_id: str, hook_scripts: dict[str, list[str]]) -> list
 
 def _script_in_quality_ci(hook_id: str, quality_ci: str, hook_scripts: dict[str, list[str]]) -> bool:
     return any(name in quality_ci for name in _hook_script_names(hook_id, hook_scripts))
+
+
+def _pytest_paths_from_hook_entry(entry: str) -> list[str]:
+    """Extract pytest file/dir targets from a hook entry command."""
+    if "pytest" not in entry:
+        return []
+    return [part for part in entry.split() if part.startswith("tests/")]
 
 
 def _validate_entry_schema(hook_id: str, entry: Any) -> list[str]:
@@ -116,18 +157,23 @@ def _validate_entry_references(
     *,
     repo: Path,
     hook_ids: set[str],
+    hook_entries: dict[str, str],
     hook_scripts: dict[str, list[str]],
+    hook_stages: dict[str, list[str]],
     quality_ci: str,
-    schema_contract: str,
+    schema_contract_paths: list[str],
 ) -> list[str]:
     errors: list[str] = []
     enforced_by = entry["enforced_by"]
     location = str(entry["location"])
 
     if enforced_by in {"guard", "guard-existing"}:
-        path = repo / _guard_location_path(location)
-        if not path.is_file():
-            errors.append(f"{hook_id}: guard location missing: {path.relative_to(repo)}")
+        path, test_name = _guard_location_parts(location)
+        guard_file = repo / path
+        if not guard_file.is_file():
+            errors.append(f"{hook_id}: guard location missing: {path}")
+        elif test_name is not None and not _guard_test_exists(repo, location):
+            errors.append(f"{hook_id}: guard test missing: {location}")
 
     if enforced_by in {"ci-step", "pre-push + ci-step"}:
         if "Makefile::quality-ci" not in location:
@@ -138,18 +184,17 @@ def _validate_entry_references(
     if enforced_by in {"pre-push", "pre-push + ci-step", "pre-push + ci"}:
         if hook_id not in hook_ids:
             errors.append(f"{hook_id}: pre-push hook id missing from .pre-commit-config.yaml")
+        elif "stages_prepush" in location and "pre-push" not in hook_stages.get(hook_id, []):
+            errors.append(f"{hook_id}: location claims stages_prepush but hook lacks pre-push stage")
 
-    if enforced_by == "pre-push + ci":
+    if enforced_by in {"pre-push + ci", "ci"}:
         if "schema-contract" not in location:
-            errors.append(f"{hook_id}: pre-push + ci location must reference schema-contract job")
-        elif hook_id == "adcp-contract-tests" and "test_adcp_contract.py" not in schema_contract:
-            errors.append(f"{hook_id}: schema-contract job must run test_adcp_contract.py")
-
-    if enforced_by == "ci":
-        if "schema-contract" not in location:
-            errors.append(f"{hook_id}: ci location must reference schema-contract job")
-        elif hook_id == "mcp-contract-validation" and "test_mcp_contract_validation.py" not in schema_contract:
-            errors.append(f"{hook_id}: schema-contract job must run test_mcp_contract_validation.py")
+            errors.append(f"{hook_id}: {enforced_by} location must reference schema-contract job")
+        else:
+            expected_paths = _pytest_paths_from_hook_entry(hook_entries.get(hook_id, ""))
+            for expected in expected_paths:
+                if expected not in schema_contract_paths:
+                    errors.append(f"{hook_id}: schema-contract job must run {expected} (from hook entry)")
 
     return errors
 
@@ -159,16 +204,21 @@ def validate_coverage_map(
     *,
     repo: Path | None = None,
     hook_ids: set[str] | None = None,
+    hook_entries: dict[str, str] | None = None,
     hook_scripts: dict[str, list[str]] | None = None,
+    hook_stages: dict[str, list[str]] | None = None,
     quality_ci: str | None = None,
-    schema_contract: str | None = None,
+    schema_contract_paths: list[str] | None = None,
 ) -> list[str]:
     """Return all schema and referential-integrity errors for *coverage_map*."""
     root = repo or repo_root()
-    hooks = hook_ids if hook_ids is not None else _pre_commit_hook_ids(root / PRE_COMMIT_CONFIG_PATH)
-    scripts = hook_scripts if hook_scripts is not None else _pre_commit_hook_scripts(root / PRE_COMMIT_CONFIG_PATH)
+    cfg_path = root / Path(".pre-commit-config.yaml")
+    hooks = hook_ids if hook_ids is not None else _pre_commit_hook_ids(cfg_path)
+    entries = hook_entries if hook_entries is not None else _pre_commit_hook_entries(cfg_path)
+    scripts = hook_scripts if hook_scripts is not None else _pre_commit_hook_scripts(cfg_path)
+    stages = hook_stages if hook_stages is not None else _pre_commit_hook_stages(cfg_path)
     ci_body = quality_ci if quality_ci is not None else _makefile_quality_ci_body(root / MAKEFILE_PATH)
-    contract = schema_contract if schema_contract is not None else _schema_contract_job_text(root / CI_WORKFLOW_PATH)
+    contract_paths = schema_contract_paths if schema_contract_paths is not None else _schema_contract_pytest_paths()
 
     errors: list[str] = []
     for hook_id, entry in coverage_map.items():
@@ -180,9 +230,11 @@ def validate_coverage_map(
                     entry,
                     repo=root,
                     hook_ids=hooks,
+                    hook_entries=entries,
                     hook_scripts=scripts,
+                    hook_stages=stages,
                     quality_ci=ci_body,
-                    schema_contract=contract,
+                    schema_contract_paths=contract_paths,
                 )
             )
     return errors
@@ -211,24 +263,127 @@ def test_coverage_map_prepush_ci_step_entries() -> None:
         assert "Makefile::quality-ci" in entry["location"], hook_id
 
 
+@dataclass(frozen=True)
+class _BrokenEntryProbe:
+    hook_id: str
+    entry: Any
+    expected_substr: str
+    hook_ids: set[str] | None = None
+    hook_entries: dict[str, str] | None = None
+    hook_scripts: dict[str, list[str]] | None = None
+    hook_stages: dict[str, list[str]] | None = None
+    quality_ci: str | None = None
+    schema_contract_paths: list[str] | None = None
+
+
+_BROKEN_ENTRY_PROBES = (
+    _BrokenEntryProbe("scalar-entry", "not-a-mapping", "entry must be a mapping"),
+    _BrokenEntryProbe("missing-keys", {}, "missing keys"),
+    _BrokenEntryProbe(
+        "bad-enforced-by",
+        {"enforced_by": "bogus", "location": "nowhere"},
+        "invalid enforced_by",
+    ),
+    _BrokenEntryProbe(
+        "phantom-guard",
+        {"enforced_by": "guard", "location": "tests/unit/test_architecture_does_not_exist.py"},
+        "guard location missing",
+    ),
+    _BrokenEntryProbe(
+        "phantom-guard-test",
+        {
+            "enforced_by": "guard",
+            "location": "tests/unit/test_architecture_pre_commit_coverage_map.py::test_does_not_exist",
+        },
+        "guard test missing",
+    ),
+    _BrokenEntryProbe(
+        "ci-step-no-makefile",
+        {"enforced_by": "ci-step", "location": "nowhere"},
+        "ci-step location must reference Makefile::quality-ci",
+    ),
+    _BrokenEntryProbe(
+        "ci-step-no-script",
+        {"enforced_by": "ci-step", "location": "Makefile::quality-ci"},
+        "no matching script for hook",
+        quality_ci="",
+    ),
+    _BrokenEntryProbe(
+        "phantom-prepush",
+        {"enforced_by": "pre-push", "location": "stages_prepush"},
+        "pre-push hook id missing",
+        hook_ids=set(),
+    ),
+    _BrokenEntryProbe(
+        "prepush-stage-mismatch",
+        {
+            "enforced_by": "pre-push + ci-step",
+            "location": "stages_prepush + Makefile::quality-ci",
+        },
+        "location claims stages_prepush but hook lacks pre-push stage",
+        hook_ids={"prepush-stage-mismatch"},
+        hook_stages={"prepush-stage-mismatch": ["commit"]},
+        hook_scripts={"prepush-stage-mismatch": ["check_docs_links.py"]},
+        quality_ci="check_docs_links.py",
+    ),
+    _BrokenEntryProbe(
+        "prepush-ci-no-job",
+        {"enforced_by": "pre-push + ci", "location": "stages_prepush"},
+        "location must reference schema-contract job",
+        hook_ids={"prepush-ci-no-job"},
+        hook_stages={"prepush-ci-no-job": ["pre-push"]},
+        hook_entries={"prepush-ci-no-job": "uv run pytest tests/unit/test_adcp_contract.py"},
+    ),
+    _BrokenEntryProbe(
+        "prepush-ci-missing-test",
+        {
+            "enforced_by": "pre-push + ci",
+            "location": "stages_prepush + .github/workflows/ci.yml::schema-contract",
+        },
+        "schema-contract job must run tests/unit/test_adcp_contract.py",
+        hook_ids={"prepush-ci-missing-test"},
+        hook_stages={"prepush-ci-missing-test": ["pre-push"]},
+        hook_entries={"prepush-ci-missing-test": "uv run pytest tests/unit/test_adcp_contract.py"},
+        schema_contract_paths=["tests/integration/test_mcp_contract_validation.py"],
+    ),
+    _BrokenEntryProbe(
+        "ci-no-job",
+        {"enforced_by": "ci", "location": "nowhere"},
+        "location must reference schema-contract job",
+    ),
+    _BrokenEntryProbe(
+        "ci-missing-test",
+        {
+            "enforced_by": "ci",
+            "location": ".github/workflows/ci.yml::schema-contract",
+        },
+        "schema-contract job must run tests/unit/test_adcp_contract.py",
+        hook_entries={"ci-missing-test": "uv run pytest tests/unit/test_adcp_contract.py"},
+        schema_contract_paths=["tests/integration/test_mcp_contract_validation.py"],
+    ),
+)
+
+
 @pytest.mark.arch_guard
-def test_coverage_map_parser_catches_broken_guard_location() -> None:
-    """Self-test: a phantom guard path must fail validation."""
+@pytest.mark.parametrize("probe", _BROKEN_ENTRY_PROBES, ids=lambda p: p.hook_id)
+def test_coverage_map_parser_catches_broken_entries(probe: _BrokenEntryProbe, tmp_path: Path) -> None:
+    """Self-test: each validation branch must fail on a deliberately broken entry."""
     repo = repo_root()
-    probe = repo / ".pre-commit-coverage-map.probe.yml"
-    probe.write_text(
-        yaml.safe_dump(
-            {
-                "phantom-guard": {
-                    "enforced_by": "guard",
-                    "location": "tests/unit/test_architecture_does_not_exist.py",
-                }
-            }
-        ),
+    probe_path = tmp_path / "probe.yml"
+    probe_path.write_text(
+        yaml.safe_dump({probe.hook_id: probe.entry}),
         encoding="utf-8",
     )
-    try:
-        errors = validate_coverage_map(_load_coverage_map(probe), repo=repo)
-        assert any("phantom-guard" in e and "missing" in e for e in errors)
-    finally:
-        probe.unlink(missing_ok=True)
+    errors = validate_coverage_map(
+        _load_coverage_map(probe_path),
+        repo=repo,
+        hook_ids=probe.hook_ids,
+        hook_entries=probe.hook_entries,
+        hook_scripts=probe.hook_scripts,
+        hook_stages=probe.hook_stages,
+        quality_ci=probe.quality_ci,
+        schema_contract_paths=probe.schema_contract_paths,
+    )
+    assert any(probe.expected_substr in e for e in errors), (
+        f"expected error containing {probe.expected_substr!r}, got: {errors}"
+    )

--- a/tests/unit/test_architecture_pre_commit_coverage_map.py
+++ b/tests/unit/test_architecture_pre_commit_coverage_map.py
@@ -1,0 +1,234 @@
+"""Guard: .pre-commit-coverage-map.yml entries are valid and referentially intact.
+
+Ensures hook migration mappings stay accurate after renames — phantom paths fail
+loudly instead of silently (Pattern 3, #1455).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from tests.unit._architecture_helpers import repo_root
+
+COVERAGE_MAP_PATH = Path(".pre-commit-coverage-map.yml")
+PRE_COMMIT_CONFIG_PATH = Path(".pre-commit-config.yaml")
+MAKEFILE_PATH = Path("Makefile")
+CI_WORKFLOW_PATH = Path(".github/workflows/ci.yml")
+
+ALLOWED_ENFORCED_BY = frozenset(
+    {
+        "guard",
+        "guard-existing",
+        "ci-step",
+        "pre-push",
+        "pre-push + ci-step",
+        "pre-push + ci",
+        "ci",
+        "deleted",
+        "consolidated",
+    }
+)
+
+_REQUIRED_KEYS = frozenset({"enforced_by", "location"})
+
+
+def _load_coverage_map(path: Path = COVERAGE_MAP_PATH) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _pre_commit_hook_ids(cfg_path: Path = PRE_COMMIT_CONFIG_PATH) -> set[str]:
+    cfg = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    return {hook["id"] for repo in cfg["repos"] for hook in repo["hooks"]}
+
+
+def _pre_commit_hook_scripts(cfg_path: Path = PRE_COMMIT_CONFIG_PATH) -> dict[str, list[str]]:
+    """Map hook id → script basenames referenced by the hook entry command."""
+    cfg = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    scripts: dict[str, list[str]] = {}
+    for repo in cfg["repos"]:
+        for hook in repo["hooks"]:
+            entry = hook.get("entry", "")
+            basenames = [Path(part).name for part in entry.split() if part.endswith(".py")]
+            scripts[hook["id"]] = basenames
+    return scripts
+
+
+def _makefile_quality_ci_body(makefile_path: Path = MAKEFILE_PATH) -> str:
+    lines = makefile_path.read_text(encoding="utf-8").splitlines()
+    body: list[str] = []
+    in_target = False
+    for line in lines:
+        if line.startswith("quality-ci:"):
+            in_target = True
+            continue
+        if in_target:
+            if line and not line[0].isspace():
+                break
+            body.append(line)
+    return "\n".join(body)
+
+
+def _schema_contract_job_text(ci_path: Path = CI_WORKFLOW_PATH) -> str:
+    text = ci_path.read_text(encoding="utf-8")
+    match = re.search(r"^  schema-contract:\n(.*?)(?=^  \w|\Z)", text, flags=re.MULTILINE | re.DOTALL)
+    assert match, "schema-contract job not found in ci.yml"
+    return match.group(1)
+
+
+def _guard_location_path(location: str) -> Path:
+    """Strip ``::test_name`` suffix and return repo-relative guard file path."""
+    file_part = location.split("::", 1)[0]
+    return Path(file_part)
+
+
+def _hook_script_names(hook_id: str, hook_scripts: dict[str, list[str]]) -> list[str]:
+    """Candidate script basenames for a coverage-map hook id."""
+    from_config = hook_scripts.get(hook_id, [])
+    underscored = hook_id.replace("-", "_")
+    return sorted({*from_config, f"{hook_id}.py", f"{underscored}.py"})
+
+
+def _script_in_quality_ci(hook_id: str, quality_ci: str, hook_scripts: dict[str, list[str]]) -> bool:
+    return any(name in quality_ci for name in _hook_script_names(hook_id, hook_scripts))
+
+
+def _validate_entry_schema(hook_id: str, entry: Any) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(entry, dict):
+        return [f"{hook_id}: entry must be a mapping"]
+    missing = _REQUIRED_KEYS - entry.keys()
+    if missing:
+        errors.append(f"{hook_id}: missing keys {sorted(missing)}")
+    enforced_by = entry.get("enforced_by")
+    if enforced_by not in ALLOWED_ENFORCED_BY:
+        errors.append(f"{hook_id}: invalid enforced_by {enforced_by!r}")
+    return errors
+
+
+def _validate_entry_references(
+    hook_id: str,
+    entry: dict[str, Any],
+    *,
+    repo: Path,
+    hook_ids: set[str],
+    hook_scripts: dict[str, list[str]],
+    quality_ci: str,
+    schema_contract: str,
+) -> list[str]:
+    errors: list[str] = []
+    enforced_by = entry["enforced_by"]
+    location = str(entry["location"])
+
+    if enforced_by in {"guard", "guard-existing"}:
+        path = repo / _guard_location_path(location)
+        if not path.is_file():
+            errors.append(f"{hook_id}: guard location missing: {path.relative_to(repo)}")
+
+    if enforced_by in {"ci-step", "pre-push + ci-step"}:
+        if "Makefile::quality-ci" not in location:
+            errors.append(f"{hook_id}: ci-step location must reference Makefile::quality-ci")
+        elif not _script_in_quality_ci(hook_id, quality_ci, hook_scripts):
+            errors.append(f"{hook_id}: no matching script for hook in Makefile quality-ci")
+
+    if enforced_by in {"pre-push", "pre-push + ci-step", "pre-push + ci"}:
+        if hook_id not in hook_ids:
+            errors.append(f"{hook_id}: pre-push hook id missing from .pre-commit-config.yaml")
+
+    if enforced_by == "pre-push + ci":
+        if "schema-contract" not in location:
+            errors.append(f"{hook_id}: pre-push + ci location must reference schema-contract job")
+        elif hook_id == "adcp-contract-tests" and "test_adcp_contract.py" not in schema_contract:
+            errors.append(f"{hook_id}: schema-contract job must run test_adcp_contract.py")
+
+    if enforced_by == "ci":
+        if "schema-contract" not in location:
+            errors.append(f"{hook_id}: ci location must reference schema-contract job")
+        elif hook_id == "mcp-contract-validation" and "test_mcp_contract_validation.py" not in schema_contract:
+            errors.append(f"{hook_id}: schema-contract job must run test_mcp_contract_validation.py")
+
+    return errors
+
+
+def validate_coverage_map(
+    coverage_map: dict[str, Any],
+    *,
+    repo: Path | None = None,
+    hook_ids: set[str] | None = None,
+    hook_scripts: dict[str, list[str]] | None = None,
+    quality_ci: str | None = None,
+    schema_contract: str | None = None,
+) -> list[str]:
+    """Return all schema and referential-integrity errors for *coverage_map*."""
+    root = repo or repo_root()
+    hooks = hook_ids if hook_ids is not None else _pre_commit_hook_ids(root / PRE_COMMIT_CONFIG_PATH)
+    scripts = hook_scripts if hook_scripts is not None else _pre_commit_hook_scripts(root / PRE_COMMIT_CONFIG_PATH)
+    ci_body = quality_ci if quality_ci is not None else _makefile_quality_ci_body(root / MAKEFILE_PATH)
+    contract = schema_contract if schema_contract is not None else _schema_contract_job_text(root / CI_WORKFLOW_PATH)
+
+    errors: list[str] = []
+    for hook_id, entry in coverage_map.items():
+        errors.extend(_validate_entry_schema(hook_id, entry))
+        if isinstance(entry, dict) and entry.keys() >= _REQUIRED_KEYS:
+            errors.extend(
+                _validate_entry_references(
+                    hook_id,
+                    entry,
+                    repo=root,
+                    hook_ids=hooks,
+                    hook_scripts=scripts,
+                    quality_ci=ci_body,
+                    schema_contract=contract,
+                )
+            )
+    return errors
+
+
+@pytest.mark.arch_guard
+def test_coverage_map_schema_and_references() -> None:
+    coverage_map = _load_coverage_map()
+    errors = validate_coverage_map(coverage_map)
+    assert not errors, "Coverage map validation failed:\n" + "\n".join(f"  {e}" for e in errors)
+
+
+@pytest.mark.arch_guard
+def test_coverage_map_prepush_ci_step_entries() -> None:
+    """Post-#1454: moved hooks must show pre-push + ci-step + Makefile::quality-ci."""
+    coverage_map = _load_coverage_map()
+    for hook_id in (
+        "check-route-conflicts",
+        "type-ignore-no-regression",
+        "check-docs-links",
+        "no-hardcoded-urls",
+    ):
+        entry = coverage_map[hook_id]
+        assert entry["enforced_by"] == "pre-push + ci-step", hook_id
+        assert "stages_prepush" in entry["location"], hook_id
+        assert "Makefile::quality-ci" in entry["location"], hook_id
+
+
+@pytest.mark.arch_guard
+def test_coverage_map_parser_catches_broken_guard_location() -> None:
+    """Self-test: a phantom guard path must fail validation."""
+    repo = repo_root()
+    probe = repo / ".pre-commit-coverage-map.probe.yml"
+    probe.write_text(
+        yaml.safe_dump(
+            {
+                "phantom-guard": {
+                    "enforced_by": "guard",
+                    "location": "tests/unit/test_architecture_does_not_exist.py",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    try:
+        errors = validate_coverage_map(_load_coverage_map(probe), repo=repo)
+        assert any("phantom-guard" in e and "missing" in e for e in errors)
+    finally:
+        probe.unlink(missing_ok=True)

--- a/tests/unit/test_architecture_pre_commit_coverage_map.py
+++ b/tests/unit/test_architecture_pre_commit_coverage_map.py
@@ -138,6 +138,31 @@ def _pytest_paths_from_hook_entry(entry: str) -> list[str]:
     return [part for part in entry.split() if part.startswith("tests/")]
 
 
+def _schema_contract_paths_from_location(location: str) -> list[str]:
+    """Extract explicit pytest paths after `` -> `` in a schema-contract location."""
+    if " -> " not in location:
+        return []
+    _, paths_part = location.rsplit(" -> ", 1)
+    return [part.strip() for part in paths_part.split(",") if part.strip()]
+
+
+def _schema_contract_expected_paths(
+    hook_id: str,
+    location: str,
+    hook_entries: dict[str, str],
+) -> list[str]:
+    """Paths the coverage map claims schema-contract must run for *hook_id*."""
+    explicit = _schema_contract_paths_from_location(location)
+    from_entry = _pytest_paths_from_hook_entry(hook_entries.get(hook_id, ""))
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for path in (*explicit, *from_entry):
+        if path not in seen:
+            seen.add(path)
+            ordered.append(path)
+    return ordered
+
+
 def _validate_entry_schema(hook_id: str, entry: Any) -> list[str]:
     errors: list[str] = []
     if not isinstance(entry, dict):
@@ -191,10 +216,15 @@ def _validate_entry_references(
         if "schema-contract" not in location:
             errors.append(f"{hook_id}: {enforced_by} location must reference schema-contract job")
         else:
-            expected_paths = _pytest_paths_from_hook_entry(hook_entries.get(hook_id, ""))
+            explicit_paths = _schema_contract_paths_from_location(location)
+            expected_paths = _schema_contract_expected_paths(hook_id, location, hook_entries)
+            if enforced_by == "ci" and hook_id not in hook_ids and not explicit_paths:
+                errors.append(f"{hook_id}: ci-only entry must declare schema-contract test path via ' -> ' in location")
+            if not expected_paths:
+                errors.append(f"{hook_id}: no schema-contract pytest paths declared (location ' -> ' or hook entry)")
             for expected in expected_paths:
                 if expected not in schema_contract_paths:
-                    errors.append(f"{hook_id}: schema-contract job must run {expected} (from hook entry)")
+                    errors.append(f"{hook_id}: schema-contract job must run {expected}")
 
     return errors
 
@@ -355,11 +385,21 @@ _BROKEN_ENTRY_PROBES = (
         "ci-missing-test",
         {
             "enforced_by": "ci",
+            "location": ".github/workflows/ci.yml::schema-contract -> tests/integration/test_mcp_contract_validation.py",
+        },
+        "schema-contract job must run tests/integration/test_mcp_contract_validation.py",
+        hook_entries={},
+        schema_contract_paths=["tests/unit/test_adcp_contract.py"],
+    ),
+    _BrokenEntryProbe(
+        "ci-only-no-path",
+        {
+            "enforced_by": "ci",
             "location": ".github/workflows/ci.yml::schema-contract",
         },
-        "schema-contract job must run tests/unit/test_adcp_contract.py",
-        hook_entries={"ci-missing-test": "uv run pytest tests/unit/test_adcp_contract.py"},
-        schema_contract_paths=["tests/integration/test_mcp_contract_validation.py"],
+        "ci-only entry must declare schema-contract test path via ' -> ' in location",
+        hook_ids=set(),
+        hook_entries={},
     ),
 )
 

--- a/tests/unit/test_architecture_pre_commit_hook_count.py
+++ b/tests/unit/test_architecture_pre_commit_hook_count.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
-import yaml
+
+from tests.unit._architecture_helpers import load_pre_commit_config
 
 COMMIT_STAGE_MIN = 10
 COMMIT_STAGE_MAX = 12
@@ -23,7 +22,7 @@ def _count_commit_stage_hooks(cfg: dict) -> int:
 
 @pytest.mark.arch_guard
 def test_pre_commit_hook_count_within_ceiling() -> None:
-    cfg = yaml.safe_load(Path(".pre-commit-config.yaml").read_text(encoding="utf-8"))
+    cfg = load_pre_commit_config()
     count = _count_commit_stage_hooks(cfg)
     assert count >= COMMIT_STAGE_MIN, (
         f"commit-stage hook count {count} < {COMMIT_STAGE_MIN} — likely over-deletion; see .pre-commit-coverage-map.yml"


### PR DESCRIPTION
Closes #1234.

## Summary
- Add `test_architecture_pre_commit_coverage_map.py` to validate `.pre-commit-coverage-map.yml` schema and referential integrity.
- Self-test probes all validation branches; shared pre-commit/CI parsers in `_architecture_helpers`.
- Part B (helper trim) deferred to a follow-up — #1400 is merged; remaining dead helpers tracked separately.

Part of #1455 (Part A only — does not auto-close; Part B is a separate PR).

## Review follow-ups (ChrisHuie)
- **ci-only schema-contract regression:** `mcp-contract-validation` now declares an explicit test path in `location` (`-> tests/integration/...`); parser validates it without relying on a pre-commit hook entry.
- **Self-test:** `ci-missing-test` and new `ci-only-no-path` probes use realistic empty `hook_entries` (no synthetic injection).

## Test plan
- [x] `uv run pytest tests/unit/test_architecture_pre_commit_coverage_map.py -v`
- [x] `make quality-ci`
- [ ] CI green on head