### PR TITLE
chore(ci): #1234 closure tails (stacked on #1401)

### DIFF
--- a/.github/actions/_install-uv/action.yml
+++ b/.github/actions/_install-uv/action.yml
@@ -1,5 +1,5 @@
-name: Install uv
-description: Install the uv version from .uv-version (single source; pin setup-uv here only).
+name: Install uv and Python
+description: Install the uv version from .uv-version and provision Python from .python-version (single-source anchors; pin setup-uv SHA here only).
 runs:
   using: composite
   steps:

--- a/.github/actions/_install-uv/action.yml
+++ b/.github/actions/_install-uv/action.yml
@@ -1,5 +1,5 @@
-name: Install uv and Python
-description: Install the uv version from .uv-version and provision Python from .python-version (single-source anchors; pin setup-uv SHA here only).
+name: Install uv
+description: Install the pinned uv from .uv-version (setup-uv SHA pinned here only). Python is resolved downstream by `uv sync` honoring .python-version.
 runs:
   using: composite
   steps:
@@ -12,4 +12,3 @@ runs:
       uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v5.4.0
       with:
         version: ${{ steps.uv_version.outputs.version }}
-        python-version-file: .python-version

--- a/.github/actions/_setup-env/action.yml
+++ b/.github/actions/_setup-env/action.yml
@@ -11,7 +11,7 @@ runs:
         path: |
           ~/.cache/uv
           .venv
-        key: ${{ runner.os }}-uv-v4-py${{ hashFiles('.python-version') }}-${{ hashFiles('uv.lock') }}
+        key: ${{ runner.os }}-uv-v5-py${{ hashFiles('.python-version') }}-${{ hashFiles('uv.lock', 'pyproject.toml') }}
 
     - name: Install dependencies
       shell: bash

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -8,7 +8,6 @@ queries:
 # Exclude generated / vendored / migration content from analysis to reduce noise.
 paths-ignore:
   - alembic/versions/
-  - src/adapters/google_ad_manager_original.py
   - tests/
   - htmlcov/
   - .venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -153,7 +153,6 @@ repos:
         language: system
         args: [--config-file=mypy.ini, src/]
         files: '^src/'
-        exclude: '^src/adapters/google_ad_manager_original\.py$'
         pass_filenames: false
         require_serial: true
         stages: [pre-push]

--- a/docs/development/ci-pipeline.md
+++ b/docs/development/ci-pipeline.md
@@ -230,6 +230,20 @@ required (or stay blocked on stale `Test Suite / …` names).
 | `make quality` | Yes (`tests/unit/ -x`) | Local pre-commit habit |
 | `make quality-full` | Full suites via `run_all_tests.sh` | Pre-PR local gate |
 
+### Local vs CI Postgres isolation (D9)
+
+Local `tox -e integration` and `make test-int` reuse a **persistent** Postgres
+instance (agent-db or Docker stack on the host). CI integration/admin/BDD jobs
+start a **fresh** `postgres:17-alpine` service container per job run.
+
+Cross-test isolation bugs that depend on process-wide factory binding (see
+`tests/admin/conftest.py`) can reproduce locally but not in CI, or vice versa.
+
+**Diagnostic:** run `tox -p` or `./run_all_tests.sh quick` locally against a
+shared Postgres, then compare with the same slice in CI. If a failure is
+isolation-specific, inspect factory session binding and tenant scoping — not
+Postgres version drift (guarded by `test_architecture_postgres_image_anchor`).
+
 ## Layered pre-commit model (PR 4 of #1234)
 
 | Layer | Trigger | Enforcement |

--- a/mypy.ini
+++ b/mypy.ini
@@ -51,10 +51,6 @@ exclude = (?x)(
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-src.adapters.google_ad_manager_original]
-# Legacy file - ignore for now
-ignore_errors = True
-
 [mypy-src.core.database.models]
 # SQLAlchemy models - be lenient with model definitions
 disallow_untyped_defs = False

--- a/tests/unit/_architecture_helpers.py
+++ b/tests/unit/_architecture_helpers.py
@@ -203,12 +203,8 @@ def iter_architecture_guard_trees(
 
 
 def src_python_files(repo: Path) -> Iterator[Path]:
-    """Every .py file under src/, excluding migrations and the legacy GAM file."""
-    excluded = {repo / "src" / "adapters" / "google_ad_manager_original.py"}
-    for p in (repo / "src").rglob("*.py"):
-        if p in excluded:
-            continue
-        yield p
+    """Every .py file under src/, excluding migrations."""
+    yield from (repo / "src").rglob("*.py")
 
 
 def iter_workflow_files(repo: Path) -> Iterator[Path]:
@@ -239,7 +235,9 @@ def iter_git_tracked_files(repo: Path) -> Iterator[Path]:
 
 # Patterns intentionally permissive: surfaces use varied formats. Each returns
 # a normalized version string ("3.12", "17", "0.11.7") via the first capture group.
-# ``anchor_kind`` labels the surface (e.g. ``target-version``) for ADR-008 exemptions.
+# ``anchor_kind`` labels the surface for ADR-008 exemptions; each kind mirrors its
+# config key verbatim (hyphen: ``requires-python``, ``target-version``; underscore:
+# ``python_version``).
 
 _DOCKERFILE_PYTHON_VERSION_PATTERN = r"^\s*ARG\s+PYTHON_VERSION=([0-9]+(?:\.[0-9]+)*)"
 
@@ -536,7 +534,11 @@ def assert_adr008_target_version_pinned(anchors: Iterable[tuple[Path, str, str]]
 
 
 def assert_dockerfile_digest_args_present(text: str) -> None:
-    """Assert Dockerfile declares digest-pinned ``UV_IMAGE_DIGEST`` and ``PYTHON_BASE_DIGEST`` ARGs."""
+    """Assert Dockerfile declares digest ARGs with ``sha256:<64-hex>`` shape.
+
+    Verifies presence and format only — not that the digest matches the pinned
+    ``PYTHON_VERSION`` / ``UV_VERSION`` tags (see #1468 for version-aware follow-up).
+    """
     missing: list[str] = []
     if not _DOCKERFILE_UV_IMAGE_DIGEST_RE.search(text):
         missing.append("ARG UV_IMAGE_DIGEST=sha256:<64-hex>")

--- a/tests/unit/_architecture_helpers.py
+++ b/tests/unit/_architecture_helpers.py
@@ -203,7 +203,7 @@ def iter_architecture_guard_trees(
 
 
 def src_python_files(repo: Path) -> Iterator[Path]:
-    """Every .py file under src/, excluding migrations."""
+    """Every .py file under src/."""
     yield from (repo / "src").rglob("*.py")
 
 
@@ -235,9 +235,7 @@ def iter_git_tracked_files(repo: Path) -> Iterator[Path]:
 
 # Patterns intentionally permissive: surfaces use varied formats. Each returns
 # a normalized version string ("3.12", "17", "0.11.7") via the first capture group.
-# ``anchor_kind`` labels the surface for ADR-008 exemptions; each kind mirrors its
-# config key verbatim (hyphen: ``requires-python``, ``target-version``; underscore:
-# ``python_version``).
+# ``anchor_kind`` labels the surface (e.g. ``target-version``) for ADR-008 exemptions.
 
 _DOCKERFILE_PYTHON_VERSION_PATTERN = r"^\s*ARG\s+PYTHON_VERSION=([0-9]+(?:\.[0-9]+)*)"
 
@@ -537,7 +535,7 @@ def assert_dockerfile_digest_args_present(text: str) -> None:
     """Assert Dockerfile declares digest ARGs with ``sha256:<64-hex>`` shape.
 
     Verifies presence and format only — not that the digest matches the pinned
-    ``PYTHON_VERSION`` / ``UV_VERSION`` tags (see #1468 for version-aware follow-up).
+    ``PYTHON_VERSION`` / ``UV_VERSION`` tags.
     """
     missing: list[str] = []
     if not _DOCKERFILE_UV_IMAGE_DIGEST_RE.search(text):

--- a/tests/unit/test_architecture_dockerfile_digest_pinned.py
+++ b/tests/unit/test_architecture_dockerfile_digest_pinned.py
@@ -25,7 +25,7 @@ _KNOWN_BAD_FROM = [
 
 @pytest.mark.arch_guard
 def test_dockerfile_digest_args_present() -> None:
-    """Dockerfile must declare digest-pinned UV_IMAGE_DIGEST and PYTHON_BASE_DIGEST ARGs."""
+    """Dockerfile must declare UV_IMAGE_DIGEST and PYTHON_BASE_DIGEST with sha256:<64-hex> shape."""
     assert_dockerfile_digest_args_present((repo_root() / "Dockerfile").read_text(encoding="utf-8"))
 
 


### PR DESCRIPTION
Closes #1234.

## Summary
Closure tails for #1234 / #1468, stacked on #1401 (PR 6). **Merge after #1401 lands**, then rebase onto `main`.

- **C5:** uv cache key includes `pyproject.toml` (#1228)
- **E1:** remove phantom `google_ad_manager_original` config (#1228)
- **D9:** document local vs CI Postgres isolation (#1233)
- **#1468 nits:** digest guard honesty, `_install-uv` description, `anchor_kind` comment

Part of closing #1234.

Depends on #1401.

## Test plan
- [x] `make quality-ci`
- [ ] Rebase onto `main` after #1401 merge
- [ ] CI green post-rebase