### PR TITLE
test(bdd): wire UC-018 list_creatives-after-sync storyboard (#1405)

### DIFF
--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -2739,6 +2739,8 @@ def _detect_uc(request: pytest.FixtureRequest) -> str | None:
         return "UC-004"
     if any(t.startswith("T-UC-011") for t in marker_names):
         return "UC-011"
+    if any(t.startswith("T-UC-018") for t in marker_names):
+        return "UC-018"
     if any(t.startswith(_ADMIN_TAG_PREFIX) for t in marker_names):
         return "ADMIN"
     if "inventory_profile" in marker_names:
@@ -2854,6 +2856,26 @@ def _harness_env(request: pytest.FixtureRequest, ctx: dict) -> Generator[None, N
         with CreativeFormatsEnv(e2e_config=ctx.get("e2e_config")) as env:
             ctx["env"] = env
             yield
+
+    elif uc == "UC-018":
+        # list_creatives — only the @list-after-sync storyboard scenario is wired
+        # (#1405). The remaining UC-018 scenarios (main/partition/boundary/filter
+        # siblings) have no step definitions yet, so xfail fast at the fixture
+        # (mirrors UC-002/006/011) rather than spinning up a DB per scenario only
+        # to auto-xfail at the first missing step.
+        marker_names = {m.name for m in request.node.iter_markers()}
+        if "list-after-sync" in marker_names:
+            # CreativeListEnv mocks only the audit logger; DB, repository, and
+            # query building are real. The Background auth step switches the env
+            # principal; the seed step owns the creatives under it.
+            request.getfixturevalue("integration_db")
+            from tests.harness.creative_list import CreativeListEnv
+
+            with CreativeListEnv(e2e_config=ctx.get("e2e_config")) as env:
+                ctx["env"] = env
+                yield
+        else:
+            pytest.xfail("UC-018 harness wired only for the @list-after-sync storyboard scenario (#1405)")
 
     elif uc == "UC-011":
         marker_names = {m.name for m in request.node.iter_markers()}

--- a/tests/bdd/test_uc018_list_creatives.py
+++ b/tests/bdd/test_uc018_list_creatives.py
@@ -1,0 +1,181 @@
+"""BDD scenario + steps for UC-018: list_creatives reflects recent sync state.
+
+Binds the single storyboard scenario
+``T-UC-018-storyboard-list-all-creatives-after-sync`` (#1405): after the buyer
+syncs creatives across formats, ``list_creatives`` with no filters returns the
+account's library — schema-valid against ``list-creatives-response.json``, each
+entry exposing ``creative_id``, ``name``, ``format_id``, ``status``. Source
+obligation: adcp ``protocols/creative/index.yaml`` · ``list_all`` (pin
+v3.1-04f59d2d5).
+
+Wired to real production across all wire transports (auto-parametrized; UC-018
+-> CreativeListEnv via conftest ``_detect_uc`` / ``_harness_env``). The repo
+sunsets the IMPL pseudo-transport in BDD, so the scenario runs on a2a/mcp/rest
+(plus e2e_rest in-network). Each transport returns the same typed response, and
+the Then steps validate its production JSON serialization
+(``model_dump(mode="json", exclude_none=True)`` — the same NestedModelSerializerMixin
+path that produces the on-the-wire bytes); the parametrization still exercises
+each dispatch path end to end (a broken transport surfaces as a missing/errored
+response).
+
+**Why steps live here (not in steps/domain/ + pytest_plugins):** pytest-bdd 8
+resolves step definitions only from the scenario's own module, conftest, or
+registered plugins — importing them does not register them. The generic
+``schema-valid against <file>`` and ``authenticated as principal`` phrasings are
+shared by other, already-wired feature files (UC-004/005/006); registering them
+globally would alter those suites. Defining the steps inline scopes them to this
+one scenario, keeping the blast radius to UC-018. The reusable, non-step schema
+validator lives in ``tests.helpers.pinned_schema``.
+
+The "synced" creatives are seeded via ``CreativeFactory`` rather than a live
+``sync_creatives`` call: ``CreativeListEnv`` mocks only the audit logger (it has
+none of sync's creative-agent / preview-generation patches), and the obligation
+under test is ``list_all`` — the listing contract, not the sync path. The
+creatives land in the same DB row shape sync would persist, so the listing query
+is exercised faithfully.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from tests.bdd.steps._outcome_helpers import _require_response
+from tests.helpers.pinned_schema import validate_against_pinned_schema
+
+# Three genuinely-different formats (display / video / audio) for the "three
+# different formats" precondition. All three are in the standard format registry:
+# the A2A path round-trips format_id through a string and re-validates it against
+# known formats, so an unregistered id would be rejected on that transport.
+_SYNCED_FORMATS = ("display_300x250", "video_640x480", "audio_30s")
+
+# Bind the UC-018 feature. Only the @list-after-sync storyboard scenario is wired
+# here (#1405); the remaining scenarios xfail fast at the conftest _harness_env
+# fixture (no UC-018 harness yet). Whole-feature binding via scenarios() is the
+# repo convention the CI shard-splitter requires (scripts/ci/shard_split.py).
+scenarios("features/BR-UC-018-list-creatives.feature")
+
+
+# ── Given ────────────────────────────────────────────────────────────
+
+
+@given(parsers.parse('the Buyer is authenticated as principal "{principal_id}"'))
+def given_buyer_authenticated_as_principal(ctx: dict, principal_id: str) -> None:
+    """Authenticate the listing buyer as *principal_id* (Background).
+
+    Mutates the harness env identity so list_creatives is principal-scoped to
+    this buyer, and records it so the seed step owns the creatives under the same
+    principal the query authenticates as (list_creatives is principal-scoped — a
+    mismatch would return an empty library).
+    """
+    env = ctx["env"]
+    env._identity_cache.clear()
+    env._principal_id = principal_id
+    ctx["principal_id"] = principal_id
+    # Post-condition: verify the identity mutation took effect.
+    actual = env.identity.principal_id
+    assert actual == principal_id, f"env.identity.principal_id is {actual!r} after setting {principal_id!r}"
+
+
+@given("the buyer recently synced three creatives in three different formats via sync_creatives")
+def given_recently_synced_three_creatives(ctx: dict) -> None:
+    """Seed three approved creatives (one per format) owned by the authenticated buyer.
+
+    Seeded via CreativeFactory rather than a live sync_creatives call — see the
+    module docstring. Records the synced creative_ids for the Then steps.
+    """
+    from tests.factories import CreativeFactory, PrincipalFactory, TenantFactory
+
+    env = ctx["env"]
+    tenant = TenantFactory(tenant_id=env._tenant_id)
+    principal = PrincipalFactory(tenant=tenant, principal_id=env._principal_id)
+    synced_ids: list[str] = []
+    for fmt in _SYNCED_FORMATS:
+        creative = CreativeFactory(
+            tenant=tenant,
+            principal=principal,
+            format=fmt,
+            status="approved",
+            # An empty-but-present assets object: the repository filters out rows
+            # whose data["assets"] IS NULL (legacy guard), so the key must exist;
+            # keeping it empty stays schema-valid (no asset-union coupling — the
+            # storyboard grades the listing contract, not asset shape).
+            data={"assets": {}},
+        )
+        synced_ids.append(creative.creative_id)
+    ctx["tenant"] = tenant
+    ctx["principal"] = principal
+    ctx["synced_creative_ids"] = synced_ids
+
+
+# ── When ─────────────────────────────────────────────────────────────
+
+
+@when("the Buyer Agent sends list_creatives with no filters for the same account")
+def when_list_creatives_no_filters(ctx: dict) -> None:
+    """Dispatch list_creatives with no filters through the scenario's transport.
+
+    Reuses the canonical generic dispatch helper (``env.call_via`` + ctx stash of
+    ``response`` / ``wire_response`` / ``error``) rather than re-implementing it.
+    No filter kwargs are passed, so the listing runs unfiltered; the helper maps a
+    missing transport to IMPL.
+    """
+    from tests.bdd.steps.generic.when_request import _call_via
+
+    _call_via(ctx, ctx.get("transport"))
+
+
+# ── Then ─────────────────────────────────────────────────────────────
+
+
+def _serialized_response(ctx: dict) -> dict[str, Any]:
+    """Serialize the typed response through the production serializer (JSON mode).
+
+    list_creatives returns the same typed payload on every transport, so each
+    transport's Then steps assert on the same serialized document. ``mode="json"``
+    drives ``NestedModelSerializerMixin`` — the same serializer that produces the
+    on-the-wire bytes (format_id -> {agent_url, id}, datetimes -> ISO strings).
+    ``exclude_none`` omits unset optional fields (format_summary, status_summary,
+    sandbox, errors, ext, context), matching the buyer-visible REST wire and the
+    AdCP contract, which type those fields only when present (a literal ``null``
+    is not a valid array/object/boolean).
+
+    The 4-transport parametrization still exercises each dispatch path end to end:
+    a broken transport surfaces as a missing/errored ``ctx["response"]`` here.
+    """
+    return _require_response(ctx).model_dump(mode="json", exclude_none=True)
+
+
+@then(parsers.parse("the response should be schema-valid against {schema_file}"))
+def then_response_schema_valid(ctx: dict, schema_file: str) -> None:
+    """Assert the serialized response validates against the pinned AdCP schema."""
+    validate_against_pinned_schema(schema_file, _serialized_response(ctx))
+
+
+@then("the creatives array should include each of the synced creatives")
+def then_creatives_include_synced(ctx: dict) -> None:
+    """Assert every creative_id seeded by the Given is present in the library."""
+    expected = set(ctx["synced_creative_ids"])
+    returned = {entry["creative_id"] for entry in _serialized_response(ctx)["creatives"]}
+    missing = expected - returned
+    assert not missing, (
+        f"synced creatives missing from the list_creatives library: {sorted(missing)}; "
+        f"returned creative_ids: {sorted(returned)}"
+    )
+
+
+@then("each creative entry should expose creative_id, name, format_id, and status")
+def then_each_creative_exposes_core_fields(ctx: dict) -> None:
+    """Assert every entry carries the four core fields, format_id as a {agent_url, id} object."""
+    creatives = _serialized_response(ctx)["creatives"]
+    assert creatives, "list_creatives returned an empty creatives array"
+    for entry in creatives:
+        for field in ("creative_id", "name", "format_id", "status"):
+            assert field in entry, f"creative entry missing {field!r}: {entry}"
+            assert entry[field] not in (None, "", {}), f"creative entry has empty {field!r}: {entry}"
+        # v3.1 federation contract: format_id is an object carrying agent_url + id.
+        fid = entry["format_id"]
+        assert isinstance(fid, dict) and fid.get("agent_url") and fid.get("id"), (
+            f"format_id must be an object with agent_url and id, got: {fid!r}"
+        )

--- a/tests/helpers/pinned_schema.py
+++ b/tests/helpers/pinned_schema.py
@@ -1,0 +1,76 @@
+"""Validate data against vendored ("pinned") AdCP JSON schemas, fully offline.
+
+Single source of truth for schema-shape assertions in tests (e.g. the BDD step
+"the response should be schema-valid against <file>"). Reads the committed
+fixtures under ``tests/fixtures/adcp_schemas_pinned/``, pinned at
+adcontextprotocol/adcp@04f59d2d5 (tag ``v3.1-04f59d2d5``). It never fetches the
+network — ``/schemas/latest`` drifts and would make tests non-deterministic.
+
+``$ref`` resolution (e.g. ``/schemas/core/format-id.json``) is wired through a
+``referencing.Registry`` retrieve callback that loads each referenced schema from
+the same pinned tree, so nested refs validate against the frozen closure. A
+missing schema (the pin moved, or a ``$ref`` is outside the vendored closure) is
+a HARD FAILURE, never a silent skip — mirroring ``load_json_schema`` in
+``tests/unit/test_pydantic_schema_alignment.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import referencing
+from jsonschema.validators import Draft7Validator
+from referencing.jsonschema import DRAFT7
+
+_PINNED_SCHEMA_DIR = Path(__file__).resolve().parent.parent / "fixtures" / "adcp_schemas_pinned"
+
+
+def _load_by_ref(schema_ref: str) -> dict[str, Any]:
+    """Load a pinned schema by its ``$id``/``$ref`` namespace path (``/schemas/...``)."""
+    rel = schema_ref.split("#", 1)[0]
+    if not rel.startswith("/schemas/"):
+        raise AssertionError(f"Unexpected schema ref (expected '/schemas/...'): {schema_ref!r}")
+    path = _PINNED_SCHEMA_DIR / rel[len("/schemas/") :]
+    if not path.exists():
+        raise AssertionError(
+            f"Pinned schema not vendored: {schema_ref} -> {path}. "
+            "Re-run tests/fixtures/adcp_schemas_pinned/_refresh.py to vendor it."
+        )
+    return json.loads(path.read_text())
+
+
+def _resolve_filename(filename: str) -> Path:
+    """Resolve a bare schema filename (e.g. ``list-creatives-response.json``) to its pinned path."""
+    matches = sorted(_PINNED_SCHEMA_DIR.rglob(filename))
+    if not matches:
+        raise AssertionError(
+            f"Pinned schema {filename!r} not found under {_PINNED_SCHEMA_DIR}. "
+            "Re-run tests/fixtures/adcp_schemas_pinned/_refresh.py to vendor it."
+        )
+    return matches[0]
+
+
+def _retrieve(uri: str) -> referencing.Resource:
+    """referencing retrieve callback: resolve a ``/schemas/...`` ref from the pinned tree."""
+    return DRAFT7.create_resource(_load_by_ref(uri))
+
+
+def validate_against_pinned_schema(filename: str, data: Any) -> None:
+    """Assert *data* is schema-valid against the pinned AdCP schema *filename*.
+
+    Raises ``AssertionError`` listing every JSON-path violation on failure.
+    """
+    schema = json.loads(_resolve_filename(filename).read_text())
+    registry: referencing.Registry = referencing.Registry(retrieve=_retrieve)
+    root_id = schema.get("$id")
+    if root_id:
+        registry = registry.with_resource(root_id, DRAFT7.create_resource(schema))
+    validator = Draft7Validator(schema, registry=registry)
+    errors = sorted(validator.iter_errors(data), key=lambda e: list(e.absolute_path))
+    if errors:
+        details = "\n".join(
+            f"  at {'.'.join(str(p) for p in e.absolute_path) or '<root>'}: {e.message}" for e in errors
+        )
+        raise AssertionError(f"Response is not schema-valid against {filename}:\n{details}")


### PR DESCRIPTION
Wire T-UC-018-storyboard-list-all-creatives-after-sync to real production across all wire transports (a2a/mcp/rest): after seeding creatives, a no-filter list_creatives returns them, schema-valid against list-creatives-response.json, each entry exposing
creative_id/name/format_id/status.

- Route UC-018 -> CreativeListEnv in the bdd conftest (_detect_uc/_harness_env), gated on @list-after-sync; the remaining UC-018 scenarios xfail fast at the fixture (mirrors UC-002/006/011) until they are individually wired.
- Add tests/helpers/pinned_schema.py: an offline validator against the vendored pinned AdCP schemas (v3.1-04f59d2d5) with $ref resolution.
- Steps are defined inline (module-scoped) so the shared "schema-valid against <file>" / "authenticated as principal" phrasings are NOT registered globally, which would alter the already-wired UC-004/005/006 suites.