### PR TITLE
chore: address #1400 review follow-ups (digest guard, action docs)

### DIFF
--- a/.github/actions/_install-uv/action.yml
+++ b/.github/actions/_install-uv/action.yml
@@ -1,5 +1,8 @@
 name: Install uv
-description: Install the pinned uv from .uv-version (setup-uv SHA pinned here only). Python is resolved downstream by `uv sync` honoring .python-version.
+description: >
+  Install the pinned uv CLI from .uv-version (setup-uv SHA pinned here only).
+  Does not install Python directly — downstream _setup-env runs `uv sync`, which
+  provisions the interpreter from .python-version.
 runs:
   using: composite
   steps:

--- a/tests/unit/_architecture_helpers.py
+++ b/tests/unit/_architecture_helpers.py
@@ -235,7 +235,9 @@ def iter_git_tracked_files(repo: Path) -> Iterator[Path]:
 
 # Patterns intentionally permissive: surfaces use varied formats. Each returns
 # a normalized version string ("3.12", "17", "0.11.7") via the first capture group.
-# ``anchor_kind`` labels the surface (e.g. ``target-version``) for ADR-008 exemptions.
+# ``anchor_kind`` labels the surface for ADR-008 exemptions. Each string mirrors
+# the config key on that surface (hyphens in TOML/YAML, underscores in ini —
+# e.g. ``requires-python`` vs ``python_version``).
 
 _DOCKERFILE_PYTHON_VERSION_PATTERN = r"^\s*ARG\s+PYTHON_VERSION=([0-9]+(?:\.[0-9]+)*)"
 

--- a/tests/unit/test_architecture_dockerfile_digest_pinned.py
+++ b/tests/unit/test_architecture_dockerfile_digest_pinned.py
@@ -1,7 +1,12 @@
-"""Guard: Dockerfile pins base image by digest and runs as non-root.
+"""Guard: Dockerfile supply-chain pins (digest ARGs, FROM pins, non-root USER).
 
-Per D34 + PR 5 of issue #1234. Without these, the runtime image carries
-unverified base-layer provenance and root-equivalent privileges.
+Per D34 + PR 5 of issue #1234. Three independent checks:
+
+- ``assert_dockerfile_digest_args_present`` — digest ARG **presence + sha256 shape
+  only**; does not verify the digest matches pinned ``PYTHON_VERSION`` / ``UV_VERSION``.
+- ``find_unpinned_dockerfile_from_lines`` — every external ``FROM`` must reference
+  ``@sha256:…`` or a digest ``ARG`` substitution, not a tag-only image ref.
+- ``runtime_user_directives`` — runtime stage must not end as root.
 """
 
 from __future__ import annotations
@@ -25,7 +30,7 @@ _KNOWN_BAD_FROM = [
 
 @pytest.mark.arch_guard
 def test_dockerfile_digest_args_present() -> None:
-    """Dockerfile must declare UV_IMAGE_DIGEST and PYTHON_BASE_DIGEST with sha256:<64-hex> shape."""
+    """Digest ARG pins present with sha256:<64-hex> shape (not version-digest match)."""
     assert_dockerfile_digest_args_present((repo_root() / "Dockerfile").read_text(encoding="utf-8"))
 
 


### PR DESCRIPTION
Closes #1234.

## Summary
- Clarify digest ARG guard checks **presence + sha256 shape only** (not version-digest match) in module and test docstrings (#1468 / #1400 review item 1, option a)
- Expand `_install-uv` composite action description: uv CLI here, Python via downstream `_setup-env` + `.python-version` (review item 3)
- Document `anchor_kind` hyphen vs underscore convention in `_architecture_helpers.py` (review item 4)
- Part B helper trim (#1455): audited all exports — none dead post-#1459; no deletions needed

Part of #1468.

## Test plan
- [x] `uv run pytest tests/unit/test_architecture_dockerfile_digest_pinned.py -q`
- [x] `make quality-ci`
- [ ] CI green on PR