### PR TITLE
test(ci): add known-bad mutation self-tests for YAML anchor detector (#1497)

### DIFF
--- a/tests/unit/_architecture_helpers.py
+++ b/tests/unit/_architecture_helpers.py
@@ -480,21 +480,6 @@ def iter_setup_uv_action_pins(repo: Path) -> Iterator[tuple[Path, str]]:
             yield path, m.group(0)
 
 
-def _match_hardcoded_yaml_anchor_lines(
-    lines: Iterable[str],
-    line_regex: re.Pattern[str],
-    *,
-    skip_substr: str | None = None,
-) -> Iterator[tuple[int, str]]:
-    """Yield ``(lineno, stripped_line)`` for hardcoded YAML anchor violations in *lines*."""
-    for lineno, line in enumerate(lines, 1):
-        stripped = line.strip()
-        if skip_substr and skip_substr in stripped:
-            continue
-        if line_regex.search(stripped):
-            yield lineno, stripped
-
-
 def _iter_hardcoded_yaml_anchor(
     repo: Path,
     line_regex: re.Pattern[str],
@@ -509,8 +494,12 @@ def _iter_hardcoded_yaml_anchor(
             lines = path.read_text(encoding="utf-8").splitlines()
         except (OSError, UnicodeDecodeError):
             continue
-        for lineno, stripped in _match_hardcoded_yaml_anchor_lines(lines, line_regex, skip_substr=skip_substr):
-            yield path, lineno, stripped
+        for lineno, line in enumerate(lines, 1):
+            stripped = line.strip()
+            if skip_substr and skip_substr in stripped:
+                continue
+            if line_regex.search(stripped):
+                yield path, lineno, stripped
 
 
 def iter_hardcoded_uv_version_env(repo: Path) -> Iterator[tuple[Path, int, str]]:

--- a/tests/unit/_architecture_helpers.py
+++ b/tests/unit/_architecture_helpers.py
@@ -480,6 +480,21 @@ def iter_setup_uv_action_pins(repo: Path) -> Iterator[tuple[Path, str]]:
             yield path, m.group(0)
 
 
+def _match_hardcoded_yaml_anchor_lines(
+    lines: Iterable[str],
+    line_regex: re.Pattern[str],
+    *,
+    skip_substr: str | None = None,
+) -> Iterator[tuple[int, str]]:
+    """Yield ``(lineno, stripped_line)`` for hardcoded YAML anchor violations in *lines*."""
+    for lineno, line in enumerate(lines, 1):
+        stripped = line.strip()
+        if skip_substr and skip_substr in stripped:
+            continue
+        if line_regex.search(stripped):
+            yield lineno, stripped
+
+
 def _iter_hardcoded_yaml_anchor(
     repo: Path,
     line_regex: re.Pattern[str],
@@ -494,12 +509,8 @@ def _iter_hardcoded_yaml_anchor(
             lines = path.read_text(encoding="utf-8").splitlines()
         except (OSError, UnicodeDecodeError):
             continue
-        for lineno, line in enumerate(lines, 1):
-            stripped = line.strip()
-            if skip_substr and skip_substr in stripped:
-                continue
-            if line_regex.search(stripped):
-                yield path, lineno, stripped
+        for lineno, stripped in _match_hardcoded_yaml_anchor_lines(lines, line_regex, skip_substr=skip_substr):
+            yield path, lineno, stripped
 
 
 def iter_hardcoded_uv_version_env(repo: Path) -> Iterator[tuple[Path, int, str]]:

--- a/tests/unit/test_architecture_uv_version_anchor.py
+++ b/tests/unit/test_architecture_uv_version_anchor.py
@@ -70,7 +70,10 @@ jobs:
           python-version-file: .python-version
 """
 
-_BAD_UV_VERSION_WORKFLOW = 'env:\n  UV_VERSION: "0.6.0"\n'
+_BAD_UV_VERSION_WORKFLOW = """\
+env:
+  UV_VERSION: "0.6.0"
+"""
 
 
 def _github_yaml_repo(tmp_path: Path, rel: str, content: str) -> Path:

--- a/tests/unit/test_architecture_uv_version_anchor.py
+++ b/tests/unit/test_architecture_uv_version_anchor.py
@@ -6,14 +6,12 @@ and the setup-env composite action.
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import pytest
 
 from tests.unit._architecture_helpers import (
-    _HARDCODED_PYTHON_VERSION_RE,
-    _HARDCODED_UV_VERSION_ENV_RE,
-    _match_hardcoded_yaml_anchor_lines,
     anchor_consistency_detects_drift,
     assert_adr008_target_version_pinned,
     assert_anchor_consistency,
@@ -54,20 +52,35 @@ _KNOWN_BAD_SETUP_UV_PINS = [
     (Path(".github/workflows/ci.yml"), "astral-sh/setup-uv@2222222222222222222222222222222222222222"),
 ]
 
-# Built via concatenation so git-tracked test sources do not embed live scanner literals.
-_KNOWN_BAD_PYTHON_VERSION_YAML_LINES = [
-    "jobs:",
-    "  test:",
-    "    steps:",
-    "      - uses: actions/setup-python@v5",
-    "        with:",
-    "          python-" + "version: '3.12'",
-]
+_BAD_PYTHON_VERSION_WORKFLOW = """\
+jobs:
+  test:
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+"""
 
-_KNOWN_BAD_UV_VERSION_ENV_YAML_LINES = [
-    "env:",
-    "  UV_" + 'VERSION: "0.6.0"',
-]
+_GOOD_PYTHON_VERSION_WORKFLOW = """\
+jobs:
+  test:
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+"""
+
+_BAD_UV_VERSION_WORKFLOW = 'env:\n  UV_VERSION: "0.6.0"\n'
+
+
+def _github_yaml_repo(tmp_path: Path, rel: str, content: str) -> Path:
+    """Throwaway git repo with one tracked workflow file (detector scans via ``git ls-files``)."""
+    target = tmp_path / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    return tmp_path
 
 
 def _read(path_suffix: str) -> str:
@@ -223,28 +236,24 @@ def test_target_version_anchor_must_stay_py311() -> None:
 
 
 @pytest.mark.arch_guard
-def test_hardcoded_python_version_yaml_detector_catches_known_bad() -> None:
-    """Mutation self-test: hardcoded python-version YAML must be detected (#1497)."""
-    matches = list(
-        _match_hardcoded_yaml_anchor_lines(
-            _KNOWN_BAD_PYTHON_VERSION_YAML_LINES,
-            _HARDCODED_PYTHON_VERSION_RE,
-            skip_substr="python-version-file",
-        )
-    )
-    assert matches, "Detector must flag known-bad hardcoded python-version YAML"
+def test_hardcoded_python_version_yaml_detector_catches_known_bad(tmp_path: Path) -> None:
+    """Full-chain self-test: a hardcoded python-version workflow must be flagged (#1497)."""
+    repo = _github_yaml_repo(tmp_path, ".github/workflows/ci.yml", _BAD_PYTHON_VERSION_WORKFLOW)
+    assert list(iter_hardcoded_python_version_yaml(repo)), "detector must flag hardcoded python-version"
 
 
 @pytest.mark.arch_guard
-def test_hardcoded_uv_version_env_detector_catches_known_bad() -> None:
-    """Mutation self-test: hardcoded UV_VERSION env YAML must be detected (#1497)."""
-    matches = list(
-        _match_hardcoded_yaml_anchor_lines(
-            _KNOWN_BAD_UV_VERSION_ENV_YAML_LINES,
-            _HARDCODED_UV_VERSION_ENV_RE,
-        )
-    )
-    assert matches, "Detector must flag known-bad hardcoded UV_VERSION env YAML"
+def test_hardcoded_python_version_yaml_detector_skips_version_file(tmp_path: Path) -> None:
+    """python-version-file must NOT be flagged — exercises skip path and guards over-broad matching."""
+    repo = _github_yaml_repo(tmp_path, ".github/workflows/ci.yml", _GOOD_PYTHON_VERSION_WORKFLOW)
+    assert list(iter_hardcoded_python_version_yaml(repo)) == []
+
+
+@pytest.mark.arch_guard
+def test_hardcoded_uv_version_env_detector_catches_known_bad(tmp_path: Path) -> None:
+    """Full-chain self-test: a hardcoded UV_VERSION env block must be flagged (#1497)."""
+    repo = _github_yaml_repo(tmp_path, ".github/workflows/ci.yml", _BAD_UV_VERSION_WORKFLOW)
+    assert list(iter_hardcoded_uv_version_env(repo)), "detector must flag hardcoded UV_VERSION env"
 
 
 @pytest.mark.arch_guard

--- a/tests/unit/test_architecture_uv_version_anchor.py
+++ b/tests/unit/test_architecture_uv_version_anchor.py
@@ -11,6 +11,9 @@ from pathlib import Path
 import pytest
 
 from tests.unit._architecture_helpers import (
+    _HARDCODED_PYTHON_VERSION_RE,
+    _HARDCODED_UV_VERSION_ENV_RE,
+    _match_hardcoded_yaml_anchor_lines,
     anchor_consistency_detects_drift,
     assert_adr008_target_version_pinned,
     assert_anchor_consistency,
@@ -49,6 +52,21 @@ _KNOWN_BAD_TARGET_VERSION_SOURCES = [
 _KNOWN_BAD_SETUP_UV_PINS = [
     (Path(".github/actions/_install-uv/action.yml"), "astral-sh/setup-uv@1111111111111111111111111111111111111111"),
     (Path(".github/workflows/ci.yml"), "astral-sh/setup-uv@2222222222222222222222222222222222222222"),
+]
+
+# Built via concatenation so git-tracked test sources do not embed live scanner literals.
+_KNOWN_BAD_PYTHON_VERSION_YAML_LINES = [
+    "jobs:",
+    "  test:",
+    "    steps:",
+    "      - uses: actions/setup-python@v5",
+    "        with:",
+    "          python-" + "version: '3.12'",
+]
+
+_KNOWN_BAD_UV_VERSION_ENV_YAML_LINES = [
+    "env:",
+    "  UV_" + 'VERSION: "0.6.0"',
 ]
 
 
@@ -202,6 +220,31 @@ def test_target_version_anchor_must_stay_py311() -> None:
     assert bad_anchors, "known-bad fixture must yield a target-version anchor"
     with pytest.raises(AssertionError, match="ADR-008 target-version must stay py311"):
         assert_adr008_target_version_pinned(bad_anchors, repo)
+
+
+@pytest.mark.arch_guard
+def test_hardcoded_python_version_yaml_detector_catches_known_bad() -> None:
+    """Mutation self-test: hardcoded python-version YAML must be detected (#1497)."""
+    matches = list(
+        _match_hardcoded_yaml_anchor_lines(
+            _KNOWN_BAD_PYTHON_VERSION_YAML_LINES,
+            _HARDCODED_PYTHON_VERSION_RE,
+            skip_substr="python-version-file",
+        )
+    )
+    assert matches, "Detector must flag known-bad hardcoded python-version YAML"
+
+
+@pytest.mark.arch_guard
+def test_hardcoded_uv_version_env_detector_catches_known_bad() -> None:
+    """Mutation self-test: hardcoded UV_VERSION env YAML must be detected (#1497)."""
+    matches = list(
+        _match_hardcoded_yaml_anchor_lines(
+            _KNOWN_BAD_UV_VERSION_ENV_YAML_LINES,
+            _HARDCODED_UV_VERSION_ENV_RE,
+        )
+    )
+    assert matches, "Detector must flag known-bad hardcoded UV_VERSION env YAML"
 
 
 @pytest.mark.arch_guard


### PR DESCRIPTION
## Summary
- Extract `_match_hardcoded_yaml_anchor_lines` shared by `iter_hardcoded_yaml_anchor`
- Add mutation self-tests for hardcoded `python-version:` and `UV_VERSION:` YAML (closes #1497)

Follow-up from #1490 review (ChrisHuie): the YAML anchor detector previously had no known-bad self-test — mutating it to yield nothing kept the suite green.

Parent: #1468

## Test plan
- [x] `uv run pytest tests/unit/test_architecture_uv_version_anchor.py -q`
- [x] CI green

Closes #1497