### PR TITLE
ci: add nightly GAM regression workflow for requires_gam tests (#1477)

### DIFF
--- a/.github/workflows/gam-nightly.yml
+++ b/.github/workflows/gam-nightly.yml
@@ -26,6 +26,7 @@ jobs:
   gam-e2e:
     name: GAM E2E (requires_gam)
     if: github.ref == 'refs/heads/main'
+    environment: gam-nightly
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -50,7 +51,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${GAM_SERVICE_ACCOUNT_JSON}" ]; then
-            echo "::error::GAM_SERVICE_ACCOUNT_JSON is not configured. Add the secret under Settings → Secrets and variables → Actions (main branch only)."
+            echo "::error::GAM_SERVICE_ACCOUNT_JSON is not configured. Add it to the gam-nightly environment (Settings → Environments → gam-nightly → Environment secrets; restrict deployment branches to main)."
             exit 1
           fi
           uv run python -c 'import json, os; json.loads(os.environ["GAM_SERVICE_ACCOUNT_JSON"])'

--- a/.github/workflows/gam-nightly.yml
+++ b/.github/workflows/gam-nightly.yml
@@ -1,7 +1,7 @@
 name: GAM Nightly Regression
 
-# Live GAM API tests (@pytest.mark.requires_gam) run here — not in per-PR CI.
-# Secrets are restricted to the default branch; fork PRs never receive them.
+# Live GAM API tests (@pytest.mark.requires_gam, ~20) run here — not in per-PR CI.
+# Secrets are restricted to the gam-nightly environment on main; fork PRs never receive them.
 # Tracking: #1477 (D13, #1233).
 
 on:
@@ -53,12 +53,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/_setup-env
-      - name: Ensure docker-compose alias exists
-        run: |
-          docker compose version
-          echo '#!/bin/bash' | sudo tee /usr/local/bin/docker-compose
-          echo 'exec docker compose "$@"' | sudo tee -a /usr/local/bin/docker-compose
-          sudo chmod +x /usr/local/bin/docker-compose
       - name: Verify GAM credentials secret
         env:
           GAM_SERVICE_ACCOUNT_JSON: ${{ secrets.GAM_SERVICE_ACCOUNT_JSON }}
@@ -69,28 +63,12 @@ jobs:
             exit 1
           fi
           uv run python -c 'import json, os; json.loads(os.environ["GAM_SERVICE_ACCOUNT_JSON"])'
-      - name: Clean up lingering containers
-        run: |
-          docker ps -q | xargs -r docker kill || true
-          docker compose -f docker-compose.e2e.yml down -v 2>/dev/null || true
-          docker compose down -v 2>/dev/null || true
-          docker container prune -f 2>/dev/null || true
-          docker network prune -f 2>/dev/null || true
-          docker volume prune -f 2>/dev/null || true
       - uses: ./.github/actions/_pytest
         with:
           paths: tests/e2e/
           extra_args: -m requires_gam --timeout=300
         env:
-          # conftest starts docker-compose.e2e.yml (same host-path pattern as CI E2E).
           ADCP_TESTING: ""
-          ADCP_SALES_PORT: 8080
-          POSTGRES_PORT: 5435
-          # gam_lifecycle_db creates ephemeral databases on this server.
+          # gam_lifecycle_db connects to the postgres maintenance DB and CREATE DATABASE per test.
           DATABASE_URL: postgresql://adcp_user:secure_password_change_me@127.0.0.1:5435/postgres
           GAM_SERVICE_ACCOUNT_JSON: ${{ secrets.GAM_SERVICE_ACCOUNT_JSON }}
-          DOCKER_BUILDKIT: 1
-          COMPOSE_DOCKER_CLI_BUILD: 1
-      - name: Cleanup Docker services
-        if: always()
-        run: docker compose -f docker-compose.e2e.yml down -v 2>/dev/null || true

--- a/.github/workflows/gam-nightly.yml
+++ b/.github/workflows/gam-nightly.yml
@@ -1,0 +1,81 @@
+name: GAM Nightly Regression
+
+# Live GAM API tests (@pytest.mark.requires_gam) run here — not in per-PR CI.
+# Secrets are restricted to the default branch; fork PRs never receive them.
+# Tracking: #1477 (D13, #1233).
+
+on:
+  schedule:
+    - cron: '0 7 * * *'  # 07:00 UTC daily
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: gam-nightly
+  cancel-in-progress: false
+
+env:
+  GEMINI_API_KEY: test_key_for_mocking
+  GOOGLE_CLIENT_ID: test_client_id
+  GOOGLE_CLIENT_SECRET: test_client_secret
+  SUPER_ADMIN_EMAILS: test@example.com
+  ENCRYPTION_KEY: MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=
+
+jobs:
+  gam-e2e:
+    name: GAM E2E (requires_gam)
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 45
+    steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/_setup-env
+      - name: Ensure docker-compose alias exists
+        run: |
+          docker compose version
+          echo '#!/bin/bash' | sudo tee /usr/local/bin/docker-compose
+          echo 'exec docker compose "$@"' | sudo tee -a /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+      - name: Verify GAM credentials secret
+        env:
+          GAM_SERVICE_ACCOUNT_JSON: ${{ secrets.GAM_SERVICE_ACCOUNT_JSON }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GAM_SERVICE_ACCOUNT_JSON}" ]; then
+            echo "::error::GAM_SERVICE_ACCOUNT_JSON is not configured. Add the secret under Settings → Secrets and variables → Actions (main branch only)."
+            exit 1
+          fi
+          uv run python -c 'import json, os; json.loads(os.environ["GAM_SERVICE_ACCOUNT_JSON"])'
+      - name: Clean up lingering containers
+        run: |
+          docker ps -q | xargs -r docker kill || true
+          docker compose -f docker-compose.e2e.yml down -v 2>/dev/null || true
+          docker compose down -v 2>/dev/null || true
+          docker container prune -f 2>/dev/null || true
+          docker network prune -f 2>/dev/null || true
+          docker volume prune -f 2>/dev/null || true
+      - uses: ./.github/actions/_pytest
+        with:
+          paths: tests/e2e/
+          extra_args: -m requires_gam --timeout=300
+        env:
+          # conftest starts docker-compose.e2e.yml (same host-path pattern as CI E2E).
+          ADCP_TESTING: ""
+          ADCP_SALES_PORT: 8080
+          POSTGRES_PORT: 5435
+          # gam_lifecycle_db creates ephemeral databases on this server.
+          DATABASE_URL: postgresql://adcp_user:secure_password_change_me@127.0.0.1:5435/postgres
+          GAM_SERVICE_ACCOUNT_JSON: ${{ secrets.GAM_SERVICE_ACCOUNT_JSON }}
+          DOCKER_BUILDKIT: 1
+          COMPOSE_DOCKER_CLI_BUILD: 1
+      - name: Cleanup Docker services
+        if: always()
+        run: docker compose -f docker-compose.e2e.yml down -v 2>/dev/null || true

--- a/.github/workflows/gam-nightly.yml
+++ b/.github/workflows/gam-nightly.yml
@@ -31,6 +31,20 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 45
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: adcp_user
+          POSTGRES_PASSWORD: secure_password_change_me
+          POSTGRES_DB: postgres
+        options: >-
+          --health-cmd "pg_isready -U adcp_user"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+        ports:
+          - 5435:5432
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -57,10 +57,12 @@ rules:
   # unpinned-images — ci.yml postgres service containers use the unified rolling
   # tag postgres:17-alpine (PR 5 / ADR-008). Digest pin for service containers
   # is deferred; test_architecture_postgres_image_anchor enforces tag consistency.
+  # gam-nightly.yml uses the same GHA postgres service pattern for gam_lifecycle_db.
   # ─────────────────────────────────────────────────────────────────────────────
   unpinned-images:
     ignore:
       - ci.yml
+      - gam-nightly.yml
 
   # ─────────────────────────────────────────────────────────────────────────────
   # secrets-outside-env — release-please.yml publishes to Docker Hub via repo

--- a/docs/development/ci-pipeline.md
+++ b/docs/development/ci-pipeline.md
@@ -256,7 +256,32 @@ coverage lives in ``tests/e2e/`` via ``live_server`` / ``docker_services_e2e``.
 | Item | Tracking | When |
 |------|----------|------|
 | `test_sell_readiness_browser.py` admin browser flows | #1233 D11 follow-up | Dedicated admin+e2e-stack CI job |
-| Nightly GAM `requires_gam` workflow | #1477 (D13) | #1485 |
+
+### Nightly GAM regression (D13, #1477)
+
+~20 tests in `tests/e2e/test_gam_*.py` carry `@pytest.mark.requires_gam`. They
+call the live GAM sandbox network and are **excluded from per-PR CI** (quota,
+credential blast radius on fork PRs).
+
+| Property | Value |
+|----------|-------|
+| Workflow | [`.github/workflows/gam-nightly.yml`](../../.github/workflows/gam-nightly.yml) |
+| Trigger | Daily cron (`07:00 UTC`) + `workflow_dispatch` |
+| Branch | `main` only (`if: github.ref == 'refs/heads/main'`) |
+| Environment | `gam-nightly` — create under **Settings → Environments**, restrict deployment branches to `main` |
+| Secret | `GAM_SERVICE_ACCOUNT_JSON` on the `gam-nightly` environment (not repo-level; unavailable to fork PRs) |
+| Command | `pytest tests/e2e/ -m requires_gam` (GHA Postgres service on :5435 for `gam_lifecycle_db`; tests that request `docker_services_e2e` still start the e2e stack via conftest) |
+| `DATABASE_URL` | `postgresql://adcp_user:secure_password_change_me@127.0.0.1:5435/postgres` — GHA `services.postgres` on host port 5435; `gam_lifecycle_db` creates ephemeral databases there |
+
+Failures notify repository watchers via GitHub's default workflow notifications.
+
+**Local equivalent** (requires credentials + Docker):
+
+```bash
+export GAM_SERVICE_ACCOUNT_JSON='{"type":"service_account",...}'
+export DATABASE_URL=postgresql://adcp_user:secure_password_change_me@127.0.0.1:5435/postgres
+uv run pytest tests/e2e/ -m requires_gam -v --timeout=300
+```
 
 ## Layered pre-commit model (PR 4 of #1234)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -20,6 +20,7 @@ markers =
     e2e: End-to-end tests with full system
     slow: Tests that take > 5 seconds
     ai: Tests requiring GEMINI_API_KEY
+    requires_gam: Live GAM API tests (nightly CI only; see gam-nightly.yml)
     skip_ci: Skip in CI environment
     asyncio: Async test functions
     requires_db: Tests requiring a real database with tables

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -123,11 +123,6 @@ def find_free_port(start_port: int = 10000, end_port: int = 60000) -> int:
     raise RuntimeError(f"No free ports found in range {start_port}-{end_port}")
 
 
-def pytest_configure(config):
-    """Register custom markers."""
-    config.addinivalue_line("markers", "requires_gam: mark test as requiring real GAM credentials")
-
-
 def pytest_addoption(parser):
     """Add custom command line options for E2E tests."""
     parser.addoption(


### PR DESCRIPTION
## Summary
- Add `.github/workflows/gam-nightly.yml` — daily cron (`07:00 UTC`) + `workflow_dispatch` on `main` only
- Run `pytest tests/e2e/ -m requires_gam` (~20 tests) with GHA `services.postgres` on host `:5435` for `gam_lifecycle_db`
- Validate `GAM_SERVICE_ACCOUNT_JSON` before tests; no full e2e Docker stack required for the marker filter
- Document workflow, environment secret, and local equivalent in `docs/development/ci-pipeline.md`

Closes #1477. Satisfies #1233 D13.

**Maintainer action (environment secret, not repo secret):**
1. Create GitHub Environment `gam-nightly` (Settings → Environments)
2. Restrict deployment branches to `main`
3. Add environment secret `GAM_SERVICE_ACCOUNT_JSON` (service account JSON)

After merge: run `workflow_dispatch` once with the secret configured to confirm all 20 tests execute.

## Test plan
- [x] `make quality`
- [x] zizmor green (gam-nightly in unpinned-images allowlist)
- [ ] CI green on PR
- [ ] After merge: `workflow_dispatch` on `main` with secret configured