### PR TITLE
fix(docker): patch base-image and supercronic CVEs blocking the release Trivy gate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Multi-stage build for smaller image
 # Cache bust: 2026-02-27
 ARG PYTHON_VERSION=3.12
-ARG PYTHON_BASE_DIGEST=sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203
+ARG PYTHON_BASE_DIGEST=sha256:423ed6ab25b1921a477529254bfeeabf5855151dc2c3141699a1bfc852199fbf
 # Consumed by BuildKit for reproducible layer timestamps (PR 6 release pipeline).
 ARG SOURCE_DATE_EPOCH=0
 # Canonical uv version: .uv-version (CI reads the file; guard keeps this ARG in sync).
@@ -11,6 +11,15 @@ ARG UV_VERSION=0.11.15
 ARG UV_IMAGE_DIGEST=sha256:e590846f4776907b254ac0f44b5b380347af5d90d668138ca7938d1b0c2f98d3
 
 FROM --platform=$TARGETPLATFORM ghcr.io/astral-sh/uv:${UV_VERSION}@${UV_IMAGE_DIGEST} AS uv
+
+# Build supercronic from source with a current Go toolchain. Upstream release
+# binaries lag the latest Go patch, so their embedded stdlib fails the release
+# Trivy gate on freshly-published Go CVEs; building here keeps it current.
+# Digest is the multi-arch manifest list for golang:1.26-trixie (resolves per TARGETPLATFORM).
+FROM golang:1.26-trixie@sha256:68b7145ec43d1820b9a56704554b53d1520aa2a15cb5233e374188a31b2a1bce AS supercronic
+ENV CGO_ENABLED=0
+RUN go install github.com/aptible/supercronic@v0.2.46
+
 FROM python:${PYTHON_VERSION}-slim@${PYTHON_BASE_DIGEST} AS builder
 
 # Disable man pages and docs to speed up apt operations
@@ -80,12 +89,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     curl \
     nginx
 
-# Install supercronic for cron jobs (container-friendly cron)
-ARG TARGETARCH
-RUN SUPERCRONIC_ARCH=$(case "${TARGETARCH}" in "arm64") echo "linux-arm64" ;; *) echo "linux-amd64" ;; esac) && \
-    curl -fsSL "https://github.com/aptible/supercronic/releases/download/v0.2.41/supercronic-${SUPERCRONIC_ARCH}" \
-    -o /usr/local/bin/supercronic && \
-    chmod +x /usr/local/bin/supercronic
+# Install supercronic for cron jobs (container-friendly cron), built from source above.
+COPY --from=supercronic /go/bin/supercronic /usr/local/bin/supercronic
+RUN chmod +x /usr/local/bin/supercronic
 
 WORKDIR /app
 


### PR DESCRIPTION
## Why

The release pipeline's Trivy gate (`release-please.yml` → `build-and-push`) fails on the current image with fixable CRITICAL/HIGH CVEs. Because the git tag and GitHub Release are cut by the earlier `release-please` job, a failure in `build-and-push` produces a **half-release**: version tagged, no image published. This job only runs on a real release (`release_created`), so it has never executed since the supply-chain hardening landed — the pending 2.0.0 release (#1191) is the first time it fires.

Verified locally by building the image and scanning with the gate's exact flags (`--severity CRITICAL,HIGH --pkg-types os,library --ignore-unfixed --exit-code 1`): findings drop **17 → 0** (`debian 0`, `gobinary 0`), scan exit `0`.

## What

- **supercronic** — `v0.2.41` embeds an old Go stdlib: 12 findings incl. `CVE-2025-68121` (crypto/tls certificate validation, CRITICAL) plus 11 HIGH DoS. Even the latest release binary (`v0.2.46`, built with Go 1.26.3) still carries 1 HIGH. Build supercronic from source with a current Go toolchain (go1.26.4) so the embedded stdlib stays ahead of newly published Go CVEs instead of lagging every release binary.
- **base image** — the pinned `python:3.12-slim` digest predates `openssl 3.5.6-1~deb13u2` (`CVE-2026-45447`, heap use-after-free in `PKCS7_verify`). Bump the base digest to the current `3.12-slim` (openssl `deb13u2`).
- nginx needed no change: a clean build already pulls `deb13u7` from apt.

## Notes

- Regular CI does not build or scan the image (Trivy runs only in the release pipeline), so a green CI run here does not exercise this fix — the validation above is the authority.
- This should merge **before** the release PR (#1191). release-please will then regenerate #1191 to include this commit under 2.0.0's Bug Fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
