### PR TITLE
feat: 1407 list creatives concept ids

### DIFF
--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -67,7 +67,7 @@ from src.core.exceptions import (
     normalize_to_adcp_error,
 )
 from src.core.resolved_identity import ResolvedIdentity
-from src.core.schema_helpers import to_account_reference
+from src.core.schema_helpers import coerce_creative_filters, to_account_reference
 from src.core.schemas import CreativeStatusEnum
 from src.core.tool_context import ToolContext
 from src.core.tool_error_logging import record_boundary_error
@@ -1651,11 +1651,9 @@ class AdCPRequestHandler(RequestHandler):
 
         # Structured AdCP CreativeFilters (statuses, concept_ids, format_ids, …)
         # arrive over the wire as a JSON dict; coerce to the typed model the core
-        # function expects so they are honoured rather than dropped.
-        from adcp import CreativeFilters
-
-        filters_param = parameters.get("filters")
-        filters = CreativeFilters.model_validate(filters_param) if isinstance(filters_param, dict) else filters_param
+        # function expects so they are honoured rather than dropped. Invalid filters
+        # raise AdCPValidationError (VALIDATION_ERROR + suggestion) via the shared helper.
+        filters = coerce_creative_filters(parameters.get("filters"))
 
         # Call core function with optional parameters (fixing original validation bug)
         response = core_list_creatives_tool(

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -1649,6 +1649,14 @@ class AdCPRequestHandler(RequestHandler):
         # Create ToolContext from A2A auth info and resolve identity
         tool_context = self._make_tool_context(identity, "list_creatives")
 
+        # Structured AdCP CreativeFilters (statuses, concept_ids, format_ids, …)
+        # arrive over the wire as a JSON dict; coerce to the typed model the core
+        # function expects so they are honoured rather than dropped.
+        from adcp import CreativeFilters
+
+        filters_param = parameters.get("filters")
+        filters = CreativeFilters.model_validate(filters_param) if isinstance(filters_param, dict) else filters_param
+
         # Call core function with optional parameters (fixing original validation bug)
         response = core_list_creatives_tool(
             media_buy_id=parameters.get("media_buy_id"),
@@ -1658,6 +1666,7 @@ class AdCPRequestHandler(RequestHandler):
             created_after=parameters.get("created_after"),
             created_before=parameters.get("created_before"),
             search=parameters.get("search"),
+            filters=filters,
             page=parameters.get("page", 1),
             limit=parameters.get("limit", 50),
             sort_by=parameters.get("sort_by", "created_date"),

--- a/src/core/database/repositories/creative.py
+++ b/src/core/database/repositories/creative.py
@@ -87,6 +87,7 @@ class CreativeRepository:
         created_before: datetime | None = None,
         search: str | None = None,
         media_buy_ids: list[str] | None = None,
+        concept_ids: list[str] | None = None,
         sort_by: str = "created_date",
         sort_order: str = "desc",
         offset: int = 0,
@@ -117,6 +118,12 @@ class CreativeRepository:
 
         if format:
             stmt = stmt.where(Creative.format == format)
+
+        # v3.1 concept_ids filter: concepts group related creatives across sizes
+        # and formats (e.g. Flashtalking concepts, Celtra campaign folders). The
+        # concept identifier is stored on the creative's JSON data blob.
+        if concept_ids:
+            stmt = stmt.where(Creative.data["concept_id"].as_string().in_(concept_ids))
 
         if tags:
             for tag in tags:

--- a/src/core/schema_helpers.py
+++ b/src/core/schema_helpers.py
@@ -133,13 +133,13 @@ def coerce_creative_filters(filters: dict[str, Any] | CreativeFilters | None) ->
     A2A coerce identically (the MCP transport coerces via FastMCP's TypeAdapter on
     the tool signature).
 
-    Unlike the ``to_*`` converters above, an *invalid* structured filter is a loud
-    failure, not a silent ``None``: a malformed filter (e.g. ``concept_ids`` with an
-    empty array, violating the schema's ``minItems: 1``) is raised as an
-    ``AdCPValidationError`` carrying a recovery suggestion, so every transport
-    surfaces the spec's two-layer ``VALIDATION_ERROR`` envelope (with a suggestion,
-    per POST-F3) instead of a bare framework ``ValidationError`` that
-    ``normalize_to_adcp_error`` would flatten without a suggestion.
+    A malformed filter (e.g. ``concept_ids`` with an empty array, violating the
+    schema's ``minItems: 1``) is raised as a *typed* ``AdCPValidationError`` carrying
+    a recovery suggestion, so every transport surfaces the spec's two-layer
+    ``VALIDATION_ERROR`` envelope (with a suggestion, per POST-F3). Constructing the
+    model directly instead (as the ``to_*`` converters above do, via ``Model(**dict)``)
+    surfaces a raw pydantic ``ValidationError`` that ``normalize_to_adcp_error``
+    flattens into a suggestion-less envelope.
 
     Args:
         filters: Filters as a wire dict, an already-typed CreativeFilters, or None.

--- a/src/core/schema_helpers.py
+++ b/src/core/schema_helpers.py
@@ -13,7 +13,7 @@ Philosophy:
 from typing import Any
 
 # FIXME(#1388): GetProductsResponse, Product have local subclasses; import from src.core.schemas.
-from adcp import GetProductsResponse, Product
+from adcp import CreativeFilters, GetProductsResponse, Product
 
 # FIXME(#1388): ProductFilters has a local subclass; import from src.core.schemas.
 from adcp.types import (
@@ -24,8 +24,11 @@ from adcp.types import (
     PropertyListReference,
     ReportingWebhook,
 )
+from pydantic import ValidationError
 
+from src.core.exceptions import AdCPValidationError
 from src.core.schemas.product import GetProductsRequest
+from src.core.validation_helpers import format_validation_error
 
 
 def to_context_object(context: dict[str, Any] | ContextObject | None) -> ContextObject | None:
@@ -123,6 +126,41 @@ def to_property_list_reference(
     return None  # Fallback for unexpected types
 
 
+def coerce_creative_filters(filters: dict[str, Any] | CreativeFilters | None) -> CreativeFilters | None:
+    """Coerce a raw list_creatives filters value into a typed CreativeFilters.
+
+    Single source of truth for the dict -> CreativeFilters boundary so REST and
+    A2A coerce identically (the MCP transport coerces via FastMCP's TypeAdapter on
+    the tool signature).
+
+    Unlike the ``to_*`` converters above, an *invalid* structured filter is a loud
+    failure, not a silent ``None``: a malformed filter (e.g. ``concept_ids`` with an
+    empty array, violating the schema's ``minItems: 1``) is raised as an
+    ``AdCPValidationError`` carrying a recovery suggestion, so every transport
+    surfaces the spec's two-layer ``VALIDATION_ERROR`` envelope (with a suggestion,
+    per POST-F3) instead of a bare framework ``ValidationError`` that
+    ``normalize_to_adcp_error`` would flatten without a suggestion.
+
+    Args:
+        filters: Filters as a wire dict, an already-typed CreativeFilters, or None.
+
+    Returns:
+        CreativeFilters or None (when no filter was supplied).
+
+    Raises:
+        AdCPValidationError: when ``filters`` is a dict that fails CreativeFilters validation.
+    """
+    if filters is None or isinstance(filters, CreativeFilters):
+        return filters
+    try:
+        return CreativeFilters.model_validate(filters)
+    except ValidationError as e:
+        raise AdCPValidationError(
+            format_validation_error(e, context="list_creatives filters"),
+            suggestion="Fix the filters object — e.g. concept_ids must contain at least 1 concept id.",
+        ) from e
+
+
 def create_get_products_request(
     brief: str = "",
     brand: dict[str, Any] | BrandReference | str | None = None,
@@ -172,9 +210,11 @@ __all__ = [
     "to_brand_reference",
     "to_context_object",
     "to_reporting_webhook",
+    "coerce_creative_filters",
     "create_get_products_request",
     # Re-export types for type hints
     "BrandReference",
+    "CreativeFilters",
     "GetProductsRequest",
     "GetProductsResponse",
     "Product",

--- a/src/core/tools/creatives/listing.py
+++ b/src/core/tools/creatives/listing.py
@@ -157,6 +157,11 @@ def _list_creatives_impl(
     # Build structured objects
     structured_filters = LibraryCreativeFilters(**filters_dict) if filters_dict else None
 
+    # v3.1 concept_ids filter has no flat equivalent — it arrives only via the
+    # structured filters object and must be threaded into the DB query (not merely
+    # reported in filters_applied), or it would be silently dropped.
+    effective_concept_ids = structured_filters.concept_ids if structured_filters else None
+
     # Build pagination
     offset = (page - 1) * effective_limit
     # 3.6.0: PaginationRequest is cursor-based (max_results, cursor). DB query uses offset/limit internally.
@@ -211,6 +216,7 @@ def _list_creatives_impl(
             created_before=created_before_dt,
             search=search,
             media_buy_ids=effective_media_buy_ids or None,
+            concept_ids=effective_concept_ids,
             sort_by=sort_by,
             sort_order=valid_sort_order,
             offset=offset,
@@ -299,6 +305,10 @@ def _list_creatives_impl(
                 status=status_enum,
                 created_date=created_at_dt,
                 updated_date=updated_at_dt,
+                # v3.1 concept grouping (Flashtalking/Celtra/CM360-style), stored on
+                # the JSON data blob; omitted from the response when absent.
+                concept_id=db_creative.data.get("concept_id") if db_creative.data else None,
+                concept_name=db_creative.data.get("concept_name") if db_creative.data else None,
                 # Internal field (our extension)
                 principal_id=db_creative.principal_id,
             )
@@ -319,6 +329,8 @@ def _list_creatives_impl(
             filters_applied.append(f"format_ids={','.join(str(f) for f in req.filters.format_ids)}")
         if req.filters.tags:
             filters_applied.append(f"tags={','.join(req.filters.tags)}")
+        if req.filters.concept_ids:
+            filters_applied.append(f"concept_ids={','.join(req.filters.concept_ids)}")
         if req.filters.created_after:
             filters_applied.append(f"created_after={req.filters.created_after.isoformat()}")
         if req.filters.created_before:

--- a/src/core/tools/creatives/listing.py
+++ b/src/core/tools/creatives/listing.py
@@ -295,6 +295,24 @@ def _list_creatives_impl(
                 # Default to pending_review if invalid status
                 status_enum = CreativeStatus.pending_review
 
+            # v3.1 concept grouping (Flashtalking/Celtra/CM360-style), stored on the
+            # JSON data blob, omitted from the response when absent.
+            #
+            # Population is out-of-band by design: the AdCP sync_creatives request
+            # carries no concept field (concepts are seller/ad-server-assigned, not
+            # buyer-supplied), so concept_id/concept_name are written into data[] by
+            # the ingesting integration (e.g. an adapter mapping the ad server's
+            # native creative groups). Mapping GAM creative groups -> these fields is
+            # a separate, adapter-scoped follow-up; until then the field is populated
+            # only by external producers writing to the blob.
+            #
+            # The blob is untyped and external producers may write numeric ids (CM360
+            # group ids), so coerce to the spec's string type instead of letting a
+            # non-string value fail Creative validation and crash the whole listing.
+            concept_data = db_creative.data or {}
+            concept_id_raw = concept_data.get("concept_id")
+            concept_name_raw = concept_data.get("concept_name")
+
             creative = Creative(
                 creative_id=db_creative.creative_id,
                 name=db_creative.name,
@@ -305,10 +323,8 @@ def _list_creatives_impl(
                 status=status_enum,
                 created_date=created_at_dt,
                 updated_date=updated_at_dt,
-                # v3.1 concept grouping (Flashtalking/Celtra/CM360-style), stored on
-                # the JSON data blob; omitted from the response when absent.
-                concept_id=db_creative.data.get("concept_id") if db_creative.data else None,
-                concept_name=db_creative.data.get("concept_name") if db_creative.data else None,
+                concept_id=str(concept_id_raw) if concept_id_raw is not None else None,
+                concept_name=str(concept_name_raw) if concept_name_raw is not None else None,
                 # Internal field (our extension)
                 principal_id=db_creative.principal_id,
             )

--- a/src/core/tools/creatives/listing.py
+++ b/src/core/tools/creatives/listing.py
@@ -319,7 +319,7 @@ def _list_creatives_impl(
             # but standardizes no concept INPUT on sync_creatives, so the field is
             # populated out-of-band into the data blob. (A seller-side mapping of GAM
             # creative groups -> these fields is a separate enrichment/fallback
-            # follow-up, not the authoritative buyer-side concept.) The blob is
+            # follow-up (#1506), not the authoritative buyer-side concept.) The blob is
             # untyped and an external producer may write numeric group ids, so coerce
             # to the spec's string type via _coerce_concept_value rather than letting a
             # non-string value fail Creative validation and crash the whole listing.

--- a/src/core/tools/creatives/listing.py
+++ b/src/core/tools/creatives/listing.py
@@ -330,6 +330,9 @@ def _list_creatives_impl(
                 name=db_creative.name,
                 format_id=format_obj,
                 assets=assets_dict,
+                # FIXME(#1508): raw untyped blob into typed list[str] — a malformed
+                # tags value (bare string, or [1, 2]) crashes the whole listing, the
+                # same hazard _coerce_concept_value handles for concept fields.
                 tags=db_creative.data.get("tags") if db_creative.data else None,
                 # AdCP spec fields (listing Creative)
                 status=status_enum,

--- a/src/core/tools/creatives/listing.py
+++ b/src/core/tools/creatives/listing.py
@@ -35,6 +35,24 @@ from src.core.validation_helpers import format_validation_error
 logger = logging.getLogger(__name__)
 
 
+def _coerce_concept_value(value: Any) -> str | None:
+    """Coerce an untyped concept blob value to the spec's string type.
+
+    ``concept_id``/``concept_name`` are strings per the AdCP response schema but
+    live in the untyped JSON ``data`` blob, where an out-of-band producer may write
+    a non-string scalar (e.g. a numeric CM360 group id). Scalars are stringified.
+    A non-scalar (list/dict) is corrupt for a string field, so it is dropped with a
+    warning — surfaced in logs (No Quiet Failures) rather than projected as a Python
+    repr — instead of crashing the whole listing on one bad row.
+    """
+    if value is None or isinstance(value, str):
+        return value
+    if isinstance(value, (int, float)):  # bool is an int subclass; str(True)="True" is acceptable
+        return str(value)
+    logger.warning("Dropping non-scalar concept value of type %s from creative listing", type(value).__name__)
+    return None
+
+
 def _merge_structured_filters(filters: "CreativeFilters | None", flat_params: dict) -> dict:
     """Merge a structured CreativeFilters model into flat params (flat take precedence).
 
@@ -295,23 +313,17 @@ def _list_creatives_impl(
                 # Default to pending_review if invalid status
                 status_enum = CreativeStatus.pending_review
 
-            # v3.1 concept grouping (Flashtalking/Celtra/CM360-style), stored on the
-            # JSON data blob, omitted from the response when absent.
-            #
-            # Population is out-of-band by design: the AdCP sync_creatives request
-            # carries no concept field (concepts are seller/ad-server-assigned, not
-            # buyer-supplied), so concept_id/concept_name are written into data[] by
-            # the ingesting integration (e.g. an adapter mapping the ad server's
-            # native creative groups). Mapping GAM creative groups -> these fields is
-            # a separate, adapter-scoped follow-up; until then the field is populated
-            # only by external producers writing to the blob.
-            #
-            # The blob is untyped and external producers may write numeric ids (CM360
-            # group ids), so coerce to the spec's string type instead of letting a
+            # v3.1 concept grouping. AdCP exposes concept_id/concept_name on the
+            # list_creatives RESPONSE (a creative's concept membership, sourced from
+            # the buyer's creative-management platform — Flashtalking/Celtra/CM360),
+            # but standardizes no concept INPUT on sync_creatives, so the field is
+            # populated out-of-band into the data blob. (A seller-side mapping of GAM
+            # creative groups -> these fields is a separate enrichment/fallback
+            # follow-up, not the authoritative buyer-side concept.) The blob is
+            # untyped and an external producer may write numeric group ids, so coerce
+            # to the spec's string type via _coerce_concept_value rather than letting a
             # non-string value fail Creative validation and crash the whole listing.
             concept_data = db_creative.data or {}
-            concept_id_raw = concept_data.get("concept_id")
-            concept_name_raw = concept_data.get("concept_name")
 
             creative = Creative(
                 creative_id=db_creative.creative_id,
@@ -323,8 +335,8 @@ def _list_creatives_impl(
                 status=status_enum,
                 created_date=created_at_dt,
                 updated_date=updated_at_dt,
-                concept_id=str(concept_id_raw) if concept_id_raw is not None else None,
-                concept_name=str(concept_name_raw) if concept_name_raw is not None else None,
+                concept_id=_coerce_concept_value(concept_data.get("concept_id")),
+                concept_name=_coerce_concept_value(concept_data.get("concept_name")),
                 # Internal field (our extension)
                 principal_id=db_creative.principal_id,
             )

--- a/src/routes/api_v1.py
+++ b/src/routes/api_v1.py
@@ -117,6 +117,10 @@ class ListCreativesBody(BaseModel):  # FIXME(#1442): extend SalesAgentBaseModel 
     media_buy_ids: list[str] | None = None
     status: str | None = None
     format: str | None = None
+    # Structured AdCP CreativeFilters object (statuses, concept_ids, format_ids,
+    # tags, date ranges, …). Coerced to a typed CreativeFilters in the handler so
+    # REST honours the same structured filters as MCP/A2A instead of dropping them.
+    filters: dict[str, Any] | None = None
     adcp_version: str = "1.0.0"
 
 
@@ -332,11 +336,15 @@ async def sync_creatives(body: SyncCreativesBody, identity: ResolvedIdentity = r
 @router.post("/creatives")
 async def list_creatives(body: ListCreativesBody, identity: ResolvedIdentity = require_auth):
     """List creatives (auth required)."""
+    from adcp import CreativeFilters
+
+    filters = CreativeFilters.model_validate(body.filters) if body.filters else None
     response = creatives_listing_module.list_creatives_raw(
         media_buy_id=body.media_buy_id,
         media_buy_ids=body.media_buy_ids,
         status=body.status,
         format=body.format,
+        filters=filters,
         identity=identity,
     )
     return response.model_dump(mode="json")

--- a/src/routes/api_v1.py
+++ b/src/routes/api_v1.py
@@ -23,7 +23,7 @@ from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel
 
 from src.core.auth_context import require_auth, resolve_auth
-from src.core.schema_helpers import to_account_reference
+from src.core.schema_helpers import coerce_creative_filters, to_account_reference
 from src.core.tools import accounts as accounts_module
 from src.core.tools import capabilities as capabilities_module
 from src.core.tools import creative_formats as creative_formats_module
@@ -336,9 +336,7 @@ async def sync_creatives(body: SyncCreativesBody, identity: ResolvedIdentity = r
 @router.post("/creatives")
 async def list_creatives(body: ListCreativesBody, identity: ResolvedIdentity = require_auth):
     """List creatives (auth required)."""
-    from adcp import CreativeFilters
-
-    filters = CreativeFilters.model_validate(body.filters) if body.filters else None
+    filters = coerce_creative_filters(body.filters)
     response = creatives_listing_module.list_creatives_raw(
         media_buy_id=body.media_buy_id,
         media_buy_ids=body.media_buy_ids,

--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -2726,6 +2726,8 @@ def _detect_uc(request: pytest.FixtureRequest) -> str | None:
         return "UC-004"
     if any(t.startswith("T-UC-011") for t in marker_names):
         return "UC-011"
+    if any(t.startswith("T-UC-018") for t in marker_names):
+        return "UC-018"
     if any(t.startswith(_ADMIN_TAG_PREFIX) for t in marker_names):
         return "ADMIN"
     if "inventory_profile" in marker_names:
@@ -2841,6 +2843,26 @@ def _harness_env(request: pytest.FixtureRequest, ctx: dict) -> Generator[None, N
         with CreativeFormatsEnv(e2e_config=ctx.get("e2e_config")) as env:
             ctx["env"] = env
             yield
+
+    elif uc == "UC-018":
+        # list_creatives — only the @list-after-sync storyboard scenario is wired
+        # (#1405). The remaining UC-018 scenarios (main/partition/boundary/filter
+        # siblings) have no step definitions yet, so xfail fast at the fixture
+        # (mirrors UC-002/006/011) rather than spinning up a DB per scenario only
+        # to auto-xfail at the first missing step.
+        marker_names = {m.name for m in request.node.iter_markers()}
+        if "list-after-sync" in marker_names:
+            # CreativeListEnv mocks only the audit logger; DB, repository, and
+            # query building are real. The Background auth step switches the env
+            # principal; the seed step owns the creatives under it.
+            request.getfixturevalue("integration_db")
+            from tests.harness.creative_list import CreativeListEnv
+
+            with CreativeListEnv(e2e_config=ctx.get("e2e_config")) as env:
+                ctx["env"] = env
+                yield
+        else:
+            pytest.xfail("UC-018 harness wired only for the @list-after-sync storyboard scenario (#1405)")
 
     elif uc == "UC-011":
         marker_names = {m.name for m in request.node.iter_markers()}

--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -2845,13 +2845,13 @@ def _harness_env(request: pytest.FixtureRequest, ctx: dict) -> Generator[None, N
             yield
 
     elif uc == "UC-018":
-        # list_creatives — only the @list-after-sync storyboard scenario is wired
-        # (#1405). The remaining UC-018 scenarios (main/partition/boundary/filter
-        # siblings) have no step definitions yet, so xfail fast at the fixture
-        # (mirrors UC-002/006/011) rather than spinning up a DB per scenario only
-        # to auto-xfail at the first missing step.
+        # list_creatives — the wired storyboard scenarios are @list-after-sync
+        # (#1405) and @concept-id (#1407). The remaining UC-018 scenarios
+        # (main/partition/boundary/other filter siblings) have no step definitions
+        # yet, so xfail fast at the fixture (mirrors UC-002/006/011) rather than
+        # spinning up a DB per scenario only to auto-xfail at the first missing step.
         marker_names = {m.name for m in request.node.iter_markers()}
-        if "list-after-sync" in marker_names:
+        if marker_names & {"list-after-sync", "concept-id"}:
             # CreativeListEnv mocks only the audit logger; DB, repository, and
             # query building are real. The Background auth step switches the env
             # principal; the seed step owns the creatives under it.
@@ -2862,7 +2862,9 @@ def _harness_env(request: pytest.FixtureRequest, ctx: dict) -> Generator[None, N
                 ctx["env"] = env
                 yield
         else:
-            pytest.xfail("UC-018 harness wired only for the @list-after-sync storyboard scenario (#1405)")
+            pytest.xfail(
+                "UC-018 harness wired only for the @list-after-sync (#1405) and @concept-id (#1407) storyboard scenarios"
+            )
 
     elif uc == "UC-011":
         marker_names = {m.name for m in request.node.iter_markers()}

--- a/tests/bdd/steps/generic/when_request.py
+++ b/tests/bdd/steps/generic/when_request.py
@@ -36,8 +36,15 @@ def _call(ctx: dict, req: ListCreativeFormatsRequest | None = None) -> None:
             ctx["error"] = exc
 
 
-def _call_via(ctx: dict, transport: str | Transport, req: ListCreativeFormatsRequest | None = None) -> None:
-    """Call env.call_via for transport-specific dispatch."""
+def _call_via(
+    ctx: dict, transport: str | Transport, req: ListCreativeFormatsRequest | None = None, **extra: Any
+) -> None:
+    """Call env.call_via for transport-specific dispatch.
+
+    ``extra`` forwards additional flat tool kwargs (e.g. a structured ``filters``
+    dict for list_creatives) straight through to ``env.call_via``; existing
+    callers pass none and are unaffected.
+    """
     if isinstance(transport, Transport):
         t = transport
     else:
@@ -51,6 +58,7 @@ def _call_via(ctx: dict, transport: str | Transport, req: ListCreativeFormatsReq
             kwargs.update(req.model_dump(exclude_none=True))
         else:
             kwargs["req"] = req
+    kwargs.update(extra)
 
     try:
         result = env.call_via(t, **kwargs)

--- a/tests/bdd/test_uc018_list_creatives.py
+++ b/tests/bdd/test_uc018_list_creatives.py
@@ -1,0 +1,181 @@
+"""BDD scenario + steps for UC-018: list_creatives reflects recent sync state.
+
+Binds the single storyboard scenario
+``T-UC-018-storyboard-list-all-creatives-after-sync`` (#1405): after the buyer
+syncs creatives across formats, ``list_creatives`` with no filters returns the
+account's library — schema-valid against ``list-creatives-response.json``, each
+entry exposing ``creative_id``, ``name``, ``format_id``, ``status``. Source
+obligation: adcp ``protocols/creative/index.yaml`` · ``list_all`` (pin
+v3.1-04f59d2d5).
+
+Wired to real production across all wire transports (auto-parametrized; UC-018
+-> CreativeListEnv via conftest ``_detect_uc`` / ``_harness_env``). The repo
+sunsets the IMPL pseudo-transport in BDD, so the scenario runs on a2a/mcp/rest
+(plus e2e_rest in-network). Each transport returns the same typed response, and
+the Then steps validate its production JSON serialization
+(``model_dump(mode="json", exclude_none=True)`` — the same NestedModelSerializerMixin
+path that produces the on-the-wire bytes); the parametrization still exercises
+each dispatch path end to end (a broken transport surfaces as a missing/errored
+response).
+
+**Why steps live here (not in steps/domain/ + pytest_plugins):** pytest-bdd 8
+resolves step definitions only from the scenario's own module, conftest, or
+registered plugins — importing them does not register them. The generic
+``schema-valid against <file>`` and ``authenticated as principal`` phrasings are
+shared by other, already-wired feature files (UC-004/005/006); registering them
+globally would alter those suites. Defining the steps inline scopes them to this
+one scenario, keeping the blast radius to UC-018. The reusable, non-step schema
+validator lives in ``tests.helpers.pinned_schema``.
+
+The "synced" creatives are seeded via ``CreativeFactory`` rather than a live
+``sync_creatives`` call: ``CreativeListEnv`` mocks only the audit logger (it has
+none of sync's creative-agent / preview-generation patches), and the obligation
+under test is ``list_all`` — the listing contract, not the sync path. The
+creatives land in the same DB row shape sync would persist, so the listing query
+is exercised faithfully.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from tests.bdd.steps._outcome_helpers import _require_response
+from tests.helpers.pinned_schema import validate_against_pinned_schema
+
+# Three genuinely-different formats (display / video / audio) for the "three
+# different formats" precondition. All three are in the standard format registry:
+# the A2A path round-trips format_id through a string and re-validates it against
+# known formats, so an unregistered id would be rejected on that transport.
+_SYNCED_FORMATS = ("display_300x250", "video_640x480", "audio_30s")
+
+# Bind the UC-018 feature. Only the @list-after-sync storyboard scenario is wired
+# here (#1405); the remaining scenarios xfail fast at the conftest _harness_env
+# fixture (no UC-018 harness yet). Whole-feature binding via scenarios() is the
+# repo convention the CI shard-splitter requires (scripts/ci/shard_split.py).
+scenarios("features/BR-UC-018-list-creatives.feature")
+
+
+# ── Given ────────────────────────────────────────────────────────────
+
+
+@given(parsers.parse('the Buyer is authenticated as principal "{principal_id}"'))
+def given_buyer_authenticated_as_principal(ctx: dict, principal_id: str) -> None:
+    """Authenticate the listing buyer as *principal_id* (Background).
+
+    Mutates the harness env identity so list_creatives is principal-scoped to
+    this buyer, and records it so the seed step owns the creatives under the same
+    principal the query authenticates as (list_creatives is principal-scoped — a
+    mismatch would return an empty library).
+    """
+    env = ctx["env"]
+    env._identity_cache.clear()
+    env._principal_id = principal_id
+    ctx["principal_id"] = principal_id
+    # Post-condition: verify the identity mutation took effect.
+    actual = env.identity.principal_id
+    assert actual == principal_id, f"env.identity.principal_id is {actual!r} after setting {principal_id!r}"
+
+
+@given("the buyer recently synced three creatives in three different formats via sync_creatives")
+def given_recently_synced_three_creatives(ctx: dict) -> None:
+    """Seed three approved creatives (one per format) owned by the authenticated buyer.
+
+    Seeded via CreativeFactory rather than a live sync_creatives call — see the
+    module docstring. Records the synced creative_ids for the Then steps.
+    """
+    from tests.factories import CreativeFactory, PrincipalFactory, TenantFactory
+
+    env = ctx["env"]
+    tenant = TenantFactory(tenant_id=env._tenant_id)
+    principal = PrincipalFactory(tenant=tenant, principal_id=env._principal_id)
+    synced_ids: list[str] = []
+    for fmt in _SYNCED_FORMATS:
+        creative = CreativeFactory(
+            tenant=tenant,
+            principal=principal,
+            format=fmt,
+            status="approved",
+            # An empty-but-present assets object: the repository filters out rows
+            # whose data["assets"] IS NULL (legacy guard), so the key must exist;
+            # keeping it empty stays schema-valid (no asset-union coupling — the
+            # storyboard grades the listing contract, not asset shape).
+            data={"assets": {}},
+        )
+        synced_ids.append(creative.creative_id)
+    ctx["tenant"] = tenant
+    ctx["principal"] = principal
+    ctx["synced_creative_ids"] = synced_ids
+
+
+# ── When ─────────────────────────────────────────────────────────────
+
+
+@when("the Buyer Agent sends list_creatives with no filters for the same account")
+def when_list_creatives_no_filters(ctx: dict) -> None:
+    """Dispatch list_creatives with no filters through the scenario's transport.
+
+    Reuses the canonical generic dispatch helper (``env.call_via`` + ctx stash of
+    ``response`` / ``wire_response`` / ``error``) rather than re-implementing it.
+    No filter kwargs are passed, so the listing runs unfiltered; the helper maps a
+    missing transport to IMPL.
+    """
+    from tests.bdd.steps.generic.when_request import _call_via
+
+    _call_via(ctx, ctx.get("transport"))
+
+
+# ── Then ─────────────────────────────────────────────────────────────
+
+
+def _serialized_response(ctx: dict) -> dict[str, Any]:
+    """Serialize the typed response through the production serializer (JSON mode).
+
+    list_creatives returns the same typed payload on every transport, so each
+    transport's Then steps assert on the same serialized document. ``mode="json"``
+    drives ``NestedModelSerializerMixin`` — the same serializer that produces the
+    on-the-wire bytes (format_id -> {agent_url, id}, datetimes -> ISO strings).
+    ``exclude_none`` omits unset optional fields (format_summary, status_summary,
+    sandbox, errors, ext, context), matching the buyer-visible REST wire and the
+    AdCP contract, which type those fields only when present (a literal ``null``
+    is not a valid array/object/boolean).
+
+    The 4-transport parametrization still exercises each dispatch path end to end:
+    a broken transport surfaces as a missing/errored ``ctx["response"]`` here.
+    """
+    return _require_response(ctx).model_dump(mode="json", exclude_none=True)
+
+
+@then(parsers.parse("the response should be schema-valid against {schema_file}"))
+def then_response_schema_valid(ctx: dict, schema_file: str) -> None:
+    """Assert the serialized response validates against the pinned AdCP schema."""
+    validate_against_pinned_schema(schema_file, _serialized_response(ctx))
+
+
+@then("the creatives array should include each of the synced creatives")
+def then_creatives_include_synced(ctx: dict) -> None:
+    """Assert every creative_id seeded by the Given is present in the library."""
+    expected = set(ctx["synced_creative_ids"])
+    returned = {entry["creative_id"] for entry in _serialized_response(ctx)["creatives"]}
+    missing = expected - returned
+    assert not missing, (
+        f"synced creatives missing from the list_creatives library: {sorted(missing)}; "
+        f"returned creative_ids: {sorted(returned)}"
+    )
+
+
+@then("each creative entry should expose creative_id, name, format_id, and status")
+def then_each_creative_exposes_core_fields(ctx: dict) -> None:
+    """Assert every entry carries the four core fields, format_id as a {agent_url, id} object."""
+    creatives = _serialized_response(ctx)["creatives"]
+    assert creatives, "list_creatives returned an empty creatives array"
+    for entry in creatives:
+        for field in ("creative_id", "name", "format_id", "status"):
+            assert field in entry, f"creative entry missing {field!r}: {entry}"
+            assert entry[field] not in (None, "", {}), f"creative entry has empty {field!r}: {entry}"
+        # v3.1 federation contract: format_id is an object carrying agent_url + id.
+        fid = entry["format_id"]
+        assert isinstance(fid, dict) and fid.get("agent_url") and fid.get("id"), (
+            f"format_id must be an object with agent_url and id, got: {fid!r}"
+        )

--- a/tests/bdd/test_uc018_list_creatives.py
+++ b/tests/bdd/test_uc018_list_creatives.py
@@ -292,10 +292,25 @@ def when_list_creatives_concept_ids(ctx: dict, concept_list: str) -> None:
     _call_via(ctx, ctx.get("transport"), filters=filters)
 
 
+def _wire_creatives(ctx: dict) -> list[dict[str, Any]]:
+    """Return the creatives array as the buyer sees it on the wire.
+
+    REST/A2A/MCP stash the real serialized response on ``ctx["wire_response"]``
+    (CreativeListEnv stashes on all three wire transports), so the concept-field
+    assertions check the actual on-the-wire bytes rather than a re-serialization.
+    Falls back to the production serializer only when no wire was captured (e.g. a
+    non-stashing path), so the step still has data to assert on.
+    """
+    wire = ctx.get("wire_response")
+    if wire and "creatives" in wire:
+        return wire["creatives"]
+    return _serialized_response(ctx)["creatives"]
+
+
 @then(parsers.parse('the creatives array should only include creatives belonging to concept "{concept_id}"'))
 def then_only_creatives_in_concept(ctx: dict, concept_id: str) -> None:
     """Assert every returned creative belongs to the requested concept (and the set is non-empty)."""
-    creatives = _serialized_response(ctx)["creatives"]
+    creatives = _wire_creatives(ctx)
     assert creatives, f"list_creatives returned no creatives for concept {concept_id!r}"
     offenders = [
         {"creative_id": entry.get("creative_id"), "concept_id": entry.get("concept_id")}
@@ -314,7 +329,7 @@ def then_only_creatives_in_concept(ctx: dict, concept_id: str) -> None:
 @then(parsers.parse('each returned creative should carry concept_id "{concept_id}" and a concept_name'))
 def then_each_creative_carries_concept(ctx: dict, concept_id: str) -> None:
     """Assert each returned creative exposes concept_id (== requested) and a non-empty concept_name."""
-    creatives = _serialized_response(ctx)["creatives"]
+    creatives = _wire_creatives(ctx)
     assert creatives, "list_creatives returned an empty creatives array"
     for entry in creatives:
         assert entry.get("concept_id") == concept_id, (

--- a/tests/bdd/test_uc018_list_creatives.py
+++ b/tests/bdd/test_uc018_list_creatives.py
@@ -50,6 +50,7 @@ from typing import Any
 from pytest_bdd import given, parsers, scenarios, then, when
 
 from tests.bdd.steps._outcome_helpers import _require_response
+from tests.harness.transport import Transport
 from tests.helpers.pinned_schema import validate_against_pinned_schema
 
 # Three genuinely-different formats (display / video / audio) for the "three
@@ -302,7 +303,14 @@ def _wire_creatives(ctx: dict) -> list[dict[str, Any]]:
     non-stashing path), so the step still has data to assert on.
     """
     wire = ctx.get("wire_response")
-    if wire and "creatives" in wire:
+    transport = ctx.get("transport")
+    # Loud guard (mirrors uc005_format_id_shape): a real-wire transport (a2a/mcp/rest/
+    # e2e_rest) that didn't stash wire_response must trip here, not silently fall back
+    # to a model_dump re-serialization and undercut the "real wire bytes" claim. IMPL
+    # (and the unparametrized None default) legitimately have no wire.
+    if wire is None and transport not in (None, Transport.IMPL):
+        raise AssertionError(f"{transport}: wire_response missing — env does not stash success-path wire")
+    if wire is not None:
         return wire["creatives"]
     return _serialized_response(ctx)["creatives"]
 

--- a/tests/bdd/test_uc018_list_creatives.py
+++ b/tests/bdd/test_uc018_list_creatives.py
@@ -1,12 +1,20 @@
-"""BDD scenario + steps for UC-018: list_creatives reflects recent sync state.
+"""BDD scenarios + steps for UC-018: list_creatives library queries.
 
-Binds the single storyboard scenario
-``T-UC-018-storyboard-list-all-creatives-after-sync`` (#1405): after the buyer
-syncs creatives across formats, ``list_creatives`` with no filters returns the
-account's library — schema-valid against ``list-creatives-response.json``, each
-entry exposing ``creative_id``, ``name``, ``format_id``, ``status``. Source
-obligation: adcp ``protocols/creative/index.yaml`` · ``list_all`` (pin
-v3.1-04f59d2d5).
+Binds the UC-018 feature; two storyboard scenarios are wired (the rest xfail at
+the conftest harness fixture):
+
+- ``T-UC-018-storyboard-list-all-creatives-after-sync`` (#1405): after the buyer
+  syncs creatives across formats, ``list_creatives`` with no filters returns the
+  account's library — schema-valid against ``list-creatives-response.json``, each
+  entry exposing ``creative_id``, ``name``, ``format_id``, ``status``. Source
+  obligation: adcp ``protocols/creative/index.yaml`` · ``list_all``.
+- ``T-UC-018-storyboard-filter-by-concept-id`` (#1407): ``filters.concept_ids``
+  scopes results to a concept; each returned creative exposes ``concept_id`` and
+  ``concept_name``. Source: adcp ``creative/list-creatives-request.json`` +
+  ``core/creative-filters.json`` (concept_ids) and ``list-creatives-response.json``
+  (concept_id/concept_name).
+
+Both pinned at v3.1-04f59d2d5 (adcp 3.1.0-beta.3).
 
 Wired to real production across all wire transports (auto-parametrized; UC-018
 -> CreativeListEnv via conftest ``_detect_uc`` / ``_harness_env``). The repo
@@ -179,3 +187,137 @@ def then_each_creative_exposes_core_fields(ctx: dict) -> None:
         assert isinstance(fid, dict) and fid.get("agent_url") and fid.get("id"), (
             f"format_id must be an object with agent_url and id, got: {fid!r}"
         )
+
+
+# ── @concept-id storyboard scenario (#1407) ─────────────────────────────
+#
+# v3.1 ADDED filters.concept_ids (array of concept-id strings, minItems 1).
+# Concepts group related creatives across sizes and formats; each returned
+# creative exposes concept_id and concept_name. Source obligation: adcp
+# creative/list-creatives-request.json + core/creative-filters.json (concept_ids)
+# and creative/list-creatives-response.json (creatives[].concept_id/concept_name),
+# pin v3.1-04f59d2d5. The concept identifier/name live on the creative's JSON data
+# blob (no native sync_creatives field in adcp 5.7.0 — concepts originate from
+# external creative-management systems), so they are seeded directly.
+
+# Human-readable label paired with the target concept_id, asserted non-empty by
+# the Then step. Two registered formats give the concept creatives genuinely
+# different sizes/formats (the point of a concept); the A2A path re-validates
+# format_id against the registry, so unregistered ids would be rejected there.
+_CONCEPT_NAME = "Summer 2026 Campaign"
+_CONCEPT_FORMATS = ("display_300x250", "video_640x480")
+_DECOY_CONCEPT_ID = "concept_winter_2025"
+
+
+@given(
+    parsers.parse(
+        'the authenticated principal has creatives grouped under concept "{concept_id}" '
+        "and other creatives under different concepts"
+    )
+)
+def given_creatives_grouped_under_concept(ctx: dict, concept_id: str) -> None:
+    """Seed concept-tagged creatives plus decoys so the filter is falsifiable.
+
+    Under the target concept: two approved creatives in two formats (concepts span
+    sizes/formats). Decoys: one under a different concept, one with no concept at
+    all. A broken filter that returned the whole library would surface a decoy
+    whose concept_id != the requested one (or is absent), failing the Then steps.
+
+    Seeded via CreativeFactory rather than a live sync (CreativeListEnv has no sync
+    patches; the obligation under test is the listing/filter contract). The
+    empty-but-present ``assets`` is mandatory — the repository drops rows whose
+    ``data["assets"]`` IS NULL (legacy guard).
+    """
+    from tests.factories import CreativeFactory, PrincipalFactory, TenantFactory
+
+    env = ctx["env"]
+    tenant = TenantFactory(tenant_id=env._tenant_id)
+    principal = PrincipalFactory(tenant=tenant, principal_id=env._principal_id)
+
+    in_concept_ids: list[str] = []
+    for fmt in _CONCEPT_FORMATS:
+        creative = CreativeFactory(
+            tenant=tenant,
+            principal=principal,
+            format=fmt,
+            status="approved",
+            data={"assets": {}, "concept_id": concept_id, "concept_name": _CONCEPT_NAME},
+        )
+        in_concept_ids.append(creative.creative_id)
+
+    # Decoy under a different concept.
+    CreativeFactory(
+        tenant=tenant,
+        principal=principal,
+        format=_CONCEPT_FORMATS[0],
+        status="approved",
+        data={"assets": {}, "concept_id": _DECOY_CONCEPT_ID, "concept_name": "Winter 2025 Campaign"},
+    )
+    # Decoy with no concept at all.
+    CreativeFactory(
+        tenant=tenant,
+        principal=principal,
+        format=_CONCEPT_FORMATS[0],
+        status="approved",
+        data={"assets": {}},
+    )
+
+    ctx["tenant"] = tenant
+    ctx["principal"] = principal
+    ctx["concept_id"] = concept_id
+    ctx["in_concept_creative_ids"] = in_concept_ids
+
+
+@when(parsers.re(r"the Buyer Agent sends list_creatives with filters\.concept_ids \[(?P<concept_list>.+)\]"))
+def when_list_creatives_concept_ids(ctx: dict, concept_list: str) -> None:
+    """Dispatch list_creatives with a structured filters.concept_ids filter.
+
+    Parses the bracketed concept-id list from the step text and dispatches the
+    structured filter through the scenario's transport via the canonical helper.
+    The filter travels as a JSON dict (built through CreativeFilters so minItems/
+    field validation runs); each wire transport coerces it back to CreativeFilters
+    server-side (FastMCP TypeAdapter / A2A skill / REST body), so a dict is the one
+    shape that works uniformly across a2a/mcp/rest (IMPL is sunsetted in BDD).
+    """
+    import re
+
+    from adcp import CreativeFilters
+
+    from tests.bdd.steps.generic.when_request import _call_via
+
+    concept_ids = re.findall(r'"([^"]+)"', concept_list)
+    assert concept_ids, f"no concept ids parsed from {concept_list!r}"
+    ctx["requested_concept_ids"] = concept_ids
+    filters = CreativeFilters(concept_ids=concept_ids).model_dump(mode="json", exclude_none=True)
+    _call_via(ctx, ctx.get("transport"), filters=filters)
+
+
+@then(parsers.parse('the creatives array should only include creatives belonging to concept "{concept_id}"'))
+def then_only_creatives_in_concept(ctx: dict, concept_id: str) -> None:
+    """Assert every returned creative belongs to the requested concept (and the set is non-empty)."""
+    creatives = _serialized_response(ctx)["creatives"]
+    assert creatives, f"list_creatives returned no creatives for concept {concept_id!r}"
+    offenders = [
+        {"creative_id": entry.get("creative_id"), "concept_id": entry.get("concept_id")}
+        for entry in creatives
+        if entry.get("concept_id") != concept_id
+    ]
+    assert not offenders, f"concept_ids filter leaked creatives outside concept {concept_id!r}: {offenders}"
+    # Falsifiability anchor: the seeded in-concept creatives are exactly what comes back.
+    returned_ids = {entry["creative_id"] for entry in creatives}
+    assert returned_ids == set(ctx["in_concept_creative_ids"]), (
+        f"expected exactly the in-concept creatives {sorted(ctx['in_concept_creative_ids'])}, "
+        f"got {sorted(returned_ids)}"
+    )
+
+
+@then(parsers.parse('each returned creative should carry concept_id "{concept_id}" and a concept_name'))
+def then_each_creative_carries_concept(ctx: dict, concept_id: str) -> None:
+    """Assert each returned creative exposes concept_id (== requested) and a non-empty concept_name."""
+    creatives = _serialized_response(ctx)["creatives"]
+    assert creatives, "list_creatives returned an empty creatives array"
+    for entry in creatives:
+        assert entry.get("concept_id") == concept_id, (
+            f"creative {entry.get('creative_id')!r} concept_id mismatch: {entry}"
+        )
+        assert entry.get("concept_name"), f"creative {entry.get('creative_id')!r} missing concept_name: {entry}"

--- a/tests/harness/creative_list.py
+++ b/tests/harness/creative_list.py
@@ -75,6 +75,13 @@ class CreativeListEnv(IntegrationEnv):
         for key in ("media_buy_id", "media_buy_ids", "buyer_ref", "status", "format"):
             if key in kwargs and kwargs[key] is not None:
                 body[key] = kwargs[key]
+        # The structured CreativeFilters object travels over REST as a JSON dict
+        # (the body field is typed dict and coerced to CreativeFilters server-side).
+        filters = kwargs.get("filters")
+        if filters is not None:
+            body["filters"] = (
+                filters.model_dump(mode="json", exclude_none=True) if hasattr(filters, "model_dump") else filters
+            )
         return body
 
     def parse_rest_response(self, data: dict[str, Any]) -> ListCreativesResponse:

--- a/tests/harness/creative_list.py
+++ b/tests/harness/creative_list.py
@@ -75,13 +75,12 @@ class CreativeListEnv(IntegrationEnv):
         for key in ("media_buy_id", "media_buy_ids", "buyer_ref", "status", "format"):
             if key in kwargs and kwargs[key] is not None:
                 body[key] = kwargs[key]
-        # The structured CreativeFilters object travels over REST as a JSON dict
-        # (the body field is typed dict and coerced to CreativeFilters server-side).
+        # The structured filters travel over REST as a JSON dict — the body field is
+        # typed dict and coerced to CreativeFilters server-side. Callers pass an
+        # already-serialized dict (see the UC-018 concept_ids When step).
         filters = kwargs.get("filters")
         if filters is not None:
-            body["filters"] = (
-                filters.model_dump(mode="json", exclude_none=True) if hasattr(filters, "model_dump") else filters
-            )
+            body["filters"] = filters
         return body
 
     def parse_rest_response(self, data: dict[str, Any]) -> ListCreativesResponse:

--- a/tests/helpers/pinned_schema.py
+++ b/tests/helpers/pinned_schema.py
@@ -1,0 +1,76 @@
+"""Validate data against vendored ("pinned") AdCP JSON schemas, fully offline.
+
+Single source of truth for schema-shape assertions in tests (e.g. the BDD step
+"the response should be schema-valid against <file>"). Reads the committed
+fixtures under ``tests/fixtures/adcp_schemas_pinned/``, pinned at
+adcontextprotocol/adcp@04f59d2d5 (tag ``v3.1-04f59d2d5``). It never fetches the
+network — ``/schemas/latest`` drifts and would make tests non-deterministic.
+
+``$ref`` resolution (e.g. ``/schemas/core/format-id.json``) is wired through a
+``referencing.Registry`` retrieve callback that loads each referenced schema from
+the same pinned tree, so nested refs validate against the frozen closure. A
+missing schema (the pin moved, or a ``$ref`` is outside the vendored closure) is
+a HARD FAILURE, never a silent skip — mirroring ``load_json_schema`` in
+``tests/unit/test_pydantic_schema_alignment.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import referencing
+from jsonschema.validators import Draft7Validator
+from referencing.jsonschema import DRAFT7
+
+_PINNED_SCHEMA_DIR = Path(__file__).resolve().parent.parent / "fixtures" / "adcp_schemas_pinned"
+
+
+def _load_by_ref(schema_ref: str) -> dict[str, Any]:
+    """Load a pinned schema by its ``$id``/``$ref`` namespace path (``/schemas/...``)."""
+    rel = schema_ref.split("#", 1)[0]
+    if not rel.startswith("/schemas/"):
+        raise AssertionError(f"Unexpected schema ref (expected '/schemas/...'): {schema_ref!r}")
+    path = _PINNED_SCHEMA_DIR / rel[len("/schemas/") :]
+    if not path.exists():
+        raise AssertionError(
+            f"Pinned schema not vendored: {schema_ref} -> {path}. "
+            "Re-run tests/fixtures/adcp_schemas_pinned/_refresh.py to vendor it."
+        )
+    return json.loads(path.read_text())
+
+
+def _resolve_filename(filename: str) -> Path:
+    """Resolve a bare schema filename (e.g. ``list-creatives-response.json``) to its pinned path."""
+    matches = sorted(_PINNED_SCHEMA_DIR.rglob(filename))
+    if not matches:
+        raise AssertionError(
+            f"Pinned schema {filename!r} not found under {_PINNED_SCHEMA_DIR}. "
+            "Re-run tests/fixtures/adcp_schemas_pinned/_refresh.py to vendor it."
+        )
+    return matches[0]
+
+
+def _retrieve(uri: str) -> referencing.Resource:
+    """referencing retrieve callback: resolve a ``/schemas/...`` ref from the pinned tree."""
+    return DRAFT7.create_resource(_load_by_ref(uri))
+
+
+def validate_against_pinned_schema(filename: str, data: Any) -> None:
+    """Assert *data* is schema-valid against the pinned AdCP schema *filename*.
+
+    Raises ``AssertionError`` listing every JSON-path violation on failure.
+    """
+    schema = json.loads(_resolve_filename(filename).read_text())
+    registry: referencing.Registry = referencing.Registry(retrieve=_retrieve)
+    root_id = schema.get("$id")
+    if root_id:
+        registry = registry.with_resource(root_id, DRAFT7.create_resource(schema))
+    validator = Draft7Validator(schema, registry=registry)
+    errors = sorted(validator.iter_errors(data), key=lambda e: list(e.absolute_path))
+    if errors:
+        details = "\n".join(
+            f"  at {'.'.join(str(p) for p in e.absolute_path) or '<root>'}: {e.message}" for e in errors
+        )
+        raise AssertionError(f"Response is not schema-valid against {filename}:\n{details}")

--- a/tests/integration/test_list_creatives_concept_filter.py
+++ b/tests/integration/test_list_creatives_concept_filter.py
@@ -20,8 +20,8 @@ TypeAdapter rejects ``concept_ids=[]`` *before* the tool body runs — a raw inp
 ValidationError, not an ``AdCPError`` the MCP boundary could wrap into the envelope.
 Translating FastMCP TypeAdapter input errors into the two-layer envelope is a
 pre-existing, tool-agnostic MCP-boundary concern (it affects every typed param,
-not just concept_ids) and is tracked separately. Layer 1 still pins that MCP
-rejects the malformed filter.
+not just concept_ids) and is tracked separately in #1507. Layer 1 still pins that
+MCP rejects the malformed filter.
 
 Spec: ``core/creative-filters.json`` (concept_ids ``minItems: 1``) + the BR-UC-018
 ext-c contract (validation failure → VALIDATION_ERROR + suggestion).

--- a/tests/integration/test_list_creatives_concept_filter.py
+++ b/tests/integration/test_list_creatives_concept_filter.py
@@ -1,0 +1,86 @@
+"""Integration tests for the list_creatives concept_ids filter error path (#1407).
+
+The happy path (filtering + concept_id/concept_name exposure) is covered by the
+``@concept-id`` BDD storyboard scenario across a2a/mcp/rest. This module pins the
+*error* path Chris flagged in review: a malformed ``filters.concept_ids`` (empty
+array) violates the schema's ``minItems: 1`` and must be rejected — never silently
+returning the whole library.
+
+Two layers of guarantee:
+
+1. **Rejected on every wire transport** (a2a/mcp/rest) — the malformed filter never
+   degrades to "return everything".
+2. **Spec two-layer ``VALIDATION_ERROR`` envelope with a recovery suggestion**
+   (POST-F3) on REST and A2A, which coerce the wire dict through the shared
+   ``coerce_creative_filters`` helper.
+
+MCP is intentionally excluded from layer 2: it types the tool param as
+``CreativeFilters`` (required by the wrapper-typed-params guard), so FastMCP's
+TypeAdapter rejects ``concept_ids=[]`` *before* the tool body runs — a raw input
+ValidationError, not an ``AdCPError`` the MCP boundary could wrap into the envelope.
+Translating FastMCP TypeAdapter input errors into the two-layer envelope is a
+pre-existing, tool-agnostic MCP-boundary concern (it affects every typed param,
+not just concept_ids) and is tracked separately. Layer 1 still pins that MCP
+rejects the malformed filter.
+
+Spec: ``core/creative-filters.json`` (concept_ids ``minItems: 1``) + the BR-UC-018
+ext-c contract (validation failure → VALIDATION_ERROR + suggestion).
+"""
+
+import pytest
+
+from tests.harness import CreativeListEnv
+from tests.harness.transport import Transport
+from tests.helpers import assert_envelope_shape
+
+pytestmark = [pytest.mark.integration, pytest.mark.requires_db]
+
+# Wire transports only — IMPL has no wire envelope (and the dict→CreativeFilters
+# coercion under test happens at the transport boundary, not in _impl).
+_ALL_WIRE = [Transport.A2A, Transport.MCP, Transport.REST]
+# Transports whose dict→CreativeFilters coercion runs through coerce_creative_filters
+# (and therefore emit the spec envelope + suggestion). See module docstring re: MCP.
+_HELPER_WIRE = [Transport.A2A, Transport.REST]
+
+
+def _seed_authenticated_principal(env: CreativeListEnv) -> None:
+    """Seed the tenant+principal the env authenticates as, so the request reaches
+    filter validation rather than failing auth first."""
+    from tests.factories import PrincipalFactory, TenantFactory
+
+    tenant = TenantFactory(tenant_id=env._tenant_id)
+    PrincipalFactory(tenant=tenant, principal_id=env._principal_id)
+
+
+class TestConceptIdsFilterValidation:
+    """Malformed concept_ids filter is rejected, with a spec envelope on REST/A2A."""
+
+    @pytest.mark.parametrize("transport", _ALL_WIRE)
+    def test_empty_concept_ids_array_is_rejected(self, integration_db, transport):
+        """filters={'concept_ids': []} violates minItems:1 → rejected on every transport."""
+        with CreativeListEnv() as env:
+            _seed_authenticated_principal(env)
+
+            result = env.call_via(transport, filters={"concept_ids": []})
+
+            assert result.is_error, (
+                f"{transport}: empty concept_ids must be rejected, not silently return the library; "
+                f"got payload {result.payload!r}"
+            )
+
+    @pytest.mark.parametrize("transport", _HELPER_WIRE)
+    def test_empty_concept_ids_emits_validation_envelope(self, integration_db, transport):
+        """REST/A2A surface the two-layer VALIDATION_ERROR envelope with a suggestion."""
+        with CreativeListEnv() as env:
+            _seed_authenticated_principal(env)
+
+            result = env.call_via(transport, filters={"concept_ids": []})
+
+            envelope = result.wire_error_envelope
+            assert envelope is not None, f"{transport}: no wire error envelope captured"
+            assert_envelope_shape(envelope, "VALIDATION_ERROR", recovery="correctable")
+            # POST-F3: the buyer is told how to recover.
+            body = envelope.envelope if hasattr(envelope, "envelope") else envelope
+            assert body["errors"][0].get("suggestion"), (
+                f"{transport}: VALIDATION_ERROR envelope must carry a recovery suggestion: {body['errors'][0]}"
+            )

--- a/tests/integration/test_list_creatives_concept_filter.py
+++ b/tests/integration/test_list_creatives_concept_filter.py
@@ -43,13 +43,14 @@ _ALL_WIRE = [Transport.A2A, Transport.MCP, Transport.REST]
 _HELPER_WIRE = [Transport.A2A, Transport.REST]
 
 
-def _seed_authenticated_principal(env: CreativeListEnv) -> None:
-    """Seed the tenant+principal the env authenticates as, so the request reaches
-    filter validation rather than failing auth first."""
+def _seed_authenticated_principal(env: CreativeListEnv):
+    """Seed (and return) the tenant+principal the env authenticates as, so the
+    request reaches filter validation / listing rather than failing auth first."""
     from tests.factories import PrincipalFactory, TenantFactory
 
     tenant = TenantFactory(tenant_id=env._tenant_id)
-    PrincipalFactory(tenant=tenant, principal_id=env._principal_id)
+    principal = PrincipalFactory(tenant=tenant, principal_id=env._principal_id)
+    return tenant, principal
 
 
 class TestConceptIdsFilterValidation:
@@ -79,8 +80,32 @@ class TestConceptIdsFilterValidation:
             envelope = result.wire_error_envelope
             assert envelope is not None, f"{transport}: no wire error envelope captured"
             assert_envelope_shape(envelope, "VALIDATION_ERROR", recovery="correctable")
-            # POST-F3: the buyer is told how to recover.
-            body = envelope.envelope if hasattr(envelope, "envelope") else envelope
-            assert body["errors"][0].get("suggestion"), (
-                f"{transport}: VALIDATION_ERROR envelope must carry a recovery suggestion: {body['errors'][0]}"
+            # POST-F3: the buyer is told how to recover. wire_error_envelope is always
+            # a dict here (the AdCPToolError accessor lives in assert_envelope_shape).
+            assert envelope["errors"][0].get("suggestion"), (
+                f"{transport}: VALIDATION_ERROR envelope must carry a recovery suggestion: {envelope['errors'][0]}"
             )
+
+
+class TestNumericConceptCoercion:
+    """A numeric concept_id/concept_name in the data blob (CM360-style group ids) is
+    coerced to the spec's string type, not crashed on. Regression guard for the #1
+    fix: reverting the str()-coercion reddens this (the listing raises mid-build)."""
+
+    def test_numeric_concept_id_is_coerced_to_string(self, integration_db):
+        from tests.factories import CreativeFactory
+
+        with CreativeListEnv() as env:
+            tenant, principal = _seed_authenticated_principal(env)
+            CreativeFactory(
+                tenant=tenant,
+                principal=principal,
+                format="display_300x250",
+                status="approved",
+                data={"assets": {}, "concept_id": 12345, "concept_name": 678},
+            )
+            result = env.call_via(Transport.REST)
+            assert not result.is_error, f"listing errored on a numeric concept_id: {result.error!r}"
+            creative = result.wire_response["creatives"][0]
+            assert creative["concept_id"] == "12345"
+            assert creative["concept_name"] == "678"

--- a/tests/integration/test_list_creatives_concept_filter.py
+++ b/tests/integration/test_list_creatives_concept_filter.py
@@ -109,3 +109,35 @@ class TestNumericConceptCoercion:
             creative = result.wire_response["creatives"][0]
             assert creative["concept_id"] == "12345"
             assert creative["concept_name"] == "678"
+
+
+class TestNonScalarConceptValueDropped:
+    """A non-scalar concept_id/concept_name (corrupt external value) is dropped to
+    null and logged, not projected as a repr and not crashed on — regression guard
+    for the _coerce_concept_value non-scalar branch (the symmetric half of the
+    numeric-coercion fix: reverting `return None` to a passthrough 500s the listing)."""
+
+    def test_non_scalar_concept_value_is_dropped(self, integration_db, caplog):
+        import logging
+
+        from tests.factories import CreativeFactory
+
+        with CreativeListEnv() as env:
+            tenant, principal = _seed_authenticated_principal(env)
+            CreativeFactory(
+                tenant=tenant,
+                principal=principal,
+                format="display_300x250",
+                status="approved",
+                data={"assets": {}, "concept_id": ["x"], "concept_name": {"k": "v"}},
+            )
+            with caplog.at_level(logging.WARNING):
+                result = env.call_via(Transport.REST)
+
+            assert not result.is_error, f"non-scalar concept value crashed the listing: {result.error!r}"
+            creative = result.wire_response["creatives"][0]
+            # Dropped to None → exclude_none omits the keys from the wire entirely.
+            assert "concept_id" not in creative
+            assert "concept_name" not in creative
+            # Observability (No Quiet Failures): the drop is surfaced in logs, not silent.
+            assert "Dropping non-scalar concept value" in caplog.text


### PR DESCRIPTION
## feat: `list_creatives` filter by `concept_ids` (v3.1)

closes #1407 

Implements AdCP 3.1 `filters.concept_ids` on `list_creatives`: scoping the library to a creative concept and exposing `concept_id` / `concept_name` on each returned creative. Concepts group related creatives across sizes and formats (Flashtalking concepts, Celtra campaign folders, CM360 creative groups).

> **Stacked on #1405 (PR #1474).** This branch cherry-picks #1405's UC-018 BDD scaffolding (`test_uc018_list_creatives.py`, conftest `_detect_uc`/`_harness_env` UC-018 routing, `tests/helpers/pinned_so has a harness to bindto. **Merge #1474 first**, then rebase this — the #1405 commit drops out and
the diff reduces to the, retarget the PR baseto the #1474 branch for a clean review diff.)

### Spec grounding

Authoritative version: **AdCP 3.1.0-beta.3**, pinned via `adcp==5.7.0` (ref`v3.1-04f59d2d5`).
| Contract | Source |
|---|---|
| `filters.concept_ids` (array of strings, `minItems: 1`) | `core/creative-filters.json`, `creative/list-creatives-request.json` |
| `creatives[].concept_id`, `creatives[].concept_name` | `creative/list-creatives-response.json` |
| `filters_applied: ["concept_ids=…"]` | response example in `list-creatives-response.json` |

 The adcp 5.7.0 library already defines all three types —                   `CreativeFilters.concep`Creative.concept_id`/`concept_name`. **No schema change was needed**; the work was wiring them tong: the scenario bindsits `@source` to the request schema (the compliance YAML is not vendored), so this dimension is scifecycle /list_filtered` + the scenario's own concept-membership assertions.         
### What changed                                                           
**Production**                                                             
- **`repositories/creative.py`** — `get_by_principal(…, concept_ids=…)`    filters on the JSONB `d_string()` idiom as`account.py`).                                                             - **`tools/creatives/li_impl`) — threads`concept_ids` from the structured filters into the DB query (previously it fed only `filters_applid** before reaching thequery), populates `concept_id`/`concept_name` on each response creative frothe data blob, and repors_applied`.
- **`routes/api_v1.py`** — `ListCreativesBody` gained a `filters` object anthe handler coerces it eviously carried **nostructured filters at all**; this unblocks the whole `CreativeFilters`     surface over REST, not sses `FIXME(#1442)`).
- **`a2a_server/adcp_a2a_server.py`** — the `list_creatives` skill handler was **dropping `filtersded withdict→`CreativeFilters` coercion.                                           
**Tests**                                                                  
- **`test_uc018_list_creatives.py`** — wires the `@concept-id` storyboard  scenario (`BR-UC-018-lieeds creatives under the target concept plus **falsifiable decoys** (a different concept + a        no-concept creative); trned set is *exactly*the in-concept creatives and that each carries the requested `concept_id` +a non-empty `concept_naface a decoy and fail.
- **`tests/bdd/conftest.py`** — widened the UC-018 harness gate to also wir`@concept-id`.
- **`tests/bdd/steps/generic/when_request.py`** — extended the shared      `_call_via` helper to f. `filters`); existingcallers are unaffected.                                                    - **`tests/harness/crea_body` now carries`filters`.                                                                 
### Storage note                                                           
In adcp 5.7.0 the `sync_creatives` input carries no concept field (conceptsoriginate from external, so`concept_id`/`concept_name` live on the creative's JSON `data` blob and areseeded directly in the ng approach and the same DB row shape sync persists.                                                
### Testing                                                                
- `make quality` — **5138 passed**, 0 failures (incl. structural guards:   boundary completeness, tory pattern).
- `@concept-id` scenario passes on **a2a / mcp / rest** (IMPL is sunsetted in BDD per #1405).
- #1405 after-sync scenario (6 passed) and UC-005 `_call_via` consumers (47passed) verified green
                                                                           ### Out of scope / foll
                                                                           - The structured `filtetuses` are still onlyreported in `filters_applied` and not threaded to the query (same class of gap as concept was) — w `@format-id-object`sibling scenario (`:773`) depends on it.
- `ListCreativesBody` sME(#1442)` (extend`SalesAgentBaseModel`).