### PR TITLE
test: wire list_creative_formats format_id object-shape scenario on all transports

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -401,6 +401,37 @@ MCP, or A2A — only those transports observe actual wire bytes.
 compatibility. Reconstruction is lossy — assert on `wire_error_envelope`
 (or `synthesized_error_envelope` for IMPL).
 
+### TransportResult.wire_response (success-path wire)
+
+`TransportResult` also exposes `wire_response: dict | None` — the **serialized
+success-path response body**, the success-path analogue of `wire_error_envelope`.
+Populated on success by the REST dispatcher (HTTP body) and by the A2A/MCP
+dispatchers **only when the env routes through `_run_a2a_handler` /
+`_run_mcp_client`** (which stash the wire). Legacy `_run_mcp_wrapper` and the
+direct `*_raw` wrappers do not stash, so `wire_response` is `None` there — as it
+is on error and on IMPL. Today only `CreativeFormatsEnv` reads it.
+Use it to assert the **actual serialized shape** a buyer receives (e.g. the v3.1
+`format_id` `{agent_url, id}` federation contract on `list_creative_formats`)
+rather than the typed `payload`, whose fields are already coerced to their
+declared types and so cannot catch a serialization regression.
+
+**Authenticity per transport:**
+
+| Transport | `wire_response` source | Notes |
+|-----------|------------------------|-------|
+| REST | HTTP JSON body (`response.json()`) | Real wire; equals `raw_response.json()`. |
+| MCP  | `ToolResult.structured_content` (real wire) | Stashed by `_run_mcp_client`. |
+| A2A  | Full artifact DataPart (real wire) | Stashed by `_run_a2a_handler` BEFORE the `message`/`success` strip, so top-level envelope fields are present. |
+| IMPL | `None` (no wire by definition) | Serialize the typed `payload` (`model_dump(mode="json")`) — exercises the production serializer, not transport framing. |
+
+As with `wire_error_envelope`, real wire-shape regressions are only observable on
+REST/MCP/A2A; IMPL's `model_dump` only exercises the serializer. See
+`tests/integration/test_harness_wire_response.py` (pins that the field is real
+wire, not a payload reconstruction) and
+`tests/bdd/steps/domain/uc005_format_id_shape.py` (uses it for the format_id
+federation contract; reusable by the `roundtrip-from-products` /
+`third-party-agent` siblings).
+
 ## Infrastructure
 
 | What you need | Command |

--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -43,6 +43,7 @@ pytest_plugins = [
     "tests.bdd.steps.domain.uc004_delivery",
     "tests.bdd.steps.domain.uc002_create_media_buy",
     "tests.bdd.steps.domain.uc006_sync_creatives",
+    "tests.bdd.steps.domain.uc005_format_id_shape",
     "tests.bdd.steps.domain.uc011_accounts",
     "tests.bdd.steps.domain.admin_accounts",
     "tests.bdd.steps.domain.uc_get_products_inventory",

--- a/tests/bdd/features/BR-UC-005-discover-creative-formats.feature
+++ b/tests/bdd/features/BR-UC-005-discover-creative-formats.feature
@@ -1101,3 +1101,6 @@ Feature: BR-UC-005 Discover Creative Formats
     # unique identifier within that agent). Sellers returning bare-string format IDs
     # break the v3.1 federation contract.
     # discover_formats: format_id object shape is the federation contract
+    # The strict "every entry / never a bare string" form is mandated by the schema
+    # (core/format-id.json: required [agent_url, id]); the storyboard grades field_present on formats[0].
+    # @source repo=adcp ref=v3.1-04f59d2d5 commit=04f59d2d5 path=static/schemas/source/core/format-id.json

--- a/tests/bdd/steps/domain/uc005_format_id_shape.py
+++ b/tests/bdd/steps/domain/uc005_format_id_shape.py
@@ -1,0 +1,74 @@
+"""UC-005 baseline: list_creative_formats format_id object shape.
+
+Scenario ``T-UC-005-storyboard-baseline-format-id-object-shape`` (@baseline-conformance):
+every ``format_id`` returned by ``list_creative_formats`` must be an object carrying
+both ``agent_url`` and ``id`` — never a bare string. The "every entry / never a bare
+string" strictness is the **schema** contract (``core/format-id.json``: required
+[agent_url, id]); the storyboard's discover_formats step only grades ``field_present``
+on ``formats[0]``, so this scenario is intentionally stricter than the graded step.
+
+Wired to real production across all 4 transports (auto-parametrized; UC-005 →
+CreativeFormatsEnv). REST/A2A/MCP assert the actual serialized wire dict surfaced
+by the harness (``ctx["wire_response"]``); IMPL has no wire, so it asserts the
+production serializer output (``model_dump(mode="json")`` — exercises
+``NestedModelSerializerMixin``). The wire/serializer path is the only place the
+contract is falsifiable: the typed payload is a required structured type and can
+never be a bare string by construction.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pytest_bdd import then, when
+
+from tests.bdd.steps._outcome_helpers import _require_response
+from tests.harness.transport import Transport
+from tests.helpers.format_assertions import assert_wire_format_id_is_object
+
+
+def _serialized_formats(ctx: dict) -> list[dict[str, Any]]:
+    """Return the formats array as the buyer sees it on the serialized wire.
+
+    REST/A2A/MCP expose the real success-path wire dict via ``ctx["wire_response"]``.
+    IMPL has no wire, so serialize the typed payload through the production
+    serializer — the same path that produces wire bytes for the other transports.
+    """
+    wire = ctx.get("wire_response")
+    transport = ctx.get("transport")
+    # Loud guard: a real-wire transport (REST/A2A/MCP) that didn't stash
+    # wire_response would otherwise fall through to the model_dump path and
+    # assert nothing on the wire — the silent tautology this scenario removes.
+    # A future sibling wired against a non-stashing env (e.g. media_buy_list,
+    # creative_sync, media_buy_update A2A/MCP) trips this instead of passing
+    # green. IMPL (and the non-parametrized None default) legitimately have no wire.
+    if wire is None and transport not in (None, Transport.IMPL):
+        raise AssertionError(f"{transport}: wire_response missing — env does not stash success-path wire")
+    if wire is not None:
+        return wire["formats"]
+    # IMPL has no wire — serialize the typed payload through the production
+    # serializer. _require_response preserves the diagnostic if a (reused) sibling
+    # scenario hit an error path, instead of a bare ctx["response"] KeyError.
+    return _require_response(ctx).model_dump(mode="json")["formats"]
+
+
+@when("the response returns a non-empty formats array")
+def when_response_returns_non_empty_formats(ctx: dict) -> None:
+    # Precondition guard (phrased as a When by the storyboard): the Given's
+    # dispatch must have returned a non-empty formats array before shape checks.
+    assert len(_require_response(ctx).formats) >= 1
+
+
+@then("every entry's format_id should be an object carrying both agent_url and id")
+def then_every_format_id_is_object(ctx: dict) -> None:
+    # Non-emptiness is asserted by the preceding When step; here we assert the
+    # shape of each entry (element-level, not a count).
+    for entry in _serialized_formats(ctx):
+        assert_wire_format_id_is_object(entry["format_id"])
+
+
+@then("no entry's format_id should be a bare string")
+def then_no_format_id_is_bare_string(ctx: dict) -> None:
+    for entry in _serialized_formats(ctx):
+        fid = entry["format_id"]
+        assert isinstance(fid, dict), f"format_id is a bare string on the wire: {fid!r}"

--- a/tests/bdd/steps/generic/when_request.py
+++ b/tests/bdd/steps/generic/when_request.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from pytest_bdd import parsers, when
+from pytest_bdd import given, parsers, when
 
 from src.core.schemas import FormatId, ListCreativeFormatsRequest
 from tests.harness.transport import Transport
@@ -58,6 +58,9 @@ def _call_via(ctx: dict, transport: str | Transport, req: ListCreativeFormatsReq
             ctx["error"] = result.error
         else:
             ctx["response"] = result.payload
+            # Real serialized wire (REST/A2A/MCP); None on IMPL — surfaced for
+            # success-path wire-shape steps (e.g. format_id federation contract).
+            ctx["wire_response"] = result.wire_response
     except Exception as exc:
         ctx["error"] = exc
 
@@ -116,6 +119,7 @@ def when_call_mcp_type(ctx: dict, type_value: str) -> None:
 # ── Generic format request (transport-agnostic) ──────────────────────
 
 
+@given("the Buyer Agent calls list_creative_formats without filters")
 @when(
     parsers.re(
         r"the Buyer Agent (?:requests the format catalog"
@@ -124,7 +128,12 @@ def when_call_mcp_type(ctx: dict, type_value: str) -> None:
     )
 )
 def when_request_unfiltered(ctx: dict) -> None:
-    """Any phrasing of 'make an unfiltered format request'."""
+    """Unfiltered list_creative_formats dispatch.
+
+    Serves both the generic 'requests/sends a list_creative_formats request'
+    When phrasings and the UC-005 baseline Given 'the Buyer Agent calls
+    list_creative_formats without filters' (single canonical dispatch step).
+    """
     _call(ctx)
 
 

--- a/tests/harness/_base.py
+++ b/tests/harness/_base.py
@@ -347,6 +347,11 @@ class BaseTestEnv:
         self._session: Session | None = None
         self._identity_cache: dict[str, ResolvedIdentity] = {}
         self._rest_client: Any = None  # Lazy-created TestClient
+        # Real serialized success-path wire, stashed by _run_a2a_handler /
+        # _run_mcp_client (the only paths that capture it) and read by the
+        # A2A/MCP dispatchers. None unless such a path ran — REST builds its
+        # own from the HTTP body; legacy/_raw paths and IMPL leave it None.
+        self._last_wire_response: dict[str, Any] | None = None
 
     # -- Identity (one function, all transports) ----------------------------
 
@@ -436,6 +441,9 @@ class BaseTestEnv:
         kwargs.setdefault("identity", self.identity_for(transport))
 
         dispatcher = DISPATCHERS[transport]
+        # Reset success-path wire capture; _run_a2a_handler / _run_mcp_client
+        # set it fresh on success so A2A/MCP dispatchers can surface real wire.
+        self._last_wire_response = None
         return dispatcher.dispatch(self, **kwargs)
 
     # -- Per-transport hooks (override in subclass) -------------------------
@@ -610,6 +618,10 @@ class BaseTestEnv:
         if not task_result.artifacts:
             raise ValueError(f"Task has no artifacts. Status: {task_result.status}")
         artifact_data = extract_data_from_artifact(task_result.artifacts[0])
+        # Surface the full, unstripped artifact DataPart as the real A2A wire for
+        # success-path assertions. Captured BEFORE stripping so siblings that need
+        # the top-level envelope fields (message/success) still see them.
+        self._last_wire_response = dict(artifact_data)
         # Strip protocol fields added by _serialize_for_a2a (message, success).
         # These are A2A-envelope fields, not part of the Pydantic response model,
         # and cause ValidationError under extra="forbid" in non-production mode.
@@ -694,6 +706,7 @@ class BaseTestEnv:
                         assert patched_th.called or patched_mw.called, (
                             f"Auth chain not exercised for {tool_name} — get_http_headers patches were not called"
                         )
+                        self._last_wire_response = result.structured_content
                         return response_cls(**result.structured_content)
 
         else:
@@ -705,6 +718,7 @@ class BaseTestEnv:
                 ):
                     async with Client(mcp) as client:
                         result = await client.call_tool(tool_name, arguments)
+                        self._last_wire_response = result.structured_content
                         return response_cls(**result.structured_content)
 
         try:

--- a/tests/harness/dispatchers.py
+++ b/tests/harness/dispatchers.py
@@ -127,7 +127,14 @@ class A2ADispatcher:
                 error=exc,
                 wire_error_envelope=_wire_envelope_from_exception(exc),
             )
-        return TransportResult(payload=payload, envelope={"transport": "a2a"})
+        # Real A2A wire: the artifact DataPart dict stashed by _run_a2a_handler
+        # (declared on BaseTestEnv, reset per call_via — read directly so a
+        # missed capture surfaces as None against a known attribute, not getattr).
+        return TransportResult(
+            payload=payload,
+            envelope={"transport": "a2a"},
+            wire_response=env._last_wire_response,
+        )
 
 
 class RestDispatcher:
@@ -161,8 +168,10 @@ class RestDispatcher:
                     wire_error_envelope=body,
                 )
 
-            payload = env.parse_rest_response(response.json())
-            return TransportResult(payload=payload, envelope=envelope, raw_response=response)
+            body = response.json()
+            payload = env.parse_rest_response(body)
+            # Real REST wire: the HTTP JSON body dict.
+            return TransportResult(payload=payload, envelope=envelope, raw_response=response, wire_response=body)
         except Exception as exc:
             return TransportResult(error=exc)
 
@@ -191,7 +200,13 @@ class McpDispatcher:
                 # ImplDispatcher caveat; never a substitute for the wire field.
                 synthesized_error_envelope=_envelope_from_adcp_error(exc),
             )
-        return TransportResult(payload=payload, envelope={"transport": "mcp"})
+        # Real MCP wire: the structured_content dict stashed by _run_mcp_client
+        # (declared on BaseTestEnv, reset per call_via — read directly).
+        return TransportResult(
+            payload=payload,
+            envelope={"transport": "mcp"},
+            wire_response=env._last_wire_response,
+        )
 
 
 DISPATCHERS: dict[Transport, ImplDispatcher | A2ADispatcher | RestDispatcher | McpDispatcher] = {

--- a/tests/harness/transport.py
+++ b/tests/harness/transport.py
@@ -66,6 +66,11 @@ class TransportResult:
         envelope: Transport-specific metadata (HTTP status, ToolResult, etc.).
         error: Exception raised during dispatch, if any.
         raw_response: Unprocessed transport response (httpx.Response, ToolResult, etc.).
+        wire_response: Serialized success-path response body as a dict, captured
+            from the real wire (REST HTTP JSON body, MCP structured_content, A2A
+            artifact DataPart). ``None`` on error and on IMPL (no wire — serialize
+            the typed ``payload`` instead). Lets success-path tests assert the
+            actual serialized shape (e.g. the v3.1 format_id federation contract).
         wire_error_envelope: Raw two-layer error envelope dict captured from
             the actual wire bytes (REST HTTP body, MCP ToolError content text,
             A2A failed-Task artifact DataPart). ``None`` on success or on the
@@ -86,6 +91,7 @@ class TransportResult:
     envelope: dict[str, Any] = field(default_factory=dict)
     error: Exception | None = None
     raw_response: Any = None
+    wire_response: dict[str, Any] | None = None
     wire_error_envelope: dict[str, Any] | None = None
     synthesized_error_envelope: dict[str, Any] | None = None
 

--- a/tests/helpers/format_assertions.py
+++ b/tests/helpers/format_assertions.py
@@ -1,0 +1,37 @@
+"""Shared assertions for the AdCP v3.1 format_id federation contract.
+
+A serialized ``format_id`` MUST be an object carrying both ``agent_url`` and
+``id`` — never a bare string. This is the **schema** contract
+(``core/format-id.json``: ``required: [agent_url, id]``, never a plain string).
+The storyboard (``creative/index.yaml`` discover_formats / list_formats) only
+grades ``field_present`` on ``formats[0]``; this helper is intentionally
+stricter — every entry, never a bare string.
+
+Used by the UC-005 ``format-id-shape`` BDD steps and their falsifiability unit
+test; reusable by the ``roundtrip-from-products`` / ``third-party-agent``
+sibling scenarios.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def assert_wire_format_id_is_object(fid: Any) -> None:
+    """Assert a single serialized ``format_id`` is an object with ``agent_url`` + ``id``.
+
+    ``isinstance(fid, dict)`` is the falsifiable check: a regression that flattens
+    the structured object to its ``id`` string on the wire serializes as ``str``
+    and fails here. Asserts *presence* of ``agent_url`` and ``id``, not an exact
+    key set — adcp 5.7.0 adds optional ``width``/``height``/``duration_ms``, and
+    ``agent_url`` normalizes with a trailing slash so its value is not asserted.
+
+    Args:
+        fid: A single ``format_id`` value as it appears on the serialized wire.
+
+    Raises:
+        AssertionError: if ``fid`` is not an object, or is missing either key.
+    """
+    assert isinstance(fid, dict), f"format_id must serialize as an object, got {type(fid).__name__}: {fid!r}"
+    assert "agent_url" in fid, f"format_id missing agent_url: {fid!r}"
+    assert "id" in fid, f"format_id missing id: {fid!r}"

--- a/tests/integration/test_harness_wire_response.py
+++ b/tests/integration/test_harness_wire_response.py
@@ -1,0 +1,72 @@
+"""Authenticity guard for TransportResult.wire_response.
+
+The UC-005 format_id federation-contract scenario asserts the ``{agent_url, id}``
+object shape on ``wire_response`` for REST/A2A/MCP. That is only meaningful if
+``wire_response`` carries the *real* serialized bytes rather than a re-serialization
+of the already-validated typed payload — otherwise the wire assertions would be
+tautological again (the typed payload can never be a bare string by construction).
+
+These tests pin that contract against ``list_creative_formats`` so a future refactor
+cannot quietly substitute a reconstruction. IMPL has no wire by definition.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.harness import CreativeFormatsEnv
+from tests.harness.transport import Transport
+
+
+@pytest.mark.requires_db
+class TestWireResponseIsRealWire:
+    """wire_response surfaces the real serialized success-path wire, per transport."""
+
+    # Envelope-only keys present only because A2A/MCP wrap the payload — absent
+    # from a bare payload reconstruction and from the REST HTTP body.
+    ENVELOPE_MARKERS = {
+        Transport.A2A: ("success", "message"),
+        Transport.MCP: ("task_id", "adcp_version"),
+    }
+
+    def test_rest_wire_response_is_the_http_body(self, integration_db):
+        """REST wire_response is the actual HTTP JSON body (provenance check).
+
+        REST serializes the payload directly, so wire_response == payload.model_dump();
+        asserting == raw_response.json() therefore pins *provenance* (the field is the
+        real HTTP response body), not a reconstruction-difference. Symmetrically, the
+        bare HTTP body must NOT carry the A2A/MCP transport-envelope markers.
+        """
+        with CreativeFormatsEnv() as env:
+            result = env.call_via(Transport.REST)
+            assert result.wire_response == result.raw_response.json()
+            assert "formats" in result.wire_response
+            for marker in (m for markers in self.ENVELOPE_MARKERS.values() for m in markers):
+                assert marker not in result.wire_response, (
+                    f"REST wire (bare HTTP body) unexpectedly carries envelope field {marker!r}"
+                )
+
+    def test_a2a_and_mcp_wire_carries_envelope_fields(self, integration_db):
+        """A2A/MCP wire carries transport-envelope fields a payload reconstruction would lack.
+
+        A payload model_dump() exposes only the response model's fields (formats,
+        creative_agents, pagination, ...). The A2A envelope adds success/message; the
+        MCP/AdCP envelope adds task_id/adcp_version. Asserting these makes the oracle
+        distinguish real serialized wire from a reconstruction.
+        """
+        with CreativeFormatsEnv() as env:
+            for transport, markers in self.ENVELOPE_MARKERS.items():
+                result = env.call_via(transport)
+                assert isinstance(result.wire_response, dict), f"{transport}: wire_response not a dict"
+                assert "formats" in result.wire_response, f"{transport}: wire_response missing formats"
+                for key in markers:
+                    assert key in result.wire_response, (
+                        f"{transport}: wire_response missing envelope field {key!r} — "
+                        "looks like a payload reconstruction, not real wire"
+                    )
+
+    def test_impl_has_no_wire(self, integration_db):
+        """IMPL is an in-process call — no wire by definition."""
+        with CreativeFormatsEnv() as env:
+            result = env.call_via(Transport.IMPL)
+            assert result.wire_response is None

--- a/tests/unit/test_uc005_format_id_shape_falsifiable.py
+++ b/tests/unit/test_uc005_format_id_shape_falsifiable.py
@@ -1,0 +1,46 @@
+"""Falsifiability guard for the format_id federation-contract assertion.
+
+The UC-005 ``format-id-shape`` scenario asserts every serialized ``format_id``
+is an object with ``agent_url`` + ``id``. Because production types ``format_id``
+as a required structured object, the typed payload can never be a bare string by
+construction — so the assertion is only falsifiable against serialized wire bytes.
+
+These tests prove ``assert_wire_format_id_is_object`` actually bites: a flattened
+(bare-string) ``format_id`` and an object missing ``agent_url`` must raise, while a
+proper object passes. Without this, the scenario could pass by construction.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.helpers.format_assertions import assert_wire_format_id_is_object
+
+
+def test_bare_string_format_id_is_rejected():
+    """A flattened string-serialized format_id (the regression) must fail."""
+    with pytest.raises(AssertionError):
+        assert_wire_format_id_is_object("display_html")
+
+
+def test_object_missing_agent_url_is_rejected():
+    """An object lacking agent_url breaks the federation contract."""
+    with pytest.raises(AssertionError):
+        assert_wire_format_id_is_object({"id": "display_html"})
+
+
+def test_object_format_id_is_accepted():
+    """The correct {agent_url, id} object shape passes."""
+    assert_wire_format_id_is_object({"agent_url": "https://creative.adcontextprotocol.org/", "id": "display_html"})
+
+
+def test_object_with_optional_5_7_0_fields_is_accepted():
+    """adcp 5.7.0 adds optional width/height/duration_ms — extra keys are valid."""
+    assert_wire_format_id_is_object(
+        {
+            "agent_url": "https://creative.adcontextprotocol.org/",
+            "id": "display_300x250",
+            "width": 300,
+            "height": 250,
+        }
+    )


### PR DESCRIPTION
## What

Wires the AdCP v3.1 baseline scenario `T-UC-005-storyboard-baseline-format-id-object-shape` to real production across all four transports (IMPL/A2A/MCP/REST), flipping it from auto-xfail (missing step definitions) to passing. Every `list_creative_formats` entry's `format_id` is asserted to be an object carrying both `agent_url` and `id` — never a bare string (the v3.1 federation contract).

Closes #1409. Unblocked by #1399 (adcp 5.7.0 / spec 3.1.0-beta.3), now on `main`.

## Approach — federation-grade

Per the implementer trace on the issue, the contract is only *falsifiable* against serialized wire bytes — the typed payload is a required structured type and can never be a bare string by construction. Previously only REST surfaced the success-path wire; this PR extends the harness so every real-wire transport does:

`TransportResult.wire_response: dict | None` — the serialized success-path body:
- **REST** — HTTP JSON body
- **MCP** — `ToolResult.structured_content`
- **A2A** — full artifact DataPart (captured *before* the `message`/`success` strip)
- **IMPL** — `None` (no wire; the step serializes the typed payload via `model_dump(mode="json")`, exercising the production serializer)

The scenario asserts the `{agent_url, id}` object shape on the actual serialized bytes for REST/A2A/MCP and on the serializer output for IMPL — meaningful on every transport, tautological on none. The `wire_response` extension is reusable for the sibling format-id scenarios (`roundtrip-from-products`, `third-party-agent`).

## On falsifiability (open-question Q3)

`tests/unit/test_uc005_format_id_shape_falsifiable.py` proves the assertion *bites* (rejects a bare-string `format_id`) at the helper level. Q3 suggested an end-to-end registry mutation; that's brittle — production can't construct a bare-string `format_id` without bypassing the typed model. Instead, end-to-end falsifiability holds **by construction** on REST/A2A/MCP (real bytes + `type(fid) is dict`), and `tests/integration/test_harness_wire_response.py` pins that `wire_response` is real wire (REST `== raw_response.json()`), not a payload reconstruction — closing the only otherwise-unproven link.

## Verification

- Scenario green on all 4 transports (`impl`/`a2a`/`mcp`/`rest`) — xfail→pass
- Full UC-005 BDD: **613 passed / 225 xfailed / 0 failed** (no harness regressions)
- `wire_response` authenticity test: 3 passed
- `make quality`: **4977 passed, 0 failed** — no new allowlist entries
- Two structural guards (duplicate-step, count-only assertion) caught real issues during development; both fixed properly, not allowlisted

## Files

- `tests/harness/{transport,_base,dispatchers}.py` — capture success-path wire
- `tests/bdd/steps/generic/when_request.py` — surface `ctx["wire_response"]`; baseline `Given` reuses the canonical unfiltered-dispatch step
- `tests/bdd/steps/domain/uc005_format_id_shape.py` — new When/Then steps
- `tests/helpers/format_assertions.py` — shared wire assertion
- `tests/unit/test_uc005_format_id_shape_falsifiable.py` — falsifiability
- `tests/integration/test_harness_wire_response.py` — wire authenticity
- `tests/CLAUDE.md` — document the `wire_response` field per transport

🤖 Generated with [Claude Code](https://claude.com/claude-code)
