### PR TITLE
chore: bump ruff target-version to py312 (ADR-008)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ dev = [
 
 [tool.ruff]
 line-length = 120
-target-version = "py311"
+target-version = "py312"
 exclude = [
     ".eggs",
     ".git",

--- a/src/core/async_patterns.py
+++ b/src/core/async_patterns.py
@@ -6,12 +6,11 @@ in the MCP server, following the A2A protocol's Task-based approach.
 
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import Any, Generic, TypeVar
+from typing import Any
 
 from pydantic import BaseModel, Field
 
-# Generic type for the result of an async operation
-T = TypeVar("T", bound=BaseModel)
+# Generic type for the result of an async operation — PEP 695 type parameters on classes below.
 
 
 class TaskState(StrEnum):
@@ -39,7 +38,7 @@ class TaskStatus(BaseModel):
     progress: float | None = None  # 0.0 to 1.0
 
 
-class AsyncTask(BaseModel, Generic[T]):
+class AsyncTask[T: BaseModel](BaseModel):
     """Generic async task following A2A Task pattern.
 
     This represents an operation that doesn't complete immediately and
@@ -82,7 +81,7 @@ class AsyncOperationResponse(BaseModel):
     estimated_completion_seconds: int | None = None
 
 
-class SyncOperationResponse(BaseModel, Generic[T]):
+class SyncOperationResponse[T: BaseModel](BaseModel):
     """Standard response for synchronous operations.
 
     Synchronous operations complete immediately and return the result directly.

--- a/src/core/schemas/_base.py
+++ b/src/core/schemas/_base.py
@@ -60,8 +60,8 @@ from adcp.types.generated_poc.enums.media_buy_valid_action import (
 from src.core.config import get_pydantic_extra_mode
 from src.core.exceptions import AdCPNotFoundError
 
-# For backward compatibility, alias AdCPPackage as LibraryPackage (TypeAlias for mypy)
-LibraryPackage: TypeAlias = AdCPPackage
+# For backward compatibility, alias AdCPPackage as LibraryPackage
+LibraryPackage: TypeAlias = AdCPPackage  # noqa: UP040 — runtime re-export used as base class
 # Simple types that match library exactly
 # V3: Structured geo targeting types
 from adcp.types import ActivateSignalRequest as LibraryActivateSignalRequest
@@ -2254,8 +2254,8 @@ from adcp.types.generated_poc.core.property import (
     Identifier as PropertySpecificIdentifier,
 )  # TODO: no stable alias in adcp.types (different from adcp.types.Identifier)
 
-PropertyIdentifier: TypeAlias = PropertySpecificIdentifier  # Property-specific identifier
-Property: TypeAlias = LibraryProperty
+PropertyIdentifier: TypeAlias = PropertySpecificIdentifier  # noqa: UP040 — runtime re-export
+Property: TypeAlias = LibraryProperty  # noqa: UP040 — runtime re-export
 
 
 class PropertyTagMetadata(SalesAgentBaseModel):

--- a/src/core/tools/creative_formats.py
+++ b/src/core/tools/creative_formats.py
@@ -14,7 +14,7 @@ import concurrent.futures
 import logging
 import time
 from collections.abc import Sequence
-from typing import Annotated, TypeVar
+from typing import Annotated
 
 # FIXME(#1388): FormatId has a local subclass; import from src.core.schemas (Pattern #7/#4).
 from adcp import FormatId
@@ -31,13 +31,11 @@ from adcp.types import (
 )
 from adcp.types import Format as AdcpFormat
 from adcp.utils.format_assets import get_format_assets
-from pydantic import Field
 
-# TypeVar for Format to preserve subclass type through backward compatibility function
-FormatT = TypeVar("FormatT", bound=AdcpFormat)
+# Format subclass preserved through backward-compatibility helper (PEP 695 type param below).
 from fastmcp.server.context import Context
 from fastmcp.tools.tool import ToolResult
-from pydantic import ValidationError
+from pydantic import Field, ValidationError
 
 from src.core.exceptions import AdCPError, AdCPServiceUnavailableError, AdCPValidationError
 from src.core.helpers import enum_value
@@ -46,7 +44,7 @@ from src.core.tool_context import ToolContext
 logger = logging.getLogger(__name__)
 
 
-def _ensure_backward_compatible_format(f: FormatT) -> FormatT:
+def _ensure_backward_compatible_format[FormatT: AdcpFormat](f: FormatT) -> FormatT:
     """Pass-through function for backward compatibility.
 
     Note: adcp 3.2.0 removed the deprecated `assets_required` field from Format.

--- a/tests/unit/_architecture_helpers.py
+++ b/tests/unit/_architecture_helpers.py
@@ -399,8 +399,8 @@ _PG_IMAGE_REF_PATTERN = (
 _PG_IMAGE_LITERAL = re.compile(_PG_IMAGE_REF_PATTERN, re.MULTILINE)
 _PG_TAG_PATTERN = _PG_IMAGE_REF_PATTERN
 
-# ADR-008: ruff target-version stays py311 until post-#1234 follow-up PR.
-_ADR_008_DEFERRED_TARGET_VERSION = "3.11"
+# ADR-008: ruff target-version pinned to py312 (runtime .python-version is 3.12).
+_ADR_008_TARGET_VERSION = "3.12"
 
 
 def postgres_image_ref(tag: str) -> str:
@@ -517,18 +517,18 @@ def iter_hardcoded_python_version_yaml(repo: Path) -> Iterator[tuple[Path, int, 
 
 
 def assert_adr008_target_version_pinned(anchors: Iterable[tuple[Path, str, str]], repo: Path) -> None:
-    """Assert ADR-008 deferred ruff ``target-version`` stays exactly py311 (normalized ``3.11``)."""
+    """Assert ADR-008 ruff ``target-version`` stays exactly py312 (normalized ``3.12``)."""
     target_versions = [version for _, version, anchor_kind in anchors if anchor_kind == "target-version"]
     if not target_versions:
         raise AssertionError("non-vacuity: pyproject.toml target-version anchor must be scanned")
     drift = [
         f"{path.relative_to(repo)}: {version}"
         for path, version, anchor_kind in anchors
-        if anchor_kind == "target-version" and version != _ADR_008_DEFERRED_TARGET_VERSION
+        if anchor_kind == "target-version" and version != _ADR_008_TARGET_VERSION
     ]
     if drift:
         raise AssertionError(
-            f"ADR-008 target-version must stay py311 ({_ADR_008_DEFERRED_TARGET_VERSION!r}):\n"
+            f"ADR-008 target-version must stay py312 ({_ADR_008_TARGET_VERSION!r}):\n"
             + "\n".join(f"  {item}" for item in drift)
         )
 

--- a/tests/unit/test_architecture_uv_version_anchor.py
+++ b/tests/unit/test_architecture_uv_version_anchor.py
@@ -194,7 +194,7 @@ def test_python_version_anchors_consistent() -> None:
     for path, version, anchor_kind in anchors:
         if path.name in {".python-version", "Dockerfile"}:
             continue
-        # ADR-008: ruff/black target-version stays py311 until a dedicated post-#1234 PR.
+        # ADR-008: ruff target-version is py312 (aligned with runtime .python-version).
         if anchor_kind == "target-version":
             continue
         if version != major_minor:
@@ -222,8 +222,8 @@ def test_python_anchor_scan_includes_github_yaml_surfaces() -> None:
 
 
 @pytest.mark.arch_guard
-def test_target_version_anchor_must_stay_py311() -> None:
-    """Mutation self-test: ADR-008 deferred target-version downgrade must fail the guard."""
+def test_target_version_anchor_must_stay_py312() -> None:
+    """Mutation self-test: ADR-008 target-version downgrade must fail the guard."""
     repo = repo_root()
     anchors = list(iter_python_version_anchors(repo))
     assert_adr008_target_version_pinned(anchors, repo)
@@ -234,7 +234,7 @@ def test_target_version_anchor_must_stay_py311() -> None:
         for version, anchor_kind in extract_python_version_anchors(bad_path, bad_text)
     ]
     assert bad_anchors, "known-bad fixture must yield a target-version anchor"
-    with pytest.raises(AssertionError, match="ADR-008 target-version must stay py311"):
+    with pytest.raises(AssertionError, match="ADR-008 target-version must stay py312"):
         assert_adr008_target_version_pinned(bad_anchors, repo)
 
 


### PR DESCRIPTION
Closes #1630.

## Summary

- Bump `[tool.ruff].target-version` from `py311` to `py312`, aligned with runtime `.python-version` (3.12).
- Update ADR-008 guard pin and mutation self-test in `test_architecture_uv_version_anchor.py`.
- Hand-fix the three pyupgrade violations unlocked by py312 (2× UP046 in `async_patterns.py`, 1× UP047 in `creative_formats.py`).
- Keep three runtime re-export aliases in `schemas/_base.py` as `TypeAlias` with `# noqa: UP040` — PEP 695 `type=` breaks base-class inheritance (`LibraryPackage`) and `is` identity checks (`PropertyIdentifier`).

Part of #1468 (ADR-008 deferred item). Rebased onto `main` after #1498 merge — **1 commit**.

## Test plan

- [x] `uv run ruff check src tests --select UP` — clean
- [x] `UV_FROZEN=1 make quality` — 5144 passed