### PR TITLE
fix: link ObjectWorkflowMapping on auto-approve path before push notification (#1378)

### DIFF
--- a/docs/test-obligations/UC-002-create-media-buy.md
+++ b/docs/test-obligations/UC-002-create-media-buy.md
@@ -297,6 +297,16 @@ Source: UC-002-main-mcp.md
 **Business Rule:** BR-RULE-018 INV-1
 **Priority:** P0
 
+#### Scenario: Auto-Approve -- ObjectWorkflowMapping Persisted Before Push Notification
+**Obligation ID** UC-002-MAIN-22
+**Layer** behavioral
+**Given** auto-approval path
+**When** the system completes the media buy and calls `update_workflow_step(status="completed")`
+**Then** an `ObjectWorkflowMapping` row linking the workflow step to the media buy is persisted in the database BEFORE `update_workflow_step` is called
+**And** `link_workflow_to_object` is invoked with `object_type="media_buy"` and the correct `object_id`
+**Business Rule:** BR-RULE-020 (regression: issue #1378 — silent webhook drop on auto-approve path)
+**Priority:** P0
+
 ---
 
 ### 3.6 Upgrade: Boundary Field Propagation (salesagent-7gnv)

--- a/src/core/tools/media_buy_create.py
+++ b/src/core/tools/media_buy_create.py
@@ -107,7 +107,7 @@ from src.core.auth import (
     resolve_principal_or_raise,
 )
 from src.core.context_manager import get_context_manager
-from src.core.database.models import AdapterConfig, CurrencyLimit, MediaBuy, ObjectWorkflowMapping
+from src.core.database.models import AdapterConfig, CurrencyLimit, MediaBuy
 from src.core.database.models import Creative as DBCreative
 from src.core.database.models import CreativeAssignment as DBAssignment
 from src.core.database.models import MediaPackage as DBMediaPackage
@@ -2815,15 +2815,14 @@ async def _create_media_buy_impl(
                 logger.info(f"✅ Created {len(pending_packages)} MediaPackage records")
 
             # Link the workflow step to the media buy so the approval button shows in UI
-            with MediaBuyUoW(tenant["tenant_id"]) as wf_uow:
-                # FIXME(salesagent-9f2): workflow mapping should use a repository method
-                assert wf_uow.session is not None
-                mapping = ObjectWorkflowMapping(
-                    object_type="media_buy", object_id=media_buy_id, step_id=step.step_id, action="create"
-                )
-                wf_uow.session.add(mapping)
-                # UoW auto-commits on clean exit
-                logger.info(f"✅ Linked workflow step {step.step_id} to media buy")
+            ctx_manager.link_workflow_to_object(
+                step_id=step.step_id,
+                object_type="media_buy",
+                object_id=media_buy_id,
+                action="create",
+                tenant_id=tenant["tenant_id"],
+            )
+            logger.info(f"✅ Linked workflow step {step.step_id} to media buy")
 
             # Create creative assignments for manual approval flow
             # This must happen AFTER media packages are created so we have package_ids
@@ -3992,7 +3991,17 @@ async def _create_media_buy_impl(
         if hooks_result.media_buy_id_override:
             modified_response = adcp_response.model_copy(update={"media_buy_id": hooks_result.media_buy_id_override})
 
-        # Mark workflow step as completed on success
+        # Link workflow step to media buy so _send_push_notifications can find the webhook URL.
+        # This MUST happen before update_workflow_step() which triggers _send_push_notifications.
+        ctx_manager.link_workflow_to_object(
+            step_id=step.step_id,
+            object_type="media_buy",
+            object_id=response.media_buy_id,
+            action="create",
+            tenant_id=tenant["tenant_id"],
+        )
+
+        # Mark workflow step as completed on success (triggers _send_push_notifications)
         ctx_manager.update_workflow_step(step.step_id, status="completed")
 
         # Send Slack notification for successful media buy creation

--- a/tests/harness/media_buy_create.py
+++ b/tests/harness/media_buy_create.py
@@ -137,10 +137,12 @@ class MediaBuyCreateEnv(IntegrationEnv):
         return product, pricing_option
 
     def _build_mock_context_manager(self, tool_name: str) -> MagicMock:
-        """Mock context manager that delegates create_context / create_workflow_step to the REAL one.
+        """Mock context manager that delegates create_context / create_workflow_step /
+        link_workflow_to_object to the REAL one.
 
-        Persisting real Context / WorkflowStep rows lets the manual-approval path satisfy
-        the ObjectWorkflowMapping foreign keys while the other ContextManager methods stay mocked.
+        Persisting real Context / WorkflowStep / ObjectWorkflowMapping rows lets both
+        the manual-approval path and the auto-approve path satisfy the FK constraints
+        that _send_push_notifications relies on to deliver webhooks.
         """
         from src.core.context_manager import get_context_manager
 
@@ -159,9 +161,13 @@ class MediaBuyCreateEnv(IntegrationEnv):
             kwargs.setdefault("tool_name", tool_name)
             return real.create_workflow_step(**kwargs)
 
+        def _link_workflow_to_object(*_args: Any, **kwargs: Any):
+            return real.link_workflow_to_object(**kwargs)
+
         mgr.create_context.side_effect = _create_context
         mgr.get_context.return_value = None
         mgr.create_workflow_step.side_effect = _create_workflow_step
+        mgr.link_workflow_to_object.side_effect = _link_workflow_to_object
         mgr.update_workflow_step.return_value = None
         mgr.add_message.return_value = None
         return mgr

--- a/tests/integration/test_create_media_buy_behavioral.py
+++ b/tests/integration/test_create_media_buy_behavioral.py
@@ -26,7 +26,7 @@ OBLIGATION COVERAGE:
   UC-002-EXT-I-03, UC-002-EXT-J-02, UC-002-EXT-K-03
   UC-002-EXT-L-01, -02, -03, UC-002-EXT-M-01, -03
   UC-002-EXT-N-02, UC-002-EXT-O-01, UC-002-EXT-Q-01, -02
-  UC-002-MAIN-01, -03, -04, -05, -09, -10, -14, -15, -17, -20
+  UC-002-MAIN-01, -03, -04, -05, -09, -10, -14, -15, -17, -20, -22
   UC-002-POST-01, -03, UC-002-PRECOND-01, -02
   UC-002-UPG-01, -02, -04, -07, -09
 
@@ -716,14 +716,16 @@ class TestMainFlowObligations:
         assert result.response.media_buy_id is not None
 
     def test_auto_approve_calls_link_workflow_to_object(self, integration_db):
-        """Auto-approve path calls link_workflow_to_object before update_workflow_step.
+        """Auto-approve path persists ObjectWorkflowMapping before update_workflow_step.
 
         Regression test for issue #1378: on the auto-approve path no ObjectWorkflowMapping
         row was created before update_workflow_step() triggered _send_push_notifications,
         causing the webhook to be silently dropped.
 
-        Covers: UC-002-MAIN-01 (push notification delivery on auto-approve)
+        Covers: UC-002-MAIN-22
         """
+        from src.core.database.repositories.workflow import WorkflowRepository
+
         req = _make_request()
 
         with _env() as env:
@@ -741,7 +743,9 @@ class TestMainFlowObligations:
                 tenant_id=ANY,
             )
             # link_workflow_to_object must be called BEFORE update_workflow_step("completed")
-            link_call_idx = next(i for i, c in enumerate(ctx_mgr_mock.method_calls) if c[0] == "link_workflow_to_object")
+            link_call_idx = next(
+                i for i, c in enumerate(ctx_mgr_mock.method_calls) if c[0] == "link_workflow_to_object"
+            )
             complete_call_idx = next(
                 i
                 for i, c in enumerate(ctx_mgr_mock.method_calls)
@@ -750,6 +754,11 @@ class TestMainFlowObligations:
             assert link_call_idx < complete_call_idx, (
                 "link_workflow_to_object must be called before update_workflow_step(status='completed')"
             )
+            # Production-state assertion: the ObjectWorkflowMapping row must actually
+            # be persisted in the DB (the harness runs the real link_workflow_to_object).
+            repo = WorkflowRepository(env._session, tenant_id=tenant.tenant_id)
+            mapping = repo.get_latest_mapping_for_object("media_buy", result.response.media_buy_id)
+            assert mapping is not None, "ObjectWorkflowMapping row was not persisted for the auto-approved media buy"
 
     @pytest.mark.asyncio
     async def test_authentication_extracts_principal_id(self):

--- a/tests/integration/test_create_media_buy_behavioral.py
+++ b/tests/integration/test_create_media_buy_behavioral.py
@@ -731,25 +731,25 @@ class TestMainFlowObligations:
             env.setup_product_chain(tenant)
             result = env.call_impl(req=req)
 
-        assert isinstance(result.response, CreateMediaBuySuccess)
-        ctx_mgr_mock = env.mock["context_mgr"].return_value
-        ctx_mgr_mock.link_workflow_to_object.assert_called_once_with(
-            step_id=ANY,
-            object_type="media_buy",
-            object_id=result.response.media_buy_id,
-            action="create",
-            tenant_id=ANY,
-        )
-        # link_workflow_to_object must be called BEFORE update_workflow_step("completed")
-        link_call_idx = next(i for i, c in enumerate(ctx_mgr_mock.method_calls) if c[0] == "link_workflow_to_object")
-        complete_call_idx = next(
-            i
-            for i, c in enumerate(ctx_mgr_mock.method_calls)
-            if c[0] == "update_workflow_step" and c[2].get("status") == "completed"
-        )
-        assert link_call_idx < complete_call_idx, (
-            "link_workflow_to_object must be called before update_workflow_step(status='completed')"
-        )
+            assert isinstance(result.response, CreateMediaBuySuccess)
+            ctx_mgr_mock = env.mock["context_mgr"].return_value
+            ctx_mgr_mock.link_workflow_to_object.assert_called_once_with(
+                step_id=ANY,
+                object_type="media_buy",
+                object_id=result.response.media_buy_id,
+                action="create",
+                tenant_id=ANY,
+            )
+            # link_workflow_to_object must be called BEFORE update_workflow_step("completed")
+            link_call_idx = next(i for i, c in enumerate(ctx_mgr_mock.method_calls) if c[0] == "link_workflow_to_object")
+            complete_call_idx = next(
+                i
+                for i, c in enumerate(ctx_mgr_mock.method_calls)
+                if c[0] == "update_workflow_step" and c[2].get("status") == "completed"
+            )
+            assert link_call_idx < complete_call_idx, (
+                "link_workflow_to_object must be called before update_workflow_step(status='completed')"
+            )
 
     @pytest.mark.asyncio
     async def test_authentication_extracts_principal_id(self):
@@ -1382,15 +1382,15 @@ class TestCrossCuttingObligations:
             _require_manual_approval(env)
             result = env.call_impl(req=req)
 
-        assert result.response.media_buy_id is not None
-        ctx_mgr_mock = env.mock["context_mgr"].return_value
-        ctx_mgr_mock.link_workflow_to_object.assert_called_once_with(
-            step_id=ANY,
-            object_type="media_buy",
-            object_id=result.response.media_buy_id,
-            action="create",
-            tenant_id=ANY,
-        )
+            assert result.response.media_buy_id is not None
+            ctx_mgr_mock = env.mock["context_mgr"].return_value
+            ctx_mgr_mock.link_workflow_to_object.assert_called_once_with(
+                step_id=ANY,
+                object_type="media_buy",
+                object_id=result.response.media_buy_id,
+                action="create",
+                tenant_id=ANY,
+            )
 
     @pytest.mark.asyncio
     async def test_creative_in_valid_state_assigned_successfully(self):

--- a/tests/integration/test_create_media_buy_behavioral.py
+++ b/tests/integration/test_create_media_buy_behavioral.py
@@ -715,6 +715,42 @@ class TestMainFlowObligations:
         assert isinstance(result.response, CreateMediaBuySuccess)
         assert result.response.media_buy_id is not None
 
+    def test_auto_approve_calls_link_workflow_to_object(self, integration_db):
+        """Auto-approve path calls link_workflow_to_object before update_workflow_step.
+
+        Regression test for issue #1378: on the auto-approve path no ObjectWorkflowMapping
+        row was created before update_workflow_step() triggered _send_push_notifications,
+        causing the webhook to be silently dropped.
+
+        Covers: UC-002-MAIN-01 (push notification delivery on auto-approve)
+        """
+        req = _make_request()
+
+        with _env() as env:
+            tenant, _principal = env.setup_default_data()
+            env.setup_product_chain(tenant)
+            result = env.call_impl(req=req)
+
+        assert isinstance(result.response, CreateMediaBuySuccess)
+        ctx_mgr_mock = env.mock["context_mgr"].return_value
+        ctx_mgr_mock.link_workflow_to_object.assert_called_once_with(
+            step_id=ANY,
+            object_type="media_buy",
+            object_id=result.response.media_buy_id,
+            action="create",
+            tenant_id=ANY,
+        )
+        # link_workflow_to_object must be called BEFORE update_workflow_step("completed")
+        link_call_idx = next(i for i, c in enumerate(ctx_mgr_mock.method_calls) if c[0] == "link_workflow_to_object")
+        complete_call_idx = next(
+            i
+            for i, c in enumerate(ctx_mgr_mock.method_calls)
+            if c[0] == "update_workflow_step" and c[2].get("status") == "completed"
+        )
+        assert link_call_idx < complete_call_idx, (
+            "link_workflow_to_object must be called before update_workflow_step(status='completed')"
+        )
+
     @pytest.mark.asyncio
     async def test_authentication_extracts_principal_id(self):
         """Authentication resolves principal_id from identity.
@@ -1328,6 +1364,33 @@ class TestCrossCuttingObligations:
             assert result.status == "submitted"
             env.mock["adapter"].return_value.create_media_buy.assert_not_called()
             assert result.response.media_buy_id is not None
+
+    def test_manual_approval_calls_link_workflow_to_object(self, integration_db):
+        """Manual-approval path calls link_workflow_to_object to create the ObjectWorkflowMapping row.
+
+        Regression test for issue #1378 (DRY follow-up): the manual-approval path must use
+        ctx_manager.link_workflow_to_object() rather than an inline ObjectWorkflowMapping insert,
+        giving both paths consistent error handling and a single code path.
+
+        Covers: UC-002-CC-ADAPTER-ATOMICITY-03
+        """
+        req = _make_request()
+
+        with _env(human_review_required=True) as env:
+            tenant, _principal = env.setup_default_data()
+            env.setup_product_chain(tenant)
+            _require_manual_approval(env)
+            result = env.call_impl(req=req)
+
+        assert result.response.media_buy_id is not None
+        ctx_mgr_mock = env.mock["context_mgr"].return_value
+        ctx_mgr_mock.link_workflow_to_object.assert_called_once_with(
+            step_id=ANY,
+            object_type="media_buy",
+            object_id=result.response.media_buy_id,
+            action="create",
+            tenant_id=ANY,
+        )
 
     @pytest.mark.asyncio
     async def test_creative_in_valid_state_assigned_successfully(self):


### PR DESCRIPTION
## Summary

Fixes #1378 — push notification webhook silently dropped on auto-approve path.

## Root cause

On the auto-approve path, `_create_media_buy_impl` called `ctx_manager.update_workflow_step(step.step_id, status="completed")` without first creating an `ObjectWorkflowMapping` row. `update_workflow_step` internally triggers `_send_push_notifications`, which queries `ObjectWorkflowMapping` to find the webhook URL. With no row present it returned early silently — the webhook was never delivered.

## Changes

### Bug fix (auto-approve path)
`src/core/tools/media_buy_create.py` — call `ctx_manager.link_workflow_to_object()` **before** `update_workflow_step(status="completed")` on the auto-approve path so `_send_push_notifications` can find the mapping row.

### DRY follow-up (manual-approval path)
Replace the inline `ObjectWorkflowMapping` insert on the manual-approval path (~line 2817) with a call to the same `ctx_manager.link_workflow_to_object()` method. This:
- Eliminates duplicated insert logic
- Gives both paths consistent error handling (the method has its own `try/except` with rollback)
- Removes the unused-dead-code risk from `link_workflow_to_object()` never being called

### Import cleanup
Remove `ObjectWorkflowMapping` from the import in `media_buy_create.py` — it is no longer referenced directly.

### Harness update
`tests/harness/media_buy_create.py` — delegate `link_workflow_to_object` to the real `ContextManager` implementation so integration tests actually persist the `ObjectWorkflowMapping` FK row (matching production behaviour).

### Tests
Two new integration tests in `tests/integration/test_create_media_buy_behavioral.py`:
- `test_auto_approve_calls_link_workflow_to_object` — asserts the method is called with correct args and **before** `update_workflow_step(status='completed')`
- `test_manual_approval_calls_link_workflow_to_object` — same assertion for the manual-approval path

## Testing
- `make quality` passes (unit tests green; mypy errors are pre-existing on `upstream/main`)
- New integration tests cover both paths
