### PR TITLE
fix: serialize push_notification_config with mode='json' at MCP/A2A transport boundaries

### DIFF
--- a/docs/test-obligations/UC-002-create-media-buy.md
+++ b/docs/test-obligations/UC-002-create-media-buy.md
@@ -1524,6 +1524,30 @@ Source: BR-RULE-026
 
 ---
 
+### Transport Boundary: push_notification_config Serialization
+
+#### Scenario: MCP Wrapper Serializes AnyUrl to Plain String
+**Obligation ID** UC-002-TRANSPORT-PNC-SERIALIZATION-01
+**Layer** behavioral
+**Given** a `create_media_buy` MCP request with `push_notification_config.url` set to a Pydantic `AnyUrl` value
+**When** the MCP wrapper serializes the `PushNotificationConfig` model to a dict before calling `_impl`
+**Then** the `url` field in the resulting dict is a plain `str`, not a Pydantic `AnyUrl` object
+**And** enum fields such as `authentication.schemes` are serialized to their string values
+**And** `_impl` receives a dict whose values are all plain Python types compatible with SQLAlchemy `String` columns
+**Priority:** P0 (regression: gh-#1377)
+
+#### Scenario: A2A Wrapper Serializes AnyUrl to Plain String
+**Obligation ID** UC-002-TRANSPORT-PNC-SERIALIZATION-02
+**Layer** behavioral
+**Given** a `create_media_buy` A2A request with `push_notification_config` as a `PushNotificationConfig` model instance
+**When** the A2A wrapper (`create_media_buy_raw`) serializes the model to a dict before calling `_impl`
+**Then** the `url` field in the resulting dict is a plain `str`, not a Pydantic `AnyUrl` object
+**And** enum fields such as `authentication.schemes` are serialized to their string values
+**And** `_impl` receives a dict whose values are all plain Python types compatible with SQLAlchemy `String` columns
+**Priority:** P0 (regression: gh-#1377)
+
+---
+
 ## Summary Statistics
 
 | Category | Count |

--- a/src/core/tools/media_buy_create.py
+++ b/src/core/tools/media_buy_create.py
@@ -4293,7 +4293,7 @@ async def create_media_buy(
     # Serialize PushNotificationConfig model to dict for _impl (which accepts dict|None).
     # Use mode='json' so Pydantic v2 converts AnyUrl fields to plain str and enum fields
     # to their string values — plain model_dump() preserves typed objects that SQLAlchemy
-    # String columns cannot coerce, causing StatementError at flush time (gh-#1377).
+    # String columns cannot coerce, causing StatementError at flush time.
     pnc_dict = push_notification_config.model_dump(mode="json") if push_notification_config else None
     result = await _create_media_buy_impl(
         req=req,
@@ -4378,7 +4378,7 @@ async def create_media_buy_raw(
     # Serialize SDK model to dict for _impl (which uses dict-based config access).
     # Use mode='json' so Pydantic v2 converts AnyUrl fields to plain str and enum fields
     # to their string values — plain model_dump() preserves typed objects that SQLAlchemy
-    # String columns cannot coerce, causing StatementError at flush time (gh-#1377).
+    # String columns cannot coerce, causing StatementError at flush time.
     pnc_dict = (
         push_notification_config.model_dump(mode="json")
         if isinstance(push_notification_config, PushNotificationConfig)

--- a/src/core/tools/media_buy_create.py
+++ b/src/core/tools/media_buy_create.py
@@ -4290,8 +4290,11 @@ async def create_media_buy(
 
     identity = enrich_identity_with_account(identity, req.account)
 
-    # Serialize PushNotificationConfig model to dict for _impl (which accepts dict|None)
-    pnc_dict = push_notification_config.model_dump() if push_notification_config else None
+    # Serialize PushNotificationConfig model to dict for _impl (which accepts dict|None).
+    # Use mode='json' so Pydantic v2 converts AnyUrl fields to plain str and enum fields
+    # to their string values — plain model_dump() preserves typed objects that SQLAlchemy
+    # String columns cannot coerce, causing StatementError at flush time (gh-#1377).
+    pnc_dict = push_notification_config.model_dump(mode="json") if push_notification_config else None
     result = await _create_media_buy_impl(
         req=req,
         push_notification_config=pnc_dict,
@@ -4372,9 +4375,12 @@ async def create_media_buy_raw(
     # pass identity directly without ctx, so this is best-effort)
     _ctx_id = (await ctx.get_state("context_id")) if isinstance(ctx, Context) else None
 
-    # Serialize SDK model to dict for _impl (which uses dict-based config access)
+    # Serialize SDK model to dict for _impl (which uses dict-based config access).
+    # Use mode='json' so Pydantic v2 converts AnyUrl fields to plain str and enum fields
+    # to their string values — plain model_dump() preserves typed objects that SQLAlchemy
+    # String columns cannot coerce, causing StatementError at flush time (gh-#1377).
     pnc_dict = (
-        push_notification_config.model_dump()
+        push_notification_config.model_dump(mode="json")
         if isinstance(push_notification_config, PushNotificationConfig)
         else push_notification_config
     )

--- a/tests/helpers/create_media_buy_capture.py
+++ b/tests/helpers/create_media_buy_capture.py
@@ -1,0 +1,128 @@
+"""Shared capture helpers for create_media_buy transport boundary tests.
+
+Both MCP and A2A wrappers serialize PushNotificationConfig before forwarding
+to _create_media_buy_impl. These helpers build the mock context, patch _impl
+with a side_effect that records its kwargs, invoke the wrapper, and return the
+forwarded push_notification_config dict — so individual tests only assert on
+the returned value without duplicating scaffolding.
+
+Used by:
+  - tests/unit/test_create_media_buy_behavioral.py  (serialization obligations)
+  - tests/unit/test_push_notification_forwarding.py  (forwarding parity)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from tests.helpers.adcp_factories import create_test_media_buy_request_dict
+
+
+def _make_mock_ctx() -> AsyncMock:
+    """Build a minimal FastMCP Context mock with identity and context_id state."""
+    mock_ctx = AsyncMock()
+    mock_ctx.http = MagicMock()
+    mock_ctx.http.headers = {}
+
+    async def _get_state(key: str) -> Any:
+        if key == "identity":
+            return MagicMock()
+        if key == "context_id":
+            return "test-ctx-id"
+        return None
+
+    mock_ctx.get_state = _get_state
+    return mock_ctx
+
+
+async def capture_mcp_forwarded_pnc(pnc: Any) -> dict | None:
+    """Invoke the MCP create_media_buy wrapper with *pnc* and return the
+    push_notification_config dict that was forwarded to _create_media_buy_impl.
+
+    The wrapper may raise after calling _impl (ToolResult serialization with a
+    mock result); that exception is swallowed — only the captured kwarg matters.
+
+    Args:
+        pnc: A PushNotificationConfig model instance (or dict) to pass as
+             push_notification_config to the MCP wrapper.
+
+    Returns:
+        The push_notification_config value received by _impl, or None if _impl
+        was not called.
+    """
+    from src.core.schemas import CreateMediaBuyResult
+    from src.core.tools.media_buy_create import create_media_buy
+
+    req_dict = create_test_media_buy_request_dict()
+    mock_result = MagicMock(spec=CreateMediaBuyResult)
+    mock_result.__str__ = lambda self: "mock_result"
+    mock_ctx = _make_mock_ctx()
+
+    captured: dict[str, Any] = {}
+
+    async def _capture(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return mock_result
+
+    with patch(
+        "src.core.tools.media_buy_create._create_media_buy_impl",
+        side_effect=_capture,
+    ):
+        try:
+            await create_media_buy(
+                brand=req_dict["brand"],
+                packages=req_dict["packages"],
+                start_time=req_dict["start_time"],
+                end_time=req_dict["end_time"],
+                idempotency_key=req_dict["idempotency_key"],
+                push_notification_config=pnc,
+                ctx=mock_ctx,
+            )
+        except Exception:
+            pass  # ToolResult serialization with mock may raise; only _impl args matter
+
+    return captured.get("push_notification_config")
+
+
+async def capture_a2a_forwarded_pnc(pnc: Any) -> dict | None:
+    """Invoke the A2A create_media_buy_raw wrapper with *pnc* and return the
+    push_notification_config dict that was forwarded to _create_media_buy_impl.
+
+    Args:
+        pnc: A PushNotificationConfig model instance or plain dict to pass as
+             push_notification_config to the A2A wrapper.
+
+    Returns:
+        The push_notification_config value received by _impl, or None if _impl
+        was not called.
+    """
+    from src.core.schemas import CreateMediaBuyResult
+    from src.core.tools.media_buy_create import create_media_buy_raw
+
+    req_dict = create_test_media_buy_request_dict()
+    mock_result = MagicMock(spec=CreateMediaBuyResult)
+    mock_result.__str__ = lambda self: "mock_result"
+    mock_identity = MagicMock()
+
+    captured: dict[str, Any] = {}
+
+    async def _capture(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return mock_result
+
+    with patch(
+        "src.core.tools.media_buy_create._create_media_buy_impl",
+        side_effect=_capture,
+    ):
+        await create_media_buy_raw(
+            brand=req_dict["brand"],
+            packages=req_dict["packages"],
+            start_time=req_dict["start_time"],
+            end_time=req_dict["end_time"],
+            idempotency_key=req_dict["idempotency_key"],
+            push_notification_config=pnc,
+            identity=mock_identity,
+        )
+
+    return captured.get("push_notification_config")

--- a/tests/unit/test_architecture_behavioral_mock_cap.py
+++ b/tests/unit/test_architecture_behavioral_mock_cap.py
@@ -38,6 +38,7 @@ BEHAVIORAL_MOCK_CONSTRUCTION_CAP: dict[str, int] = {
     "tests/integration/test_delivery_webhook_behavioral.py": 5,
     "tests/integration/test_get_products_behavioral.py": 44,
     "tests/unit/test_authorized_properties_behavioral.py": 23,
+    "tests/unit/test_create_media_buy_behavioral.py": 15,  # gh-#1377: transport boundary serialization tests
     "tests/unit/test_creative_formats_behavioral.py": 17,
     "tests/unit/test_delivery_poll_behavioral.py": 14,
     "tests/unit/test_delivery_service_behavioral.py": 6,

--- a/tests/unit/test_architecture_behavioral_mock_cap.py
+++ b/tests/unit/test_architecture_behavioral_mock_cap.py
@@ -38,7 +38,6 @@ BEHAVIORAL_MOCK_CONSTRUCTION_CAP: dict[str, int] = {
     "tests/integration/test_delivery_webhook_behavioral.py": 5,
     "tests/integration/test_get_products_behavioral.py": 44,
     "tests/unit/test_authorized_properties_behavioral.py": 23,
-    "tests/unit/test_create_media_buy_behavioral.py": 15,  # gh-#1377: transport boundary serialization tests
     "tests/unit/test_creative_formats_behavioral.py": 17,
     "tests/unit/test_delivery_poll_behavioral.py": 14,
     "tests/unit/test_delivery_service_behavioral.py": 6,

--- a/tests/unit/test_architecture_weak_mock_assertions.py
+++ b/tests/unit/test_architecture_weak_mock_assertions.py
@@ -79,8 +79,6 @@ WEAK_ASSERTION_ALLOWLIST: set[tuple[str, str]] = {
     ("tests/unit/test_performance_index_behavioral.py", "test_empty_performance_data_succeeds"),
     ("tests/unit/test_performance_index_behavioral.py", "test_product_to_package_mapping"),
     ("tests/unit/test_pr1071_review_fixes.py", "test_audit_log_records_has_brand_not_has_brand_manifest"),
-    ("tests/unit/test_push_notification_forwarding.py", "test_a2a_wrapper_forwards_push_notification_config"),
-    ("tests/unit/test_push_notification_forwarding.py", "test_mcp_wrapper_forwards_push_notification_config"),
     ("tests/unit/test_sync_creatives_behavioral.py", "test_slack_notification_only_when_webhook_configured"),
     ("tests/unit/test_transport_tenant_resolution.py", "test_ensure_resolved_sets_current_tenant"),
     ("tests/unit/test_update_media_buy_behavioral.py", "test_update_both_start_and_end_time"),

--- a/tests/unit/test_create_media_buy_behavioral.py
+++ b/tests/unit/test_create_media_buy_behavioral.py
@@ -1,9 +1,9 @@
 """Behavioral tests for create_media_buy transport boundary serialization.
 
-Covers the push_notification_config serialization obligations introduced in
-gh-#1377: both MCP and A2A wrappers must use model_dump(mode='json') so that
-Pydantic v2 AnyUrl fields and enum instances are converted to plain Python
-strings before reaching _impl and SQLAlchemy String columns.
+Covers the push_notification_config serialization obligations: both MCP and A2A
+wrappers must use model_dump(mode='json') so that Pydantic v2 AnyUrl fields and
+enum instances are converted to plain Python strings before reaching _impl and
+SQLAlchemy String columns.
 
 Obligation IDs:
   UC-002-TRANSPORT-PNC-SERIALIZATION-01  (MCP wrapper)
@@ -12,26 +12,16 @@ Obligation IDs:
 
 from __future__ import annotations
 
-from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
-
 import pytest
 
-from src.core.schemas import CreateMediaBuyResult
-from tests.helpers.adcp_factories import create_test_media_buy_request_dict
-
-
-def _mock_create_result() -> CreateMediaBuyResult:
-    result = MagicMock(spec=CreateMediaBuyResult)
-    result.__str__ = lambda self: "mock_result"
-    return result
+from tests.helpers.create_media_buy_capture import capture_a2a_forwarded_pnc, capture_mcp_forwarded_pnc
 
 
 class TestMCPWrapperPncJsonSerialization:
     """MCP wrapper must serialize PushNotificationConfig with mode='json'.
 
-    Regression: gh-#1377 — plain model_dump() preserves AnyUrl objects that
-    SQLAlchemy String columns cannot coerce, raising StatementError at flush.
+    Regression: plain model_dump() preserves AnyUrl objects that SQLAlchemy
+    String columns cannot coerce, raising StatementError at flush.
     """
 
     @pytest.mark.asyncio
@@ -44,61 +34,22 @@ class TestMCPWrapperPncJsonSerialization:
         """
         from adcp import PushNotificationConfig
 
-        from src.core.tools.media_buy_create import create_media_buy
-
         pnc = PushNotificationConfig(
             url="https://buyer.example.com/webhook",
             authentication={"credentials": "a" * 32, "schemes": ["Bearer"]},
         )
-        mock_result = _mock_create_result()
-        req_dict = create_test_media_buy_request_dict()
+        forwarded = await capture_mcp_forwarded_pnc(pnc)
 
-        mock_ctx = AsyncMock()
-        mock_ctx.http = MagicMock()
-        mock_ctx.http.headers = {}
+        assert forwarded is not None, "MCP wrapper did not forward push_notification_config to _impl"
+        assert isinstance(forwarded, dict), f"push_notification_config must be a dict, got {type(forwarded).__name__}"
 
-        async def _get_state(key: str) -> Any:
-            if key == "identity":
-                return MagicMock()
-            if key == "context_id":
-                return "test-ctx-id"
-            return None
-
-        mock_ctx.get_state = _get_state
-
-        with patch(
-            "src.core.tools.media_buy_create._create_media_buy_impl",
-            new_callable=AsyncMock,
-            return_value=mock_result,
-        ) as mock_impl:
-            try:
-                await create_media_buy(
-                    brand=req_dict["brand"],
-                    packages=req_dict["packages"],
-                    start_time=req_dict["start_time"],
-                    end_time=req_dict["end_time"],
-                    idempotency_key=req_dict["idempotency_key"],
-                    push_notification_config=pnc,
-                    ctx=mock_ctx,
-                )
-            except Exception:
-                pass  # ToolResult serialization with mock may raise; we only care about _impl args
-
-            mock_impl.assert_called_once()
-            forwarded: dict | None = mock_impl.call_args.kwargs.get("push_notification_config")
-
-            assert forwarded is not None, "MCP wrapper did not forward push_notification_config to _impl"
-            assert isinstance(forwarded, dict), (
-                f"push_notification_config must be a dict, got {type(forwarded).__name__}"
-            )
-
-            url = forwarded.get("url")
-            assert isinstance(url, str), (
-                f"url must be a plain str after model_dump(mode='json'), got {type(url).__name__!r}. "
-                "This indicates model_dump() was used instead of model_dump(mode='json'), "
-                "which preserves AnyUrl objects and causes SQLAlchemy StatementError (gh-#1377)."
-            )
-            assert url == "https://buyer.example.com/webhook", f"url value mismatch: {url!r}"
+        url = forwarded.get("url")
+        assert isinstance(url, str), (
+            f"url must be a plain str after model_dump(mode='json'), got {type(url).__name__!r}. "
+            "This indicates model_dump() was used instead of model_dump(mode='json'), "
+            "which preserves AnyUrl objects and causes SQLAlchemy StatementError."
+        )
+        assert url == "https://buyer.example.com/webhook", f"url value mismatch: {url!r}"
 
     @pytest.mark.asyncio
     async def test_mcp_wrapper_enum_schemes_are_plain_strings(self):
@@ -110,64 +61,27 @@ class TestMCPWrapperPncJsonSerialization:
         """
         from adcp import PushNotificationConfig
 
-        from src.core.tools.media_buy_create import create_media_buy
-
         pnc = PushNotificationConfig(
             url="https://buyer.example.com/webhook",
             authentication={"credentials": "a" * 32, "schemes": ["Bearer"]},
         )
-        mock_result = _mock_create_result()
-        req_dict = create_test_media_buy_request_dict()
+        forwarded = await capture_mcp_forwarded_pnc(pnc)
+        assert forwarded is not None
 
-        mock_ctx = AsyncMock()
-        mock_ctx.http = MagicMock()
-        mock_ctx.http.headers = {}
-
-        async def _get_state(key: str) -> Any:
-            if key == "identity":
-                return MagicMock()
-            if key == "context_id":
-                return "test-ctx-id"
-            return None
-
-        mock_ctx.get_state = _get_state
-
-        with patch(
-            "src.core.tools.media_buy_create._create_media_buy_impl",
-            new_callable=AsyncMock,
-            return_value=mock_result,
-        ) as mock_impl:
-            try:
-                await create_media_buy(
-                    brand=req_dict["brand"],
-                    packages=req_dict["packages"],
-                    start_time=req_dict["start_time"],
-                    end_time=req_dict["end_time"],
-                    idempotency_key=req_dict["idempotency_key"],
-                    push_notification_config=pnc,
-                    ctx=mock_ctx,
-                )
-            except Exception:
-                pass
-
-            mock_impl.assert_called_once()
-            forwarded: dict | None = mock_impl.call_args.kwargs.get("push_notification_config")
-            assert forwarded is not None
-
-            auth = forwarded.get("authentication", {})
-            schemes = auth.get("schemes", [])
-            for scheme in schemes:
-                assert isinstance(scheme, str), (
-                    f"authentication.schemes entries must be plain str after model_dump(mode='json'), "
-                    f"got {type(scheme).__name__!r} — enum instances cause SQLAlchemy coercion errors (gh-#1377)."
-                )
+        auth = forwarded.get("authentication", {})
+        schemes = auth.get("schemes", [])
+        for scheme in schemes:
+            assert isinstance(scheme, str), (
+                f"authentication.schemes entries must be plain str after model_dump(mode='json'), "
+                f"got {type(scheme).__name__!r} — enum instances cause SQLAlchemy coercion errors."
+            )
 
 
 class TestA2AWrapperPncJsonSerialization:
     """A2A wrapper must serialize PushNotificationConfig with mode='json'.
 
-    Regression: gh-#1377 — plain model_dump() preserves AnyUrl objects that
-    SQLAlchemy String columns cannot coerce, raising StatementError at flush.
+    Regression: plain model_dump() preserves AnyUrl objects that SQLAlchemy
+    String columns cannot coerce, raising StatementError at flush.
     """
 
     @pytest.mark.asyncio
@@ -180,46 +94,22 @@ class TestA2AWrapperPncJsonSerialization:
         """
         from adcp import PushNotificationConfig
 
-        from src.core.tools.media_buy_create import create_media_buy_raw
-
         pnc = PushNotificationConfig(
             url="https://buyer.example.com/webhook",
             authentication={"credentials": "a" * 32, "schemes": ["Bearer"]},
         )
-        mock_result = _mock_create_result()
-        mock_identity = MagicMock()
-        req_dict = create_test_media_buy_request_dict()
+        forwarded = await capture_a2a_forwarded_pnc(pnc)
 
-        with patch(
-            "src.core.tools.media_buy_create._create_media_buy_impl",
-            new_callable=AsyncMock,
-            return_value=mock_result,
-        ) as mock_impl:
-            await create_media_buy_raw(
-                brand=req_dict["brand"],
-                packages=req_dict["packages"],
-                start_time=req_dict["start_time"],
-                end_time=req_dict["end_time"],
-                idempotency_key=req_dict["idempotency_key"],
-                push_notification_config=pnc,
-                identity=mock_identity,
-            )
+        assert forwarded is not None, "A2A wrapper did not forward push_notification_config to _impl"
+        assert isinstance(forwarded, dict), f"push_notification_config must be a dict, got {type(forwarded).__name__}"
 
-            mock_impl.assert_called_once()
-            forwarded: dict | None = mock_impl.call_args.kwargs.get("push_notification_config")
-
-            assert forwarded is not None, "A2A wrapper did not forward push_notification_config to _impl"
-            assert isinstance(forwarded, dict), (
-                f"push_notification_config must be a dict, got {type(forwarded).__name__}"
-            )
-
-            url = forwarded.get("url")
-            assert isinstance(url, str), (
-                f"url must be a plain str after model_dump(mode='json'), got {type(url).__name__!r}. "
-                "This indicates model_dump() was used instead of model_dump(mode='json'), "
-                "which preserves AnyUrl objects and causes SQLAlchemy StatementError (gh-#1377)."
-            )
-            assert url == "https://buyer.example.com/webhook", f"url value mismatch: {url!r}"
+        url = forwarded.get("url")
+        assert isinstance(url, str), (
+            f"url must be a plain str after model_dump(mode='json'), got {type(url).__name__!r}. "
+            "This indicates model_dump() was used instead of model_dump(mode='json'), "
+            "which preserves AnyUrl objects and causes SQLAlchemy StatementError."
+        )
+        assert url == "https://buyer.example.com/webhook", f"url value mismatch: {url!r}"
 
     @pytest.mark.asyncio
     async def test_a2a_wrapper_passthrough_dict_unchanged(self):
@@ -229,38 +119,16 @@ class TestA2AWrapperPncJsonSerialization:
         dict (the normal A2A JSON path), it must pass it through unchanged without
         re-serializing it.
         """
-        from src.core.tools.media_buy_create import create_media_buy_raw
-
         pnc_dict = {
             "url": "https://buyer.example.com/webhook",
             "authentication": {"credentials": "a" * 32, "schemes": ["Bearer"]},
         }
-        mock_result = _mock_create_result()
-        mock_identity = MagicMock()
-        req_dict = create_test_media_buy_request_dict()
+        forwarded = await capture_a2a_forwarded_pnc(pnc_dict)
 
-        with patch(
-            "src.core.tools.media_buy_create._create_media_buy_impl",
-            new_callable=AsyncMock,
-            return_value=mock_result,
-        ) as mock_impl:
-            await create_media_buy_raw(
-                brand=req_dict["brand"],
-                packages=req_dict["packages"],
-                start_time=req_dict["start_time"],
-                end_time=req_dict["end_time"],
-                idempotency_key=req_dict["idempotency_key"],
-                push_notification_config=pnc_dict,
-                identity=mock_identity,
-            )
-
-            mock_impl.assert_called_once()
-            forwarded: dict | None = mock_impl.call_args.kwargs.get("push_notification_config")
-
-            assert forwarded is not None
-            assert isinstance(forwarded, dict)
-            assert forwarded["url"] == "https://buyer.example.com/webhook"
-            assert forwarded["authentication"]["schemes"] == ["Bearer"]
+        assert forwarded is not None
+        assert isinstance(forwarded, dict)
+        assert forwarded["url"] == "https://buyer.example.com/webhook"
+        assert forwarded["authentication"]["schemes"] == ["Bearer"]
 
     @pytest.mark.asyncio
     async def test_a2a_wrapper_enum_schemes_are_plain_strings(self):
@@ -271,39 +139,17 @@ class TestA2AWrapperPncJsonSerialization:
         """
         from adcp import PushNotificationConfig
 
-        from src.core.tools.media_buy_create import create_media_buy_raw
-
         pnc = PushNotificationConfig(
             url="https://buyer.example.com/webhook",
             authentication={"credentials": "a" * 32, "schemes": ["Bearer"]},
         )
-        mock_result = _mock_create_result()
-        mock_identity = MagicMock()
-        req_dict = create_test_media_buy_request_dict()
+        forwarded = await capture_a2a_forwarded_pnc(pnc)
+        assert forwarded is not None
 
-        with patch(
-            "src.core.tools.media_buy_create._create_media_buy_impl",
-            new_callable=AsyncMock,
-            return_value=mock_result,
-        ) as mock_impl:
-            await create_media_buy_raw(
-                brand=req_dict["brand"],
-                packages=req_dict["packages"],
-                start_time=req_dict["start_time"],
-                end_time=req_dict["end_time"],
-                idempotency_key=req_dict["idempotency_key"],
-                push_notification_config=pnc,
-                identity=mock_identity,
+        auth = forwarded.get("authentication", {})
+        schemes = auth.get("schemes", [])
+        for scheme in schemes:
+            assert isinstance(scheme, str), (
+                f"authentication.schemes entries must be plain str after model_dump(mode='json'), "
+                f"got {type(scheme).__name__!r} — enum instances cause SQLAlchemy coercion errors."
             )
-
-            mock_impl.assert_called_once()
-            forwarded: dict | None = mock_impl.call_args.kwargs.get("push_notification_config")
-            assert forwarded is not None
-
-            auth = forwarded.get("authentication", {})
-            schemes = auth.get("schemes", [])
-            for scheme in schemes:
-                assert isinstance(scheme, str), (
-                    f"authentication.schemes entries must be plain str after model_dump(mode='json'), "
-                    f"got {type(scheme).__name__!r} — enum instances cause SQLAlchemy coercion errors (gh-#1377)."
-                )

--- a/tests/unit/test_create_media_buy_behavioral.py
+++ b/tests/unit/test_create_media_buy_behavioral.py
@@ -1,0 +1,309 @@
+"""Behavioral tests for create_media_buy transport boundary serialization.
+
+Covers the push_notification_config serialization obligations introduced in
+gh-#1377: both MCP and A2A wrappers must use model_dump(mode='json') so that
+Pydantic v2 AnyUrl fields and enum instances are converted to plain Python
+strings before reaching _impl and SQLAlchemy String columns.
+
+Obligation IDs:
+  UC-002-TRANSPORT-PNC-SERIALIZATION-01  (MCP wrapper)
+  UC-002-TRANSPORT-PNC-SERIALIZATION-02  (A2A wrapper)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.core.schemas import CreateMediaBuyResult
+from tests.helpers.adcp_factories import create_test_media_buy_request_dict
+
+
+def _mock_create_result() -> CreateMediaBuyResult:
+    result = MagicMock(spec=CreateMediaBuyResult)
+    result.__str__ = lambda self: "mock_result"
+    return result
+
+
+class TestMCPWrapperPncJsonSerialization:
+    """MCP wrapper must serialize PushNotificationConfig with mode='json'.
+
+    Regression: gh-#1377 — plain model_dump() preserves AnyUrl objects that
+    SQLAlchemy String columns cannot coerce, raising StatementError at flush.
+    """
+
+    @pytest.mark.asyncio
+    async def test_mcp_wrapper_url_is_plain_str_not_anyurl(self):
+        """Covers: UC-002-TRANSPORT-PNC-SERIALIZATION-01
+
+        When the MCP wrapper serializes PushNotificationConfig to a dict,
+        the url field must be a plain str (not a Pydantic AnyUrl object) so
+        that SQLAlchemy String columns can persist it without StatementError.
+        """
+        from adcp import PushNotificationConfig
+
+        from src.core.tools.media_buy_create import create_media_buy
+
+        pnc = PushNotificationConfig(
+            url="https://buyer.example.com/webhook",
+            authentication={"credentials": "a" * 32, "schemes": ["Bearer"]},
+        )
+        mock_result = _mock_create_result()
+        req_dict = create_test_media_buy_request_dict()
+
+        mock_ctx = AsyncMock()
+        mock_ctx.http = MagicMock()
+        mock_ctx.http.headers = {}
+
+        async def _get_state(key: str) -> Any:
+            if key == "identity":
+                return MagicMock()
+            if key == "context_id":
+                return "test-ctx-id"
+            return None
+
+        mock_ctx.get_state = _get_state
+
+        with patch(
+            "src.core.tools.media_buy_create._create_media_buy_impl",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ) as mock_impl:
+            try:
+                await create_media_buy(
+                    brand=req_dict["brand"],
+                    packages=req_dict["packages"],
+                    start_time=req_dict["start_time"],
+                    end_time=req_dict["end_time"],
+                    idempotency_key=req_dict["idempotency_key"],
+                    push_notification_config=pnc,
+                    ctx=mock_ctx,
+                )
+            except Exception:
+                pass  # ToolResult serialization with mock may raise; we only care about _impl args
+
+            mock_impl.assert_called_once()
+            forwarded: dict | None = mock_impl.call_args.kwargs.get("push_notification_config")
+
+            assert forwarded is not None, "MCP wrapper did not forward push_notification_config to _impl"
+            assert isinstance(forwarded, dict), (
+                f"push_notification_config must be a dict, got {type(forwarded).__name__}"
+            )
+
+            url = forwarded.get("url")
+            assert isinstance(url, str), (
+                f"url must be a plain str after model_dump(mode='json'), got {type(url).__name__!r}. "
+                "This indicates model_dump() was used instead of model_dump(mode='json'), "
+                "which preserves AnyUrl objects and causes SQLAlchemy StatementError (gh-#1377)."
+            )
+            assert url == "https://buyer.example.com/webhook", f"url value mismatch: {url!r}"
+
+    @pytest.mark.asyncio
+    async def test_mcp_wrapper_enum_schemes_are_plain_strings(self):
+        """Covers: UC-002-TRANSPORT-PNC-SERIALIZATION-01
+
+        When the MCP wrapper serializes PushNotificationConfig, enum fields
+        such as authentication.schemes must be plain strings, not enum instances,
+        so SQLAlchemy can persist them without coercion errors.
+        """
+        from adcp import PushNotificationConfig
+
+        from src.core.tools.media_buy_create import create_media_buy
+
+        pnc = PushNotificationConfig(
+            url="https://buyer.example.com/webhook",
+            authentication={"credentials": "a" * 32, "schemes": ["Bearer"]},
+        )
+        mock_result = _mock_create_result()
+        req_dict = create_test_media_buy_request_dict()
+
+        mock_ctx = AsyncMock()
+        mock_ctx.http = MagicMock()
+        mock_ctx.http.headers = {}
+
+        async def _get_state(key: str) -> Any:
+            if key == "identity":
+                return MagicMock()
+            if key == "context_id":
+                return "test-ctx-id"
+            return None
+
+        mock_ctx.get_state = _get_state
+
+        with patch(
+            "src.core.tools.media_buy_create._create_media_buy_impl",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ) as mock_impl:
+            try:
+                await create_media_buy(
+                    brand=req_dict["brand"],
+                    packages=req_dict["packages"],
+                    start_time=req_dict["start_time"],
+                    end_time=req_dict["end_time"],
+                    idempotency_key=req_dict["idempotency_key"],
+                    push_notification_config=pnc,
+                    ctx=mock_ctx,
+                )
+            except Exception:
+                pass
+
+            mock_impl.assert_called_once()
+            forwarded: dict | None = mock_impl.call_args.kwargs.get("push_notification_config")
+            assert forwarded is not None
+
+            auth = forwarded.get("authentication", {})
+            schemes = auth.get("schemes", [])
+            for scheme in schemes:
+                assert isinstance(scheme, str), (
+                    f"authentication.schemes entries must be plain str after model_dump(mode='json'), "
+                    f"got {type(scheme).__name__!r} — enum instances cause SQLAlchemy coercion errors (gh-#1377)."
+                )
+
+
+class TestA2AWrapperPncJsonSerialization:
+    """A2A wrapper must serialize PushNotificationConfig with mode='json'.
+
+    Regression: gh-#1377 — plain model_dump() preserves AnyUrl objects that
+    SQLAlchemy String columns cannot coerce, raising StatementError at flush.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a2a_wrapper_url_is_plain_str_not_anyurl(self):
+        """Covers: UC-002-TRANSPORT-PNC-SERIALIZATION-02
+
+        When the A2A wrapper (create_media_buy_raw) receives a PushNotificationConfig
+        model instance and serializes it to a dict, the url field must be a plain str
+        (not a Pydantic AnyUrl object) so SQLAlchemy String columns can persist it.
+        """
+        from adcp import PushNotificationConfig
+
+        from src.core.tools.media_buy_create import create_media_buy_raw
+
+        pnc = PushNotificationConfig(
+            url="https://buyer.example.com/webhook",
+            authentication={"credentials": "a" * 32, "schemes": ["Bearer"]},
+        )
+        mock_result = _mock_create_result()
+        mock_identity = MagicMock()
+        req_dict = create_test_media_buy_request_dict()
+
+        with patch(
+            "src.core.tools.media_buy_create._create_media_buy_impl",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ) as mock_impl:
+            await create_media_buy_raw(
+                brand=req_dict["brand"],
+                packages=req_dict["packages"],
+                start_time=req_dict["start_time"],
+                end_time=req_dict["end_time"],
+                idempotency_key=req_dict["idempotency_key"],
+                push_notification_config=pnc,
+                identity=mock_identity,
+            )
+
+            mock_impl.assert_called_once()
+            forwarded: dict | None = mock_impl.call_args.kwargs.get("push_notification_config")
+
+            assert forwarded is not None, "A2A wrapper did not forward push_notification_config to _impl"
+            assert isinstance(forwarded, dict), (
+                f"push_notification_config must be a dict, got {type(forwarded).__name__}"
+            )
+
+            url = forwarded.get("url")
+            assert isinstance(url, str), (
+                f"url must be a plain str after model_dump(mode='json'), got {type(url).__name__!r}. "
+                "This indicates model_dump() was used instead of model_dump(mode='json'), "
+                "which preserves AnyUrl objects and causes SQLAlchemy StatementError (gh-#1377)."
+            )
+            assert url == "https://buyer.example.com/webhook", f"url value mismatch: {url!r}"
+
+    @pytest.mark.asyncio
+    async def test_a2a_wrapper_passthrough_dict_unchanged(self):
+        """Covers: UC-002-TRANSPORT-PNC-SERIALIZATION-02
+
+        When the A2A wrapper receives push_notification_config already as a plain
+        dict (the normal A2A JSON path), it must pass it through unchanged without
+        re-serializing it.
+        """
+        from src.core.tools.media_buy_create import create_media_buy_raw
+
+        pnc_dict = {
+            "url": "https://buyer.example.com/webhook",
+            "authentication": {"credentials": "a" * 32, "schemes": ["Bearer"]},
+        }
+        mock_result = _mock_create_result()
+        mock_identity = MagicMock()
+        req_dict = create_test_media_buy_request_dict()
+
+        with patch(
+            "src.core.tools.media_buy_create._create_media_buy_impl",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ) as mock_impl:
+            await create_media_buy_raw(
+                brand=req_dict["brand"],
+                packages=req_dict["packages"],
+                start_time=req_dict["start_time"],
+                end_time=req_dict["end_time"],
+                idempotency_key=req_dict["idempotency_key"],
+                push_notification_config=pnc_dict,
+                identity=mock_identity,
+            )
+
+            mock_impl.assert_called_once()
+            forwarded: dict | None = mock_impl.call_args.kwargs.get("push_notification_config")
+
+            assert forwarded is not None
+            assert isinstance(forwarded, dict)
+            assert forwarded["url"] == "https://buyer.example.com/webhook"
+            assert forwarded["authentication"]["schemes"] == ["Bearer"]
+
+    @pytest.mark.asyncio
+    async def test_a2a_wrapper_enum_schemes_are_plain_strings(self):
+        """Covers: UC-002-TRANSPORT-PNC-SERIALIZATION-02
+
+        When the A2A wrapper serializes a PushNotificationConfig model, enum
+        fields such as authentication.schemes must be plain strings.
+        """
+        from adcp import PushNotificationConfig
+
+        from src.core.tools.media_buy_create import create_media_buy_raw
+
+        pnc = PushNotificationConfig(
+            url="https://buyer.example.com/webhook",
+            authentication={"credentials": "a" * 32, "schemes": ["Bearer"]},
+        )
+        mock_result = _mock_create_result()
+        mock_identity = MagicMock()
+        req_dict = create_test_media_buy_request_dict()
+
+        with patch(
+            "src.core.tools.media_buy_create._create_media_buy_impl",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ) as mock_impl:
+            await create_media_buy_raw(
+                brand=req_dict["brand"],
+                packages=req_dict["packages"],
+                start_time=req_dict["start_time"],
+                end_time=req_dict["end_time"],
+                idempotency_key=req_dict["idempotency_key"],
+                push_notification_config=pnc,
+                identity=mock_identity,
+            )
+
+            mock_impl.assert_called_once()
+            forwarded: dict | None = mock_impl.call_args.kwargs.get("push_notification_config")
+            assert forwarded is not None
+
+            auth = forwarded.get("authentication", {})
+            schemes = auth.get("schemes", [])
+            for scheme in schemes:
+                assert isinstance(scheme, str), (
+                    f"authentication.schemes entries must be plain str after model_dump(mode='json'), "
+                    f"got {type(scheme).__name__!r} — enum instances cause SQLAlchemy coercion errors (gh-#1377)."
+                )

--- a/tests/unit/test_push_notification_forwarding.py
+++ b/tests/unit/test_push_notification_forwarding.py
@@ -1,8 +1,8 @@
 """
-Regression test for salesagent-c1xl: MCP create_media_buy wrapper must forward
+Regression test: MCP and A2A create_media_buy wrappers must forward
 push_notification_config to _create_media_buy_impl.
 
-Both MCP and A2A wrappers must forward push_notification_config identically
+Both wrappers must forward push_notification_config identically
 (transport parity invariant). The _impl function accepts dict|None, so:
 - MCP wrapper (receives PushNotificationConfig model from FastMCP) must serialize to dict
 - A2A wrapper (receives dict from JSON) passes through directly
@@ -10,25 +10,9 @@ Both MCP and A2A wrappers must forward push_notification_config identically
 
 from __future__ import annotations
 
-from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
-
 import pytest
 
-from src.core.schemas import CreateMediaBuyResult
-from tests.helpers.adcp_factories import create_test_media_buy_request_dict
-
-
-def _make_push_notification_config_dict() -> dict[str, Any]:
-    """Create push_notification_config as a raw dict (A2A transport format)."""
-    return {"url": "https://example.com/webhook", "authentication": {"credentials": "a" * 32, "schemes": ["Bearer"]}}
-
-
-def _mock_create_result() -> CreateMediaBuyResult:
-    """Create a minimal mock result for _create_media_buy_impl."""
-    result = MagicMock(spec=CreateMediaBuyResult)
-    result.__str__ = lambda self: "mock_result"
-    return result
+from tests.helpers.create_media_buy_capture import capture_a2a_forwarded_pnc, capture_mcp_forwarded_pnc
 
 
 class TestMCPForwardsPushNotificationConfig:
@@ -39,64 +23,19 @@ class TestMCPForwardsPushNotificationConfig:
         """When push_notification_config is provided, MCP wrapper forwards it to _impl as a dict."""
         from adcp import PushNotificationConfig
 
-        from src.core.tools.media_buy_create import create_media_buy
-
         pnc = PushNotificationConfig(
             url="https://example.com/webhook",
             authentication={"credentials": "a" * 32, "schemes": ["Bearer"]},
         )
-        mock_result = _mock_create_result()
+        forwarded = await capture_mcp_forwarded_pnc(pnc)
 
-        # Build valid request kwargs from factory
-        req_dict = create_test_media_buy_request_dict()
-
-        # Mock Context with get_state returning identity and context_id
-        mock_ctx = AsyncMock()
-        mock_ctx.http = MagicMock()
-        mock_ctx.http.headers = {}
-
-        async def _get_state(key: str) -> Any:
-            if key == "identity":
-                return MagicMock()
-            if key == "context_id":
-                return "test-ctx-id"
-            return None
-
-        mock_ctx.get_state = _get_state
-
-        with patch(
-            "src.core.tools.media_buy_create._create_media_buy_impl",
-            new_callable=AsyncMock,
-            return_value=mock_result,
-        ) as mock_impl:
-            # The wrapper may fail at ToolResult serialization with a mock;
-            # we only care that _impl received push_notification_config.
-            try:
-                await create_media_buy(
-                    brand=req_dict["brand"],
-                    packages=req_dict["packages"],
-                    start_time=req_dict["start_time"],
-                    end_time=req_dict["end_time"],
-                    idempotency_key=req_dict["idempotency_key"],
-                    push_notification_config=pnc,
-                    ctx=mock_ctx,
-                )
-            except (TypeError, Exception):
-                pass  # ToolResult serialization error with mock is expected
-
-            # _impl must have been called with push_notification_config
-            mock_impl.assert_called_once()
-            call_kwargs = mock_impl.call_args.kwargs
-            assert "push_notification_config" in call_kwargs, (
-                "MCP wrapper does not forward push_notification_config to _impl. "
-                "This is a transport parity violation (salesagent-c1xl)."
-            )
-            forwarded = call_kwargs["push_notification_config"]
-            assert forwarded is not None, "push_notification_config was forwarded as None despite being provided"
-            # _impl expects dict, not PushNotificationConfig model
-            assert isinstance(forwarded, dict), (
-                f"push_notification_config must be forwarded as dict, got {type(forwarded).__name__}"
-            )
+        assert forwarded is not None, (
+            "MCP wrapper does not forward push_notification_config to _impl. This is a transport parity violation."
+        )
+        assert isinstance(forwarded, dict), (
+            f"push_notification_config must be forwarded as dict, got {type(forwarded).__name__}"
+        )
+        assert forwarded["url"] == "https://example.com/webhook"
 
 
 class TestA2AForwardsPushNotificationConfig:
@@ -105,35 +44,12 @@ class TestA2AForwardsPushNotificationConfig:
     @pytest.mark.asyncio
     async def test_a2a_wrapper_forwards_push_notification_config(self):
         """When push_notification_config is provided, A2A wrapper forwards it to _impl."""
-        from src.core.tools.media_buy_create import create_media_buy_raw
+        pnc_dict = {
+            "url": "https://example.com/webhook",
+            "authentication": {"credentials": "a" * 32, "schemes": ["Bearer"]},
+        }
+        forwarded = await capture_a2a_forwarded_pnc(pnc_dict)
 
-        pnc_dict = _make_push_notification_config_dict()
-        mock_result = _mock_create_result()
-        mock_identity = MagicMock()
-
-        req_dict = create_test_media_buy_request_dict()
-
-        with patch(
-            "src.core.tools.media_buy_create._create_media_buy_impl",
-            new_callable=AsyncMock,
-            return_value=mock_result,
-        ) as mock_impl:
-            await create_media_buy_raw(
-                brand=req_dict["brand"],
-                packages=req_dict["packages"],
-                start_time=req_dict["start_time"],
-                end_time=req_dict["end_time"],
-                idempotency_key=req_dict["idempotency_key"],
-                push_notification_config=pnc_dict,
-                identity=mock_identity,
-            )
-
-            mock_impl.assert_called_once()
-            call_kwargs = mock_impl.call_args.kwargs
-            assert "push_notification_config" in call_kwargs, (
-                "A2A wrapper does not forward push_notification_config to _impl"
-            )
-            forwarded = call_kwargs["push_notification_config"]
-            assert forwarded is not None
-            assert isinstance(forwarded, dict)
-            assert forwarded["url"] == "https://example.com/webhook"
+        assert forwarded is not None, "A2A wrapper does not forward push_notification_config to _impl"
+        assert isinstance(forwarded, dict)
+        assert forwarded["url"] == "https://example.com/webhook"


### PR DESCRIPTION
## Summary

Fixes #1377

Pydantic v2's default `model_dump()` preserves `AnyUrl` fields as typed `AnyUrl` objects and enum fields as enum instances rather than converting them to `str`. SQLAlchemy's `String` column type does not coerce these objects and raises a `StatementError` at flush time when `push_notification_config.url` is persisted.

## Root Cause

```python
pnc = PushNotificationConfig(url='https://example.com/webhook')
pnc.model_dump()              # {'url': AnyUrl('https://example.com/webhook')}  ← AnyUrl object
pnc.model_dump(mode='json')   # {'url': 'https://example.com/webhook'}          ← plain str ✓
```

## Fix

Changed `.model_dump()` → `.model_dump(mode="json")` at both transport boundaries in `src/core/tools/media_buy_create.py`:

1. **MCP wrapper** (`create_media_buy` tool)
2. **A2A wrapper** (`create_media_buy_raw`)

The protobuf-based A2A path (`adcp_a2a_server.py`) uses `json_format.MessageToDict()` which always produces plain strings and is not affected.

## Verification

The regression tests were verified to:
- **FAIL** with the bug (plain `model_dump()`): `AssertionError: url must be a plain str after model_dump(mode='json'), got 'AnyUrl'`
- **PASS** with the fix (`model_dump(mode="json")`): all 5 tests green

## Spec Citation

This fix is at the transport boundary layer (Critical Pattern #5 in AGENTS.md). No AdCP protocol behavior is changed — this is a serialization correctness fix ensuring `_impl` receives plain Python types as the architecture requires.

## Test Obligations

New behavioral obligations added to `docs/test-obligations/UC-002-create-media-buy.md`:
- `UC-002-TRANSPORT-PNC-SERIALIZATION-01` — MCP wrapper serializes AnyUrl to plain str
- `UC-002-TRANSPORT-PNC-SERIALIZATION-02` — A2A wrapper serializes AnyUrl to plain str

New test file: `tests/unit/test_create_media_buy_behavioral.py` with 5 tests covering both obligations.