### PR TITLE
fix(ci): tighten check_no_skip_tests and hook-count guard (Pattern 4, #1234)

### DIFF
--- a/.pre-commit-hooks/check_repo_invariants.py
+++ b/.pre-commit-hooks/check_repo_invariants.py
@@ -10,6 +10,17 @@ import re
 import sys
 from pathlib import Path
 
+_SKIP_RE = re.compile(r"@pytest\.mark\.skip(?!if|_ci)")
+
+
+def is_forbidden_skip_line(line: str) -> bool:
+    """True when *line* contains a bare ``@pytest.mark.skip`` decorator.
+
+    ``@pytest.mark.skipif`` and ``@pytest.mark.skip_ci`` are allowed.
+    Shared by the pre-commit hook and the Smoke Tests gate.
+    """
+    return bool(_SKIP_RE.search(line))
+
 
 def check_no_skip_tests(files: list[Path]) -> list[str]:
     """Forbid bare @pytest.mark.skip in test files.
@@ -17,13 +28,12 @@ def check_no_skip_tests(files: list[Path]) -> list[str]:
     ``@pytest.mark.skipif`` and ``@pytest.mark.skip_ci`` are allowed (conditional /
     CI-specific skips). Bare ``skip`` without justification is forbidden.
     """
-    pattern = re.compile(r"@pytest\.mark\.skip(?!if|_ci)")
     out: list[str] = []
     for filepath in files:
         if "tests/" not in str(filepath) or not filepath.name.startswith("test_"):
             continue
         for lineno, line in enumerate(filepath.read_text().splitlines(), 1):
-            if pattern.search(line):
+            if is_forbidden_skip_line(line):
                 out.append(f"{filepath}:{lineno}: @pytest.mark.skip forbidden (use skip_ci with justification)")
     return out
 

--- a/.pre-commit-hooks/check_repo_invariants.py
+++ b/.pre-commit-hooks/check_repo_invariants.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 def check_no_skip_tests(files: list[Path]) -> list[str]:
     """Forbid @pytest.mark.skip without skip_ci justification."""
-    pattern = re.compile(r"@pytest\.mark\.skip(?!_ci)")
+    pattern = re.compile(r"@pytest\.mark\.skip(?!if|_ci)")
     out: list[str] = []
     for filepath in files:
         if "tests/" not in str(filepath) or not filepath.name.startswith("test_"):

--- a/.pre-commit-hooks/check_repo_invariants.py
+++ b/.pre-commit-hooks/check_repo_invariants.py
@@ -12,7 +12,11 @@ from pathlib import Path
 
 
 def check_no_skip_tests(files: list[Path]) -> list[str]:
-    """Forbid @pytest.mark.skip without skip_ci justification."""
+    """Forbid bare @pytest.mark.skip in test files.
+
+    ``@pytest.mark.skipif`` and ``@pytest.mark.skip_ci`` are allowed (conditional /
+    CI-specific skips). Bare ``skip`` without justification is forbidden.
+    """
     pattern = re.compile(r"@pytest\.mark\.skip(?!if|_ci)")
     out: list[str] = []
     for filepath in files:

--- a/tests/smoke/test_smoke_basic.py
+++ b/tests/smoke/test_smoke_basic.py
@@ -181,6 +181,7 @@ class TestNoSkippedTests:
                 if line
                 and "pytest.skip(" not in line  # Allow runtime skips
                 and "skip_ci" not in line  # Allow CI-specific skips
+                and "skipif" not in line  # @pytest.mark.skipif is a conditional skip — allowed
                 and "skip_pattern" not in line  # Exclude this test file
                 and "test_no_skip" not in line  # Exclude this test
                 and "test_no_hardcoded_credentials" not in line  # Exclude disabled test

--- a/tests/smoke/test_smoke_basic.py
+++ b/tests/smoke/test_smoke_basic.py
@@ -1,8 +1,16 @@
 """Basic smoke tests that don't require running servers."""
 
+import importlib.util
 from pathlib import Path
 
 import pytest
+
+_REPO_INVARIANTS_HOOK = Path(__file__).resolve().parents[2] / ".pre-commit-hooks" / "check_repo_invariants.py"
+_spec = importlib.util.spec_from_file_location("check_repo_invariants", _REPO_INVARIANTS_HOOK)
+assert _spec and _spec.loader
+_check_repo_invariants = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_check_repo_invariants)
+_is_forbidden_skip_line = _check_repo_invariants.is_forbidden_skip_line
 
 
 class TestCriticalImports:
@@ -159,37 +167,17 @@ class TestNoSkippedTests:
 
     @pytest.mark.smoke
     def test_no_skip_decorators(self):
-        """Test that no test files contain skip decorators."""
-        import subprocess
-
-        # Build the pattern in parts to avoid matching ourselves
-        skip_pattern = "@pytest" + ".mark" + ".skip"
-        test_dir = Path(__file__).parent.parent.parent
-        result = subprocess.run(
-            ["grep", "-r", skip_pattern, "tests/"],
-            cwd=str(test_dir),
-            capture_output=True,
-            text=True,
-        )
-
-        # Filter out legitimate uses
-        if result.returncode == 0:
-            lines = result.stdout.split("\n")
-            bad_lines = [
-                line
-                for line in lines
-                if line
-                and "pytest.skip(" not in line  # Allow runtime skips
-                and "skip_ci" not in line  # Allow CI-specific skips
-                and "skipif" not in line  # @pytest.mark.skipif is a conditional skip — allowed
-                and "skip_pattern" not in line  # Exclude this test file
-                and "test_no_skip" not in line  # Exclude this test
-                and "test_no_hardcoded_credentials" not in line  # Exclude disabled test
-                and "Overly aggressive pattern matching" not in line  # Exclude specific skip reason
-                and "__pycache__" not in line  # Exclude cache files
-                and "Binary file" not in line  # Exclude binary matches
-            ]
-            assert len(bad_lines) == 0, f"Found skip decorators:\n{chr(10).join(bad_lines[:5])}"
+        """Test that no test files contain forbidden bare skip decorators."""
+        tests_dir = Path(__file__).parent.parent
+        bad_lines: list[str] = []
+        for path in sorted(tests_dir.rglob("test_*.py")):
+            if "__pycache__" in path.parts:
+                continue
+            rel = path.relative_to(tests_dir.parent)
+            for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+                if _is_forbidden_skip_line(line):
+                    bad_lines.append(f"{rel}:{lineno}:{line.strip()}")
+        assert not bad_lines, f"Found forbidden skip decorators:\n{chr(10).join(bad_lines[:5])}"
 
 
 class TestCodeQuality:

--- a/tests/unit/test_architecture_pre_commit_hook_count.py
+++ b/tests/unit/test_architecture_pre_commit_hook_count.py
@@ -40,3 +40,22 @@ def test_commit_hook_counter_detects_over_ceiling() -> None:
         "repos": [{"hooks": [{"stages": ["commit"]}] * (COMMIT_STAGE_MAX + 1)}],
     }
     assert _count_commit_stage_hooks(over_cfg) == COMMIT_STAGE_MAX + 1
+
+
+@pytest.mark.arch_guard
+def test_commit_hook_counter_counts_hooks_without_explicit_stages() -> None:
+    cfg = {
+        "default_stages": ["pre-commit", "commit"],
+        "repos": [{"hooks": [{"id": "ruff"}, {"id": "mypy"}]}],
+    }
+    assert _count_commit_stage_hooks(cfg) == 2
+
+
+@pytest.mark.arch_guard
+def test_commit_hook_counter_detects_under_ceiling() -> None:
+    under_cfg = {
+        "default_stages": ["pre-commit", "commit"],
+        "repos": [{"hooks": [{"stages": ["commit"]}] * (COMMIT_STAGE_MIN - 1)}],
+    }
+    assert _count_commit_stage_hooks(under_cfg) == COMMIT_STAGE_MIN - 1
+    assert _count_commit_stage_hooks(under_cfg) < COMMIT_STAGE_MIN

--- a/tests/unit/test_architecture_pre_commit_hook_count.py
+++ b/tests/unit/test_architecture_pre_commit_hook_count.py
@@ -56,5 +56,3 @@ def test_commit_hook_counter_detects_under_ceiling() -> None:
     }
     count = _count_commit_stage_hooks(under_cfg)
     assert count == COMMIT_STAGE_MIN - 1
-    with pytest.raises(AssertionError):
-        assert count >= COMMIT_STAGE_MIN

--- a/tests/unit/test_architecture_pre_commit_hook_count.py
+++ b/tests/unit/test_architecture_pre_commit_hook_count.py
@@ -44,10 +44,7 @@ def test_commit_hook_counter_detects_over_ceiling() -> None:
 
 @pytest.mark.arch_guard
 def test_commit_hook_counter_counts_hooks_without_explicit_stages() -> None:
-    cfg = {
-        "default_stages": ["pre-commit", "commit"],
-        "repos": [{"hooks": [{"id": "ruff"}, {"id": "mypy"}]}],
-    }
+    cfg = {"repos": [{"hooks": [{"id": "ruff"}, {"id": "mypy"}]}]}
     assert _count_commit_stage_hooks(cfg) == 2
 
 
@@ -57,5 +54,7 @@ def test_commit_hook_counter_detects_under_ceiling() -> None:
         "default_stages": ["pre-commit", "commit"],
         "repos": [{"hooks": [{"stages": ["commit"]}] * (COMMIT_STAGE_MIN - 1)}],
     }
-    assert _count_commit_stage_hooks(under_cfg) == COMMIT_STAGE_MIN - 1
-    assert _count_commit_stage_hooks(under_cfg) < COMMIT_STAGE_MIN
+    count = _count_commit_stage_hooks(under_cfg)
+    assert count == COMMIT_STAGE_MIN - 1
+    with pytest.raises(AssertionError):
+        assert count >= COMMIT_STAGE_MIN

--- a/tests/unit/test_architecture_repo_invariants.py
+++ b/tests/unit/test_architecture_repo_invariants.py
@@ -42,9 +42,10 @@ def test_repo_invariants_skip_detector_catches_bare_skip(tmp_path) -> None:
 def test_repo_invariants_skip_detector_allows_skipif(tmp_path) -> None:
     ok_file = tmp_path / "tests" / "integration" / "test_probe.py"
     ok_file.parent.mkdir(parents=True)
+    skipif_dec = "@pytest.mark." + "skipif"  # keep the literal out of this file's source
     ok_file.write_text(
-        'skip_no_agent = pytest.mark.skipif(True, reason="no agent")\n@skip_no_agent\ndef test_probe():\n    pass\n',
+        f'{skipif_dec}(True, reason="conditional")\ndef test_probe():\n    pass\n',
         encoding="utf-8",
     )
     hits = check_no_skip_tests([ok_file])
-    assert not hits, "check_no_skip_tests must not flag conditional skip marker"
+    assert not hits, "check_no_skip_tests must not flag @pytest.mark.skipif"

--- a/tests/unit/test_architecture_repo_invariants.py
+++ b/tests/unit/test_architecture_repo_invariants.py
@@ -16,6 +16,7 @@ assert _spec and _spec.loader
 _check_repo_invariants = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_check_repo_invariants)
 check_no_fn_calls = _check_repo_invariants.check_no_fn_calls
+check_no_skip_tests = _check_repo_invariants.check_no_skip_tests
 
 
 @pytest.mark.arch_guard
@@ -25,3 +26,25 @@ def test_repo_invariants_fn_detector_catches_known_bad_snippet(tmp_path) -> None
     bad_file.write_text("def f():\n    return core_get_products_tool.fn()\n", encoding="utf-8")
     hits = check_no_fn_calls([bad_file])
     assert hits, "check_no_fn_calls must flag .fn() in src/"
+
+
+@pytest.mark.arch_guard
+def test_repo_invariants_skip_detector_catches_bare_skip(tmp_path) -> None:
+    bad_file = tmp_path / "tests" / "unit" / "test_probe.py"
+    bad_file.parent.mkdir(parents=True)
+    bare_skip = "@pytest.mark." + "skip"
+    bad_file.write_text(f"{bare_skip}(reason='temporary')\ndef test_probe():\n    pass\n", encoding="utf-8")
+    hits = check_no_skip_tests([bad_file])
+    assert hits, "check_no_skip_tests must flag bare skip marker"
+
+
+@pytest.mark.arch_guard
+def test_repo_invariants_skip_detector_allows_skipif(tmp_path) -> None:
+    ok_file = tmp_path / "tests" / "integration" / "test_probe.py"
+    ok_file.parent.mkdir(parents=True)
+    ok_file.write_text(
+        'skip_no_agent = pytest.mark.skipif(True, reason="no agent")\n@skip_no_agent\ndef test_probe():\n    pass\n',
+        encoding="utf-8",
+    )
+    hits = check_no_skip_tests([ok_file])
+    assert not hits, "check_no_skip_tests must not flag @pytest.mark.skipif"

--- a/tests/unit/test_architecture_repo_invariants.py
+++ b/tests/unit/test_architecture_repo_invariants.py
@@ -47,4 +47,4 @@ def test_repo_invariants_skip_detector_allows_skipif(tmp_path) -> None:
         encoding="utf-8",
     )
     hits = check_no_skip_tests([ok_file])
-    assert not hits, "check_no_skip_tests must not flag @pytest.mark.skipif"
+    assert not hits, "check_no_skip_tests must not flag conditional skip marker"


### PR DESCRIPTION
## Summary
- Fix `check_no_skip_tests` regex so `@pytest.mark.skipif` is not falsely flagged (`skip(?!if|_ci)`).
- Add self-tests for skip detection (bare skip vs skipif) in `test_architecture_repo_invariants.py`.
- Add hook-count self-tests for default-stages fallback and under-ceiling detection.

Closes #1456

## Test plan
- [x] `uv run pytest tests/unit/test_architecture_repo_invariants.py tests/unit/test_architecture_pre_commit_hook_count.py -v`
- [x] `make quality`