### PR TITLE
fix: wrap MCP TypeAdapter validation errors

### DIFF
--- a/.duplication-baseline
+++ b/.duplication-baseline
@@ -1,5 +1,5 @@
 {
   "src": 35,
-  "tests": 86,
+  "tests": 83,
   "scripts": 0
 }

--- a/src/app.py
+++ b/src/app.py
@@ -35,6 +35,7 @@ from src.core.auth_middleware import UnifiedAuthMiddleware
 from src.core.domain_config import get_a2a_server_url, get_sales_agent_domain
 from src.core.domain_routing import route_landing_page
 from src.core.exceptions import (
+    INVALID_REQUEST_SUGGESTION,
     VALIDATION_ERROR_SUGGESTION,
     AdCPError,
     AdCPInvalidRequestError,
@@ -244,11 +245,14 @@ async def request_validation_error_handler(request: Request, exc: RequestValidat
     # value-vs-structural reclassification across all fields is a repo-wide
     # follow-up; for now the attribution_window family — reconciled to
     # VALIDATION_ERROR upstream in adcp-req — is mapped explicitly. (salesagent-meho)
-    exc_cls = AdCPValidationError if (field and field.startswith("attribution_window")) else AdCPInvalidRequestError
+    if field and field.startswith("attribution_window"):
+        exc_cls, suggestion = AdCPValidationError, VALIDATION_ERROR_SUGGESTION
+    else:
+        exc_cls, suggestion = AdCPInvalidRequestError, INVALID_REQUEST_SUGGESTION
     adcp_exc = exc_cls(
         message,
         field=field,
-        suggestion=VALIDATION_ERROR_SUGGESTION,
+        suggestion=suggestion,
         details=build_validation_error_details(errors),
     )
     return _envelope_response(request, adcp_exc)

--- a/src/app.py
+++ b/src/app.py
@@ -35,10 +35,12 @@ from src.core.auth_middleware import UnifiedAuthMiddleware
 from src.core.domain_config import get_a2a_server_url, get_sales_agent_domain
 from src.core.domain_routing import route_landing_page
 from src.core.exceptions import (
+    VALIDATION_ERROR_SUGGESTION,
     AdCPError,
     AdCPInvalidRequestError,
     AdCPValidationError,
     build_two_layer_error_envelope,
+    build_validation_error_details,
     normalize_to_adcp_error,
 )
 from src.core.http_utils import get_header_case_insensitive as _get_header_case_insensitive
@@ -246,10 +248,8 @@ async def request_validation_error_handler(request: Request, exc: RequestValidat
     adcp_exc = exc_cls(
         message,
         field=field,
-        suggestion="check request parameters and fix",
-        details={
-            "validation_errors": [{"loc": e.get("loc"), "msg": e.get("msg"), "type": e.get("type")} for e in errors]
-        },
+        suggestion=VALIDATION_ERROR_SUGGESTION,
+        details=build_validation_error_details(errors),
     )
     return _envelope_response(request, adcp_exc)
 

--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -1026,15 +1026,21 @@ def build_two_layer_error_envelope(exc: AdCPError) -> dict[str, Any]:
     return envelope
 
 
-VALIDATION_ERROR_SUGGESTION = "check request parameters and fix"
+# Canonical buyer-facing suggestions from error-code.json enumMetadata (AdCP 3.1.1):
+# each code carries its own default hint, so a VALIDATION_ERROR must not borrow
+# INVALID_REQUEST's text.
+INVALID_REQUEST_SUGGESTION = "check request parameters and fix"
+VALIDATION_ERROR_SUGGESTION = "review error details and fix field values"
 
 
 def first_validation_error_field(validation_error: ValidationError) -> str | None:
-    """Return the bracket-notation path of the first Pydantic error.
+    """Return the bracket-notation path of the first Pydantic error, or ``None``.
 
-    List indices render as ``[i]`` so boundary-derived paths such as
-    ``packages[0].budget`` align with the ``packages[].budget`` field strings
-    raised by the implementation layer.
+    Lets a transport boundary attach a structured ``field`` to the
+    ``AdCPValidationError`` it raises, so the wire envelope carries the offending
+    field path instead of only the rendered message. List indices render as
+    ``[i]`` so boundary-derived paths such as ``packages[0].budget`` align with
+    the ``packages[].budget`` field strings raised by the implementation layer.
     """
     errors = validation_error.errors()
     if not errors:

--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -14,10 +14,10 @@ import logging
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from adcp.server.helpers import STANDARD_ERROR_CODES, adcp_error
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterator, Sequence
 
     from adcp.types import ContextObject
 
@@ -1026,6 +1026,39 @@ def build_two_layer_error_envelope(exc: AdCPError) -> dict[str, Any]:
     return envelope
 
 
+VALIDATION_ERROR_SUGGESTION = "check request parameters and fix"
+
+
+def first_validation_error_field(validation_error: ValidationError) -> str | None:
+    """Return the bracket-notation path of the first Pydantic error."""
+    errors = validation_error.errors()
+    if not errors:
+        return None
+    parts: list[str] = []
+    for loc in errors[0]["loc"]:
+        if isinstance(loc, int):
+            parts.append(f"[{loc}]")
+        elif parts:
+            parts.append(f".{loc}")
+        else:
+            parts.append(str(loc))
+    return "".join(parts)
+
+
+def build_validation_error_details(errors: Sequence[Any]) -> dict[str, Any]:
+    """Project Pydantic errors into the buyer-safe structured detail shape."""
+    return {
+        "validation_errors": [
+            {
+                "loc": list(error.get("loc", ())),
+                "msg": error.get("msg"),
+                "type": error.get("type"),
+            }
+            for error in errors
+        ]
+    }
+
+
 def normalize_to_adcp_error(exc: Exception) -> AdCPError:
     """Normalize untyped exceptions to typed AdCPError subclasses.
 
@@ -1038,26 +1071,13 @@ def normalize_to_adcp_error(exc: Exception) -> AdCPError:
     """
     if isinstance(exc, AdCPError):
         return exc
-    from pydantic import ValidationError
-
     if isinstance(exc, ValidationError):
-        from src.core.validation_helpers import first_validation_error_field
-
         errors = exc.errors()
         return AdCPValidationError(
             errors[0].get("msg") if errors else "Request failed schema validation",
             field=first_validation_error_field(exc),
-            suggestion="check request parameters and fix",
-            details={
-                "validation_errors": [
-                    {
-                        "loc": list(error.get("loc", ())),
-                        "msg": error.get("msg"),
-                        "type": error.get("type"),
-                    }
-                    for error in errors
-                ]
-            },
+            suggestion=VALIDATION_ERROR_SUGGESTION,
+            details=build_validation_error_details(errors),
         )
     if isinstance(exc, ValueError):
         return AdCPValidationError(str(exc))

--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -427,12 +427,12 @@ class AdCPValidationError(AdCPError):
 
 
 class AdCPInvalidRequestError(AdCPValidationError):
-    """A request value is well-formed but semantically invalid (400 → INVALID_REQUEST).
+    """A structurally invalid request graded as INVALID_REQUEST by the storyboard (400).
 
-    Distinct from the schema-level VALIDATION_ERROR: the value passes type/shape
-    validation but is invalid in context (e.g. start_time in the past, end_time
-    before start_time). Carries the INVALID_REQUEST standard wire code as class
-    identity; inherits 400 + correctable from AdCPValidationError.
+    Distinct from operation-level VALIDATION_ERROR failures. The AdCP storyboard
+    defines the code per operation, so callers must use the exception class graded
+    for that scenario rather than inferring the code from validation phase alone.
+    Inherits 400 + correctable from AdCPValidationError.
     """
 
     _default_error_code: ClassVar[str] = "INVALID_REQUEST"
@@ -1030,13 +1030,35 @@ def normalize_to_adcp_error(exc: Exception) -> AdCPError:
     """Normalize untyped exceptions to typed AdCPError subclasses.
 
     Single source of truth for the wrapping applied at all three transport
-    boundaries (MCP, A2A, REST).  Already-typed ``AdCPError`` passes through
-    unchanged.  ``ValueError`` maps to ``AdCPValidationError``,
-    ``PermissionError`` to ``AdCPAuthorizationError``, and anything else
-    wraps in base ``AdCPError`` (INTERNAL_ERROR).
+    boundaries (MCP, A2A, REST). Already-typed ``AdCPError`` passes through
+    unchanged. Pydantic ``ValidationError`` maps to a structured, sanitized
+    ``AdCPValidationError``; other ``ValueError`` instances map to the plain
+    validation error, ``PermissionError`` to ``AdCPAuthorizationError``, and
+    anything else wraps in base ``AdCPError`` (INTERNAL_ERROR).
     """
     if isinstance(exc, AdCPError):
         return exc
+    from pydantic import ValidationError
+
+    if isinstance(exc, ValidationError):
+        from src.core.validation_helpers import first_validation_error_field
+
+        errors = exc.errors()
+        return AdCPValidationError(
+            errors[0].get("msg") if errors else "Request failed schema validation",
+            field=first_validation_error_field(exc),
+            suggestion="check request parameters and fix",
+            details={
+                "validation_errors": [
+                    {
+                        "loc": list(error.get("loc", ())),
+                        "msg": error.get("msg"),
+                        "type": error.get("type"),
+                    }
+                    for error in errors
+                ]
+            },
+        )
     if isinstance(exc, ValueError):
         return AdCPValidationError(str(exc))
     if isinstance(exc, PermissionError):

--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -17,7 +17,7 @@ from adcp.server.helpers import STANDARD_ERROR_CODES, adcp_error
 from pydantic import BaseModel, ValidationError
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Sequence
+    from collections.abc import Iterator, Mapping, Sequence
 
     from adcp.types import ContextObject
 
@@ -1030,7 +1030,12 @@ VALIDATION_ERROR_SUGGESTION = "check request parameters and fix"
 
 
 def first_validation_error_field(validation_error: ValidationError) -> str | None:
-    """Return the bracket-notation path of the first Pydantic error."""
+    """Return the bracket-notation path of the first Pydantic error.
+
+    List indices render as ``[i]`` so boundary-derived paths such as
+    ``packages[0].budget`` align with the ``packages[].budget`` field strings
+    raised by the implementation layer.
+    """
     errors = validation_error.errors()
     if not errors:
         return None
@@ -1045,7 +1050,7 @@ def first_validation_error_field(validation_error: ValidationError) -> str | Non
     return "".join(parts)
 
 
-def build_validation_error_details(errors: Sequence[Any]) -> dict[str, Any]:
+def build_validation_error_details(errors: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     """Project Pydantic errors into the buyer-safe structured detail shape."""
     return {
         "validation_errors": [

--- a/src/core/mcp_compat_middleware.py
+++ b/src/core/mcp_compat_middleware.py
@@ -14,7 +14,10 @@ from fastmcp.server.middleware import Middleware, MiddlewareContext
 from fastmcp.tools.tool import ToolResult
 from mcp.types import CallToolRequestParams
 
+from src.core.exceptions import AdCPValidationError, build_two_layer_error_envelope
 from src.core.request_compat import deep_strip_to_schema, normalize_request_params, strip_unknown_params
+from src.core.tool_error_logging import AdCPToolError
+from src.core.validation_helpers import first_validation_error_field
 
 logger = logging.getLogger(__name__)
 
@@ -83,32 +86,37 @@ class RequestCompatMiddleware(Middleware):
         try:
             return await call_next(context)
         except Exception as exc:
-            if not self._should_retry(exc):
+            if not self._is_typeadapter_validation_error(exc):
                 raise
 
-            # Deep-strip unknown fields at every nesting level using the tool's
-            # JSON Schema. TypeAdapter rejects unknown fields in objects with
-            # additionalProperties: false. Our Pydantic models (extra='ignore')
-            # would accept them — stripping bridges the gap.
-            tool_schema = await self._get_tool_schema(context, tool_name)
-            if tool_schema is None:
-                raise  # Can't strip without schema — let the error propagate
+            if self._should_retry(exc):
+                # Deep-strip unknown fields at every nesting level using the tool's
+                # JSON Schema. TypeAdapter rejects unknown fields in objects with
+                # additionalProperties: false. Our Pydantic models (extra='ignore')
+                # would accept them — stripping bridges the gap.
+                tool_schema = await self._get_tool_schema(context, tool_name)
+                if tool_schema is not None:
+                    stripped = deep_strip_to_schema(normalized, tool_schema)
+                    if stripped != normalized:
+                        logger.warning(
+                            "TypeAdapter rejected %s — retrying with deep-stripped arguments "
+                            "(production forward-compat): %s",
+                            tool_name,
+                            _summarize_error(exc),
+                        )
+                        stripped_message = CallToolRequestParams(
+                            name=tool_name,
+                            arguments=stripped,
+                        )
+                        stripped_context = context.copy(message=stripped_message)
+                        try:
+                            return await call_next(stripped_context)
+                        except Exception as retry_exc:
+                            if not self._is_typeadapter_validation_error(retry_exc):
+                                raise
+                            exc = retry_exc
 
-            stripped = deep_strip_to_schema(normalized, tool_schema)
-            if stripped == normalized:
-                raise  # Stripping didn't change anything — no point retrying
-
-            logger.warning(
-                "TypeAdapter rejected %s — retrying with deep-stripped arguments (production forward-compat): %s",
-                tool_name,
-                _summarize_error(exc),
-            )
-            stripped_message = CallToolRequestParams(
-                name=tool_name,
-                arguments=stripped,
-            )
-            stripped_context = context.copy(message=stripped_message)
-            return await call_next(stripped_context)
+            raise _typeadapter_validation_tool_error(exc) from exc
 
     @staticmethod
     def _should_retry(exc: Exception) -> bool:
@@ -132,6 +140,13 @@ class RequestCompatMiddleware(Middleware):
             return False
 
         return exc.title.startswith("call[")
+
+    @staticmethod
+    def _is_typeadapter_validation_error(exc: Exception) -> bool:
+        """Return True for FastMCP TypeAdapter validation failures."""
+        from pydantic import ValidationError
+
+        return isinstance(exc, ValidationError) and exc.title.startswith("call[")
 
     async def _get_tool_schema(
         self,
@@ -184,3 +199,28 @@ def _summarize_error(exc: Exception) -> str:
     # Take first line or first 150 chars
     first_line = text.split("\n")[0]
     return first_line[:150] if len(first_line) > 150 else first_line
+
+
+def _typeadapter_validation_tool_error(exc: Exception) -> AdCPToolError:
+    """Translate FastMCP TypeAdapter schema failures to the AdCP MCP wire shape."""
+    from pydantic import ValidationError
+
+    if not isinstance(exc, ValidationError):
+        raise TypeError(f"expected ValidationError, got {type(exc).__name__}")
+
+    typed = AdCPValidationError(
+        f"Invalid parameters: {exc}",
+        field=first_validation_error_field(exc),
+        suggestion="check request parameters and fix",
+        details={
+            "validation_errors": [
+                {
+                    "loc": list(error.get("loc", ())),
+                    "msg": error.get("msg"),
+                    "type": error.get("type"),
+                }
+                for error in exc.errors()
+            ]
+        },
+    )
+    return AdCPToolError(build_two_layer_error_envelope(typed), status_code=typed.status_code)

--- a/src/core/mcp_compat_middleware.py
+++ b/src/core/mcp_compat_middleware.py
@@ -1,7 +1,8 @@
 """FastMCP middleware for AdCP backward-compatibility normalization.
 
-Translates deprecated field names, strips unknown fields, and provides
-a production-mode fallback for TypeAdapter structural validation errors.
+Translates deprecated field names, strips unknown fields, and converts FastMCP
+TypeAdapter validation failures into AdCP envelopes in every environment. In
+production, it first retries structural failures after schema-aware deep stripping.
 Runs after MCPAuthMiddleware.
 """
 
@@ -28,10 +29,11 @@ class RequestCompatMiddleware(Middleware):
     Three-stage pipeline:
     1. Translate deprecated field names via normalize_request_params()
     2. Strip fields not in the tool's JSON Schema via strip_unknown_params()
-    3. (Production only) If TypeAdapter rejects the arguments with a structural
-       validation error, erase complex types to raw dicts via JSON round-trip
-       and retry. This lets our Pydantic models (with extra='ignore') be the
-       sole validation gate — matching A2A and REST behavior.
+    3. If TypeAdapter rejects the arguments, always translate and record the
+       failure as an AdCP validation envelope. In production only, first deep-
+       strip schema-unknown nested fields and retry when that changes the input.
+       This lets our Pydantic models (with extra='ignore') remain the validation
+       gate for forward-compatible fields while preserving typed failures in dev.
 
     The fallback only catches TypeAdapter ValidationErrors (structural type
     mismatches). Business logic errors from the tool function propagate normally.
@@ -116,6 +118,9 @@ class RequestCompatMiddleware(Middleware):
                                 raise
                             exc = retry_exc
 
+            # Normalize once for the audit record, then pass the raw exception to
+            # _translate_to_tool_error so the emitted AdCPToolError keeps it as
+            # __cause__. The translator intentionally normalizes it a second time.
             typed = normalize_to_adcp_error(exc)
             tenant_id = None
             principal_id = None

--- a/src/core/mcp_compat_middleware.py
+++ b/src/core/mcp_compat_middleware.py
@@ -13,11 +13,11 @@ from typing import Any
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 from fastmcp.tools.tool import ToolResult
 from mcp.types import CallToolRequestParams
+from pydantic import ValidationError
 
-from src.core.exceptions import AdCPValidationError, build_two_layer_error_envelope
+from src.core.exceptions import normalize_to_adcp_error
 from src.core.request_compat import deep_strip_to_schema, normalize_request_params, strip_unknown_params
-from src.core.tool_error_logging import AdCPToolError
-from src.core.validation_helpers import first_validation_error_field
+from src.core.tool_error_logging import _translate_to_tool_error, record_boundary_error
 
 logger = logging.getLogger(__name__)
 
@@ -116,7 +116,25 @@ class RequestCompatMiddleware(Middleware):
                                 raise
                             exc = retry_exc
 
-            raise _typeadapter_validation_tool_error(exc) from exc
+            typed = normalize_to_adcp_error(exc)
+            tenant_id = None
+            principal_id = None
+            if context.fastmcp_context is not None:
+                try:
+                    identity = await context.fastmcp_context.get_state("identity")
+                    if identity is not None:
+                        tenant_id = identity.tenant_id
+                        principal_id = identity.principal_id
+                except Exception:
+                    logger.debug("Could not read MCP identity for validation error logging", exc_info=True)
+            record_boundary_error(
+                "mcp",
+                tool_name,
+                typed,
+                tenant_id=tenant_id,
+                principal_id=principal_id,
+            )
+            _translate_to_tool_error(exc)
 
     @staticmethod
     def _should_retry(exc: Exception) -> bool:
@@ -131,21 +149,11 @@ class RequestCompatMiddleware(Middleware):
         """
         from src.core.config import is_production
 
-        if not is_production():
-            return False
-
-        from pydantic import ValidationError
-
-        if not isinstance(exc, ValidationError):
-            return False
-
-        return exc.title.startswith("call[")
+        return is_production() and RequestCompatMiddleware._is_typeadapter_validation_error(exc)
 
     @staticmethod
     def _is_typeadapter_validation_error(exc: Exception) -> bool:
         """Return True for FastMCP TypeAdapter validation failures."""
-        from pydantic import ValidationError
-
         return isinstance(exc, ValidationError) and exc.title.startswith("call[")
 
     async def _get_tool_schema(
@@ -199,28 +207,3 @@ def _summarize_error(exc: Exception) -> str:
     # Take first line or first 150 chars
     first_line = text.split("\n")[0]
     return first_line[:150] if len(first_line) > 150 else first_line
-
-
-def _typeadapter_validation_tool_error(exc: Exception) -> AdCPToolError:
-    """Translate FastMCP TypeAdapter schema failures to the AdCP MCP wire shape."""
-    from pydantic import ValidationError
-
-    if not isinstance(exc, ValidationError):
-        raise TypeError(f"expected ValidationError, got {type(exc).__name__}")
-
-    typed = AdCPValidationError(
-        f"Invalid parameters: {exc}",
-        field=first_validation_error_field(exc),
-        suggestion="check request parameters and fix",
-        details={
-            "validation_errors": [
-                {
-                    "loc": list(error.get("loc", ())),
-                    "msg": error.get("msg"),
-                    "type": error.get("type"),
-                }
-                for error in exc.errors()
-            ]
-        },
-    )
-    return AdCPToolError(build_two_layer_error_envelope(typed), status_code=typed.status_code)

--- a/src/core/validation_helpers.py
+++ b/src/core/validation_helpers.py
@@ -13,7 +13,12 @@ from contextlib import contextmanager
 
 from pydantic import ValidationError
 
-from src.core.exceptions import AdCPValidationError
+from src.core.exceptions import (
+    AdCPValidationError,
+)
+from src.core.exceptions import (
+    first_validation_error_field as first_validation_error_field,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -137,29 +142,6 @@ def safe_parse_json_field(field_value, field_name="field", default=None):
     else:
         logger.warning(f"Unexpected type for {field_name}: {type(field_value)}")
         return default if default is not None else {}
-
-
-def first_validation_error_field(validation_error: ValidationError) -> str | None:
-    """Return the bracket-notation field path of the first Pydantic error, or ``None``.
-
-    Lets a transport boundary attach a structured ``field`` to the
-    ``AdCPValidationError`` it raises, so the wire envelope carries the offending
-    field path (e.g. ``packages[0].budget``) instead of only the rendered message.
-    List indices render as ``[i]`` so the boundary-derived path matches the
-    hand-rolled ``field=`` strings raised inside the _impl layer (``packages[].budget``).
-    """
-    errors = validation_error.errors()
-    if not errors:
-        return None
-    parts: list[str] = []
-    for loc in errors[0]["loc"]:
-        if isinstance(loc, int):
-            parts.append(f"[{loc}]")
-        elif parts:
-            parts.append(f".{loc}")
-        else:
-            parts.append(str(loc))
-    return "".join(parts)
 
 
 def package_field_path(attr: str) -> str:

--- a/src/core/validation_helpers.py
+++ b/src/core/validation_helpers.py
@@ -15,6 +15,7 @@ from pydantic import ValidationError
 
 from src.core.exceptions import (
     AdCPValidationError,
+    build_validation_error_details,
 )
 from src.core.exceptions import (
     first_validation_error_field as first_validation_error_field,
@@ -49,10 +50,12 @@ def adcp_validation_boundary(context: str = "parameters", field: str | None = No
     try:
         yield
     except ValidationError as e:
+        errors = e.errors()
         raise AdCPValidationError(
             format_validation_error(e, context=context),
             field=field if field is not None else first_validation_error_field(e),
             suggestion=suggest_validation_fix(e),
+            details=build_validation_error_details(errors),
         ) from e
 
 

--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -3230,6 +3230,8 @@ def _harness_env(request: pytest.FixtureRequest, ctx: dict) -> Generator[None, N
                 ctx["default_product"] = product
                 ctx["default_pricing_option"] = pricing_option
                 yield
+        elif "T-UC-002-inv-015-6" in marker_names:
+            pytest.xfail("T-UC-002-inv-015-6 create_media_buy harness wiring is tracked in #1652")
         else:
             # Restore the xfail guard every other use case keeps on its catch-all:
             # non-account / non-extension UC-002 scenarios are NOT yet wired (no
@@ -3368,6 +3370,8 @@ def _harness_env(request: pytest.FixtureRequest, ctx: dict) -> Generator[None, N
             with _db_scope_for(request, e2e_config), CreativeListEnv(e2e_config=e2e_config) as env:
                 ctx["env"] = env
                 yield
+        elif "T-UC-018-ext-c" in marker_names:
+            pytest.xfail("T-UC-018-ext-c list_creatives validation harness wiring is tracked in #1652")
         else:
             pytest.xfail(
                 "UC-018 harness wired only for the @list-after-sync (#1405), @concept-id (#1407), "

--- a/tests/harness/test_forward_compat_acceptance.py
+++ b/tests/harness/test_forward_compat_acceptance.py
@@ -411,33 +411,37 @@ class TestDeepStripRetryE2E:
 
         asyncio.run(_call())
 
-    def test_stripping_no_change_does_not_retry(self):
-        """If deep-strip doesn't change args, middleware raises original error (no infinite loop)."""
-        from fastmcp import Client
+    def test_stripping_no_change_becomes_validation_envelope(self):
+        """An unstrippable type mismatch is translated without a retry or raw leak."""
+        from pydantic import ValidationError
 
-        from src.core.main import mcp
+        from src.core.mcp_compat_middleware import RequestCompatMiddleware
+        from src.core.tool_error_logging import AdCPToolError
 
-        # Send a field with wrong TYPE (int where string expected) — deep-strip
-        # can't fix type mismatches, only unknown fields. Must propagate error.
+        middleware = RequestCompatMiddleware()
+        error = ValidationError.from_exception_data(
+            title="call[get_products]",
+            line_errors=[
+                {
+                    "type": "string_type",
+                    "loc": ("brief",),
+                    "input": 12345,
+                }
+            ],
+        )
+        call_next = AsyncMock(side_effect=error)
+        ctx = _make_mcp_context("get_products", {"brief": 12345})
+
         async def _call():
-            patches = _get_products_patches()
-            with patch.dict(os.environ, {"ENVIRONMENT": "production"}):
-                for p in patches:
-                    p.start()
-                try:
-                    async with Client(mcp) as client:
-                        result = await client.call_tool(
-                            "get_products",
-                            {"brief": 12345},  # Wrong type: int instead of str
-                            raise_on_error=False,
-                        )
-                        # This should either succeed (TypeAdapter coerces int→str)
-                        # or fail with a type error — but must NOT hang in a retry loop.
-                        # Either outcome is acceptable; the test verifies no hang.
-                        assert result is not None
-                finally:
-                    for p in patches:
-                        p.stop()
+            with (
+                patch.dict(os.environ, {"ENVIRONMENT": "production"}),
+                patch.object(middleware, "_get_tool_schema", return_value=_simple_tool_schema()),
+            ):
+                with pytest.raises(AdCPToolError) as exc_info:
+                    await middleware.on_call_tool(ctx, call_next)
+                assert_envelope_shape(exc_info.value, "VALIDATION_ERROR", recovery="correctable")
+                assert exc_info.value.__cause__ is error
+                assert call_next.call_count == 1
 
         asyncio.run(_call())
 

--- a/tests/harness/test_forward_compat_acceptance.py
+++ b/tests/harness/test_forward_compat_acceptance.py
@@ -25,6 +25,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from src.core.request_compat import normalize_request_params
+from tests.helpers import assert_envelope_shape
 
 # ---------------------------------------------------------------------------
 # Payloads: each is a (tool_name, params) tuple
@@ -766,17 +767,18 @@ class TestErrorPropagation:
 
         asyncio.run(_call())
 
-    def test_second_attempt_error_propagates_not_original(self):
+    def test_second_attempt_error_uses_retry_error_envelope(self):
         """TypeAdapter rejects → deep-strip → retry → retry ALSO fails.
-        The RETRY error must propagate, not the original.
+        The buyer-facing envelope must describe the retry error, not the original.
 
         This catches a subtle bug: if the middleware catches the retry
-        exception and re-raises the original instead, the buyer gets a
-        confusing error about fields that were already stripped.
+        exception and wraps the original instead, the buyer gets a confusing
+        error about fields that were already stripped.
         """
         from pydantic import ValidationError
 
         from src.core.mcp_compat_middleware import RequestCompatMiddleware
+        from src.core.tool_error_logging import AdCPToolError
 
         middleware = RequestCompatMiddleware()
 
@@ -805,10 +807,10 @@ class TestErrorPropagation:
                 patch.dict(os.environ, {"ENVIRONMENT": "production"}),
                 patch.object(middleware, "_get_tool_schema", return_value=_simple_tool_schema()),
             ):
-                with pytest.raises(ValidationError) as exc_info:
+                with pytest.raises(AdCPToolError) as exc_info:
                     await middleware.on_call_tool(ctx, call_next_with_different_errors)
-                # The retry error should propagate (the one from the 2nd call_next)
-                assert exc_info.value is retry_error
+                assert_envelope_shape(exc_info.value, "VALIDATION_ERROR", recovery="correctable")
+                assert exc_info.value.__cause__ is retry_error
 
         asyncio.run(_call())
 
@@ -821,11 +823,12 @@ class TestErrorPropagation:
 class TestMiddlewareAdversarial:
     """Adversarial scenarios designed to break the middleware."""
 
-    def test_schema_lookup_fails_error_propagates(self):
-        """_get_tool_schema returns None → original error propagates (no retry)."""
+    def test_schema_lookup_fails_error_becomes_envelope(self):
+        """_get_tool_schema returns None → no retry, but no raw validation leak."""
         from pydantic import ValidationError
 
         from src.core.mcp_compat_middleware import RequestCompatMiddleware
+        from src.core.tool_error_logging import AdCPToolError
 
         middleware = RequestCompatMiddleware()
 
@@ -838,8 +841,10 @@ class TestMiddlewareAdversarial:
                 patch.dict(os.environ, {"ENVIRONMENT": "production"}),
                 patch.object(middleware, "_get_tool_schema", return_value=None),
             ):
-                with pytest.raises(ValidationError):
+                with pytest.raises(AdCPToolError) as exc_info:
                     await middleware.on_call_tool(ctx, call_next)
+                assert_envelope_shape(exc_info.value, "VALIDATION_ERROR", recovery="correctable")
+                assert exc_info.value.__cause__ is error
                 # Only called once — no retry when schema unavailable
                 assert call_next.call_count == 1
 

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -76,7 +76,7 @@ from tests.helpers.adcp_factories import (
     create_test_property,
     create_test_property_dict,
 )
-from tests.helpers.envelope_assertions import assert_envelope_shape
+from tests.helpers.envelope_assertions import assert_envelope_shape, assert_no_raw_validation_leak
 from tests.helpers.idempotency_seeds import (
     make_active_cached_success,
     seed_cached_success,
@@ -89,6 +89,7 @@ __all__ = [
     "assert_resolve_auth_dep_passes_token",
     # Envelope assertions
     "assert_envelope_shape",
+    "assert_no_raw_validation_leak",
     # Idempotency cache seeding
     "make_active_cached_success",
     "seed_cached_success",

--- a/tests/helpers/envelope_assertions.py
+++ b/tests/helpers/envelope_assertions.py
@@ -19,6 +19,12 @@ from __future__ import annotations
 from typing import Any
 
 
+def assert_no_raw_validation_leak(message: str) -> None:
+    """Assert a buyer-facing validation message omits raw Pydantic internals."""
+    assert "input_value" not in message, f"raw Pydantic input leaked into validation message: {message!r}"
+    assert "errors.pydantic.dev" not in message, f"Pydantic documentation URL leaked into message: {message!r}"
+
+
 def assert_envelope_shape(
     target: Any,
     code: str,

--- a/tests/helpers/mcp_envelope_capture.py
+++ b/tests/helpers/mcp_envelope_capture.py
@@ -1,0 +1,53 @@
+"""Shared real-wire MCP error-envelope capture helper."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import ExitStack
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from fastmcp import Client
+
+from src.core.main import mcp
+from tests.factories.principal import PrincipalFactory
+
+_AUTO_IDENTITY = object()
+
+
+def call_mcp_tool_capturing_envelope(
+    tool_name: str,
+    params: dict[str, Any],
+    identity: Any = _AUTO_IDENTITY,
+    *,
+    stub_lifecycle_schedulers: bool = False,
+) -> tuple[bool, dict[str, Any] | None]:
+    """Invoke an MCP tool and return its error flag and parsed wire envelope."""
+    resolved_identity = PrincipalFactory.make_identity(protocol="mcp") if identity is _AUTO_IDENTITY else identity
+
+    async def _call() -> tuple[bool, str | None]:
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch(
+                    "src.core.mcp_auth_middleware.resolve_identity_from_context",
+                    return_value=resolved_identity,
+                )
+            )
+            if stub_lifecycle_schedulers:
+                for target in (
+                    "src.services.delivery_webhook_scheduler.start_delivery_webhook_scheduler",
+                    "src.services.delivery_webhook_scheduler.stop_delivery_webhook_scheduler",
+                    "src.services.media_buy_status_scheduler.start_media_buy_status_scheduler",
+                    "src.services.media_buy_status_scheduler.stop_media_buy_status_scheduler",
+                ):
+                    stack.enter_context(patch(target, AsyncMock()))
+            async with Client(mcp) as client:
+                result = await client.call_tool(tool_name, params, raise_on_error=False)
+                if not result.content:
+                    return result.is_error, None
+                text = next((item.text for item in result.content if hasattr(item, "text")), None)
+                return result.is_error, text
+
+    is_error, envelope_text = asyncio.run(_call())
+    return is_error, json.loads(envelope_text) if envelope_text is not None else None

--- a/tests/integration/test_a2a_error_responses.py
+++ b/tests/integration/test_a2a_error_responses.py
@@ -281,7 +281,7 @@ class TestA2AErrorPropagation:
             artifact_data,
             "VALIDATION_ERROR",
             recovery="correctable",
-            message_substr="Field required",
+            message_substr="Required field is missing",
         )
         assert "input_value" not in artifact_data["errors"][0]["message"]
         assert "errors.pydantic.dev" not in artifact_data["errors"][0]["message"]

--- a/tests/integration/test_a2a_error_responses.py
+++ b/tests/integration/test_a2a_error_responses.py
@@ -283,6 +283,8 @@ class TestA2AErrorPropagation:
             recovery="correctable",
             message_substr="Field required",
         )
+        assert "input_value" not in artifact_data["errors"][0]["message"]
+        assert "errors.pydantic.dev" not in artifact_data["errors"][0]["message"]
         assert "account" in (artifact_data["errors"][0].get("field") or "")
 
     async def test_create_media_buy_negative_budget_wire_envelope(self, handler, test_tenant, test_principal):
@@ -336,6 +338,8 @@ class TestA2AErrorPropagation:
             message_substr="greater than or equal to 0",
             recovery="correctable",
         )
+        assert "input_value" not in artifact_data["errors"][0]["message"]
+        assert "errors.pydantic.dev" not in artifact_data["errors"][0]["message"]
         # The structured field path is propagated from the Pydantic error (drift-proof
         # vs the rendered message substring) — both envelope layers carry it.
         wire_field = artifact_data["errors"][0].get("field") or ""

--- a/tests/integration/test_a2a_error_responses.py
+++ b/tests/integration/test_a2a_error_responses.py
@@ -20,7 +20,7 @@ from a2a.types import Message, SendMessageRequest, Task
 
 from src.a2a_server.adcp_a2a_server import AdCPRequestHandler
 from tests.factories.principal import PrincipalFactory
-from tests.helpers import assert_envelope_shape
+from tests.helpers import assert_envelope_shape, assert_no_raw_validation_leak
 from tests.helpers.adcp_factories import create_test_package_request_dict
 from tests.integration.conftest import seed_error_test_tenant
 from tests.utils.a2a_helpers import create_a2a_message_with_skill, extract_data_from_artifact
@@ -283,8 +283,7 @@ class TestA2AErrorPropagation:
             recovery="correctable",
             message_substr="Required field is missing",
         )
-        assert "input_value" not in artifact_data["errors"][0]["message"]
-        assert "errors.pydantic.dev" not in artifact_data["errors"][0]["message"]
+        assert_no_raw_validation_leak(artifact_data["errors"][0]["message"])
         assert "account" in (artifact_data["errors"][0].get("field") or "")
 
     async def test_create_media_buy_negative_budget_wire_envelope(self, handler, test_tenant, test_principal):
@@ -338,8 +337,7 @@ class TestA2AErrorPropagation:
             message_substr="greater than or equal to 0",
             recovery="correctable",
         )
-        assert "input_value" not in artifact_data["errors"][0]["message"]
-        assert "errors.pydantic.dev" not in artifact_data["errors"][0]["message"]
+        assert_no_raw_validation_leak(artifact_data["errors"][0]["message"])
         # The structured field path is propagated from the Pydantic error (drift-proof
         # vs the rendered message substring) — both envelope layers carry it.
         wire_field = artifact_data["errors"][0].get("field") or ""

--- a/tests/integration/test_a2a_error_responses.py
+++ b/tests/integration/test_a2a_error_responses.py
@@ -277,16 +277,13 @@ class TestA2AErrorPropagation:
         assert len(result.artifacts) > 0
 
         artifact_data = self.extract_data_from_artifact(result.artifacts[0])
-        # message_substr is the load-bearing assertion: a bare pydantic ValidationError is a
-        # ValueError, which the dispatcher also normalizes to VALIDATION_ERROR/correctable — so
-        # only the handler's wrapped "Invalid parameters" message distinguishes the fix (typed
-        # AdCPValidationError) from the raw-leak it replaced. Keep it when editing this assert.
         assert_envelope_shape(
             artifact_data,
             "VALIDATION_ERROR",
             recovery="correctable",
-            message_substr="Invalid parameters",
+            message_substr="Field required",
         )
+        assert "account" in (artifact_data["errors"][0].get("field") or "")
 
     async def test_create_media_buy_negative_budget_wire_envelope(self, handler, test_tenant, test_principal):
         """A negative package budget surfaces VALIDATION_ERROR on the A2A wire.
@@ -333,7 +330,12 @@ class TestA2AErrorPropagation:
         assert len(result.artifacts) > 0
 
         artifact_data = self.extract_data_from_artifact(result.artifacts[0])
-        assert_envelope_shape(artifact_data, "VALIDATION_ERROR", message_substr="budget", recovery="correctable")
+        assert_envelope_shape(
+            artifact_data,
+            "VALIDATION_ERROR",
+            message_substr="greater than or equal to 0",
+            recovery="correctable",
+        )
         # The structured field path is propagated from the Pydantic error (drift-proof
         # vs the rendered message substring) — both envelope layers carry it.
         wire_field = artifact_data["errors"][0].get("field") or ""

--- a/tests/integration/test_idempotency_wire_matrix.py
+++ b/tests/integration/test_idempotency_wire_matrix.py
@@ -244,7 +244,7 @@ class TestMissingKeyWireMatrix:
             envelope,
             "VALIDATION_ERROR",
             recovery="correctable",
-            message_substr="Field required",
+            message_substr="Required field is missing",
         )
         assert envelope["errors"][0].get("field") == "idempotency_key"
 

--- a/tests/integration/test_idempotency_wire_matrix.py
+++ b/tests/integration/test_idempotency_wire_matrix.py
@@ -244,7 +244,7 @@ class TestMissingKeyWireMatrix:
             envelope,
             "VALIDATION_ERROR",
             recovery="correctable",
-            message_substr="Required field is missing",
+            message_substr="Field required" if transport is Transport.A2A else "Required field is missing",
         )
         assert envelope["errors"][0].get("field") == "idempotency_key"
 

--- a/tests/integration/test_idempotency_wire_matrix.py
+++ b/tests/integration/test_idempotency_wire_matrix.py
@@ -244,7 +244,7 @@ class TestMissingKeyWireMatrix:
             envelope,
             "VALIDATION_ERROR",
             recovery="correctable",
-            message_substr="Field required" if transport is Transport.A2A else "Required field is missing",
+            message_substr="Required field is missing",
         )
         assert envelope["errors"][0].get("field") == "idempotency_key"
 

--- a/tests/integration/test_idempotency_wire_matrix.py
+++ b/tests/integration/test_idempotency_wire_matrix.py
@@ -244,8 +244,9 @@ class TestMissingKeyWireMatrix:
             envelope,
             "VALIDATION_ERROR",
             recovery="correctable",
-            message_substr="idempotency_key",
+            message_substr="Field required",
         )
+        assert envelope["errors"][0].get("field") == "idempotency_key"
 
 
 class TestWireLevelHashInput:

--- a/tests/integration/test_list_creatives_concept_filter.py
+++ b/tests/integration/test_list_creatives_concept_filter.py
@@ -30,7 +30,6 @@ pytestmark = [pytest.mark.integration, pytest.mark.requires_db]
 # Wire transports only — IMPL has no wire envelope (and the dict→CreativeFilters
 # coercion under test happens at the transport boundary, not in _impl).
 _ALL_WIRE = [Transport.A2A, Transport.MCP, Transport.REST]
-_ENVELOPE_WIRE = _ALL_WIRE
 
 
 def _seed_authenticated_principal(env: CreativeListEnv):
@@ -59,7 +58,7 @@ class TestConceptIdsFilterValidation:
                 f"got payload {result.payload!r}"
             )
 
-    @pytest.mark.parametrize("transport", _ENVELOPE_WIRE)
+    @pytest.mark.parametrize("transport", _ALL_WIRE)
     def test_empty_concept_ids_emits_validation_envelope(self, integration_db, transport):
         """Wire transports surface the two-layer VALIDATION_ERROR envelope with a suggestion."""
         with CreativeListEnv() as env:

--- a/tests/integration/test_list_creatives_concept_filter.py
+++ b/tests/integration/test_list_creatives_concept_filter.py
@@ -11,17 +11,9 @@ Two layers of guarantee:
 1. **Rejected on every wire transport** (a2a/mcp/rest) — the malformed filter never
    degrades to "return everything".
 2. **Spec two-layer ``VALIDATION_ERROR`` envelope with a recovery suggestion**
-   (POST-F3) on REST and A2A, which coerce the wire dict through the shared
-   ``coerce_creative_filters`` helper.
-
-MCP is intentionally excluded from layer 2: it types the tool param as
-``CreativeFilters`` (required by the wrapper-typed-params guard), so FastMCP's
-TypeAdapter rejects ``concept_ids=[]`` *before* the tool body runs — a raw input
-ValidationError, not an ``AdCPError`` the MCP boundary could wrap into the envelope.
-Translating FastMCP TypeAdapter input errors into the two-layer envelope is a
-pre-existing, tool-agnostic MCP-boundary concern (it affects every typed param,
-not just concept_ids) and is tracked separately in #1507. Layer 1 still pins that
-MCP rejects the malformed filter.
+   (POST-F3) on every wire transport. REST and A2A coerce the wire dict through
+   the shared ``coerce_creative_filters`` helper; MCP catches FastMCP TypeAdapter
+   validation at the boundary and emits the same AdCP envelope.
 
 Spec: ``core/creative-filters.json`` (concept_ids ``minItems: 1``) + the BR-UC-018
 ext-c contract (validation failure → VALIDATION_ERROR + suggestion).
@@ -38,9 +30,7 @@ pytestmark = [pytest.mark.integration, pytest.mark.requires_db]
 # Wire transports only — IMPL has no wire envelope (and the dict→CreativeFilters
 # coercion under test happens at the transport boundary, not in _impl).
 _ALL_WIRE = [Transport.A2A, Transport.MCP, Transport.REST]
-# Transports whose dict→CreativeFilters coercion runs through coerce_creative_filters
-# (and therefore emit the spec envelope + suggestion). See module docstring re: MCP.
-_HELPER_WIRE = [Transport.A2A, Transport.REST]
+_ENVELOPE_WIRE = _ALL_WIRE
 
 
 def _seed_authenticated_principal(env: CreativeListEnv):
@@ -54,7 +44,7 @@ def _seed_authenticated_principal(env: CreativeListEnv):
 
 
 class TestConceptIdsFilterValidation:
-    """Malformed concept_ids filter is rejected, with a spec envelope on REST/A2A."""
+    """Malformed concept_ids filter is rejected, with a spec envelope on every wire transport."""
 
     @pytest.mark.parametrize("transport", _ALL_WIRE)
     def test_empty_concept_ids_array_is_rejected(self, integration_db, transport):
@@ -69,9 +59,9 @@ class TestConceptIdsFilterValidation:
                 f"got payload {result.payload!r}"
             )
 
-    @pytest.mark.parametrize("transport", _HELPER_WIRE)
+    @pytest.mark.parametrize("transport", _ENVELOPE_WIRE)
     def test_empty_concept_ids_emits_validation_envelope(self, integration_db, transport):
-        """REST/A2A surface the two-layer VALIDATION_ERROR envelope with a suggestion."""
+        """Wire transports surface the two-layer VALIDATION_ERROR envelope with a suggestion."""
         with CreativeListEnv() as env:
             _seed_authenticated_principal(env)
 

--- a/tests/integration/test_mcp_error_envelope.py
+++ b/tests/integration/test_mcp_error_envelope.py
@@ -23,19 +23,15 @@ AdCPValidationError raised directly.
 
 from __future__ import annotations
 
-import asyncio
-import json
 import uuid
 from datetime import UTC, datetime, timedelta
-from unittest.mock import patch
 
 import pytest
-from fastmcp import Client
 
-from src.core.main import mcp
 from tests.factories.principal import PrincipalFactory
 from tests.helpers import assert_envelope_shape
 from tests.helpers.adcp_factories import create_test_package_request_dict
+from tests.helpers.mcp_envelope_capture import call_mcp_tool_capturing_envelope
 from tests.integration.conftest import seed_error_test_tenant
 
 pytestmark = [pytest.mark.integration, pytest.mark.requires_db]
@@ -93,7 +89,7 @@ class TestMcpWireErrorEnvelope:
         """
         identity = PrincipalFactory.make_identity(protocol="mcp")
 
-        is_error, envelope = self._call_mcp_tool_capturing_envelope(
+        is_error, envelope = call_mcp_tool_capturing_envelope(
             "update_media_buy",
             {
                 "media_buy_id": "mb_does_not_exist_mcp_wire",
@@ -118,36 +114,6 @@ class TestMcpWireErrorEnvelope:
         single_error_msg = "errors[0].message must be byte-identical to adcp_error.message in single-error case"
         assert envelope["errors"][0]["message"] == envelope["adcp_error"]["message"], single_error_msg
 
-    def _call_mcp_tool_capturing_envelope(self, tool_name: str, params: dict, identity) -> tuple[bool, dict | None]:
-        """Shared helper: invoke an MCP tool and return (is_error, parsed_envelope).
-
-        Single source of truth for the "Client(mcp) → patch identity → call_tool →
-        parse content[0].text as JSON envelope" pattern used by every wire test.
-        Returns ``None`` envelope when the result lacks content (caller asserts
-        that's not the case).
-        """
-
-        async def _call() -> tuple[bool, str | None]:
-            with patch(
-                "src.core.mcp_auth_middleware.resolve_identity_from_context",
-                return_value=identity,
-            ):
-                async with Client(mcp) as client:
-                    result = await client.call_tool(tool_name, params, raise_on_error=False)
-                    if not result.content:
-                        return result.is_error, None
-                    text = None
-                    for c in result.content:
-                        if hasattr(c, "text"):
-                            text = c.text
-                            break
-                    return result.is_error, text
-
-        is_error, envelope_text = asyncio.run(_call())
-        if envelope_text is None:
-            return is_error, None
-        return is_error, json.loads(envelope_text)
-
     def test_create_media_buy_budget_too_low_emits_envelope_on_wire(self, mcp_real_tenant_setup):
         """Production BUDGET_TOO_LOW validator surfaces as a spec two-layer envelope on the wire.
 
@@ -169,7 +135,7 @@ class TestMcpWireErrorEnvelope:
         start_time = (datetime.now(UTC) + timedelta(days=1)).isoformat()
         end_time = (datetime.now(UTC) + timedelta(days=31)).isoformat()
 
-        is_error, envelope = self._call_mcp_tool_capturing_envelope(
+        is_error, envelope = call_mcp_tool_capturing_envelope(
             "create_media_buy",
             {
                 "brand": {"domain": "wiretest.example"},
@@ -206,7 +172,7 @@ class TestMcpWireErrorEnvelope:
         """
         identity = mcp_real_tenant_setup
 
-        is_error, envelope = self._call_mcp_tool_capturing_envelope(
+        is_error, envelope = call_mcp_tool_capturing_envelope(
             "create_media_buy",
             {
                 "brand": {"domain": "wiretest.example"},
@@ -243,7 +209,7 @@ class TestMcpWireErrorEnvelope:
 
         AUTH_REQUIRED is a STANDARD spec code — passes through unchanged.
         """
-        is_error, envelope = self._call_mcp_tool_capturing_envelope(
+        is_error, envelope = call_mcp_tool_capturing_envelope(
             "get_media_buy_delivery",
             {"media_buy_ids": ["any_id"]},
             identity=None,
@@ -282,7 +248,7 @@ class TestMcpWireErrorEnvelope:
             protocol="mcp",
         )
 
-        is_error, envelope = self._call_mcp_tool_capturing_envelope(
+        is_error, envelope = call_mcp_tool_capturing_envelope(
             "get_media_buys",
             {"account_id": "acc_unsupported_wire_test"},
             identity,

--- a/tests/integration/test_mcp_typeadapter_validation_envelope.py
+++ b/tests/integration/test_mcp_typeadapter_validation_envelope.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import pytest
 
-from tests.helpers import assert_envelope_shape
+from tests.helpers import assert_envelope_shape, assert_no_raw_validation_leak
 from tests.helpers.adcp_factories import create_test_package_request_dict
 from tests.helpers.mcp_envelope_capture import call_mcp_tool_capturing_envelope
 
@@ -32,8 +32,7 @@ def test_typeadapter_validation_error_emits_adcp_envelope_on_mcp_wire():
     assert_envelope_shape(envelope, "VALIDATION_ERROR", recovery="correctable", message_substr="List should have")
     assert envelope["errors"][0].get("suggestion"), f"{tool_name}: envelope must include a recovery suggestion"
     assert envelope["errors"][0].get("field") == "filters.concept_ids"
-    assert "input_value" not in envelope["errors"][0]["message"]
-    assert "errors.pydantic.dev" not in envelope["errors"][0]["message"]
+    assert_no_raw_validation_leak(envelope["errors"][0]["message"])
 
 
 def test_create_media_buy_missing_key_preserves_field_on_mcp_wire():
@@ -64,8 +63,7 @@ def test_create_media_buy_missing_key_preserves_field_on_mcp_wire():
         message_substr="Required field is missing",
     )
     assert envelope["errors"][0].get("field") == "idempotency_key"
-    assert "input_value" not in envelope["errors"][0]["message"]
-    assert "errors.pydantic.dev" not in envelope["errors"][0]["message"]
+    assert_no_raw_validation_leak(envelope["errors"][0]["message"])
 
 
 @pytest.mark.xfail(

--- a/tests/integration/test_mcp_typeadapter_validation_envelope.py
+++ b/tests/integration/test_mcp_typeadapter_validation_envelope.py
@@ -9,45 +9,23 @@ The payloads fail before the tool body runs, so no database setup is required.
 
 from __future__ import annotations
 
-import asyncio
-import json
-from unittest.mock import AsyncMock, patch
-
 import pytest
-from fastmcp import Client
 
-from src.core.main import mcp
-from tests.factories.principal import PrincipalFactory
 from tests.helpers import assert_envelope_shape
+from tests.helpers.adcp_factories import create_test_package_request_dict
+from tests.helpers.mcp_envelope_capture import call_mcp_tool_capturing_envelope
 
 pytestmark = pytest.mark.integration
-
-
-def _call_mcp_tool_capturing_envelope(tool_name: str, params: dict) -> tuple[bool, dict | None]:
-    """Invoke a tool through the real in-memory MCP client and parse error content."""
-
-    async def _call() -> tuple[bool, str | None]:
-        identity = PrincipalFactory.make_identity(protocol="mcp")
-        with (
-            patch("src.core.mcp_auth_middleware.resolve_identity_from_context", return_value=identity),
-            patch("src.services.delivery_webhook_scheduler.start_delivery_webhook_scheduler", AsyncMock()),
-            patch("src.services.delivery_webhook_scheduler.stop_delivery_webhook_scheduler", AsyncMock()),
-            patch("src.services.media_buy_status_scheduler.start_media_buy_status_scheduler", AsyncMock()),
-            patch("src.services.media_buy_status_scheduler.stop_media_buy_status_scheduler", AsyncMock()),
-        ):
-            async with Client(mcp) as client:
-                result = await client.call_tool(tool_name, params, raise_on_error=False)
-                text = next((c.text for c in result.content if hasattr(c, "text")), None)
-                return result.is_error, text
-
-    is_error, envelope_text = asyncio.run(_call())
-    return is_error, json.loads(envelope_text) if envelope_text else None
 
 
 def test_typeadapter_validation_error_emits_adcp_envelope_on_mcp_wire():
     tool_name = "list_creatives"
     params = {"filters": {"concept_ids": []}}
-    is_error, envelope = _call_mcp_tool_capturing_envelope(tool_name, params)
+    is_error, envelope = call_mcp_tool_capturing_envelope(
+        tool_name,
+        params,
+        stub_lifecycle_schedulers=True,
+    )
 
     assert is_error, f"{tool_name}: invalid typed params must produce a tool error"
     assert envelope is not None, f"{tool_name}: no MCP wire error envelope captured"
@@ -59,7 +37,7 @@ def test_typeadapter_validation_error_emits_adcp_envelope_on_mcp_wire():
 
 
 def test_create_media_buy_missing_key_preserves_field_on_mcp_wire():
-    is_error, envelope = _call_mcp_tool_capturing_envelope(
+    is_error, envelope = call_mcp_tool_capturing_envelope(
         "create_media_buy",
         {
             "brand": {"domain": "wiretest.example"},
@@ -74,6 +52,7 @@ def test_create_media_buy_missing_key_preserves_field_on_mcp_wire():
             "end_time": "2026-09-01T00:00:00Z",
             "po_number": "WIRE-1",
         },
+        stub_lifecycle_schedulers=True,
     )
 
     assert is_error
@@ -85,16 +64,35 @@ def test_create_media_buy_missing_key_preserves_field_on_mcp_wire():
         message_substr="Required field is missing",
     )
     assert envelope["errors"][0].get("field") == "idempotency_key"
+    assert "input_value" not in envelope["errors"][0]["message"]
+    assert "errors.pydantic.dev" not in envelope["errors"][0]["message"]
 
 
 @pytest.mark.xfail(
-    reason="AdCP 3.1 grades create_media_buy schema failures INVALID_REQUEST; all transports currently emit VALIDATION_ERROR",
+    reason=(
+        "Tracked in #1604: AdCP 3.1.0-beta.3 BR-UC-002-create-media-buy.feature "
+        "@T-UC-002-inv-015-6 grades this in-body missing-field path INVALID_REQUEST; "
+        "the current TypeAdapter boundary emits VALIDATION_ERROR"
+    ),
     strict=True,
 )
 def test_create_media_buy_typeadapter_error_uses_storyboard_invalid_request_code():
-    is_error, envelope = _call_mcp_tool_capturing_envelope(
+    package = create_test_package_request_dict(
+        product_id="prod_missing",
+        pricing_option_id="cpm_usd_fixed",
+        budget=5000,
+    )
+    del package["product_id"]
+    is_error, envelope = call_mcp_tool_capturing_envelope(
         "create_media_buy",
-        {"brand": "wiretest.example", "packages": [{}]},
+        {
+            "brand": {"domain": "wiretest.example"},
+            "idempotency_key": "wire-missing-package-product",
+            "packages": [package],
+            "start_time": "2026-08-01T00:00:00Z",
+            "end_time": "2026-09-01T00:00:00Z",
+        },
+        stub_lifecycle_schedulers=True,
     )
 
     assert is_error

--- a/tests/integration/test_mcp_typeadapter_validation_envelope.py
+++ b/tests/integration/test_mcp_typeadapter_validation_envelope.py
@@ -44,28 +44,29 @@ def _call_mcp_tool_capturing_envelope(tool_name: str, params: dict) -> tuple[boo
     return is_error, json.loads(envelope_text) if envelope_text else None
 
 
-@pytest.mark.parametrize(
-    ("tool_name", "params", "message_substr", "field_prefix"),
-    [
-        (
-            "list_creatives",
-            {"filters": {"concept_ids": []}},
-            "filters.concept_ids",
-            "filters.concept_ids",
-        ),
-        (
-            "create_media_buy",
-            {"brand": "wiretest.example", "packages": [{}]},
-            "packages.0",
-            "packages[0].",
-        ),
-    ],
-)
-def test_typeadapter_validation_error_emits_adcp_envelope_on_mcp_wire(tool_name, params, message_substr, field_prefix):
+def test_typeadapter_validation_error_emits_adcp_envelope_on_mcp_wire():
+    tool_name = "list_creatives"
+    params = {"filters": {"concept_ids": []}}
     is_error, envelope = _call_mcp_tool_capturing_envelope(tool_name, params)
 
     assert is_error, f"{tool_name}: invalid typed params must produce a tool error"
     assert envelope is not None, f"{tool_name}: no MCP wire error envelope captured"
-    assert_envelope_shape(envelope, "VALIDATION_ERROR", recovery="correctable", message_substr=message_substr)
+    assert_envelope_shape(envelope, "VALIDATION_ERROR", recovery="correctable", message_substr="List should have")
     assert envelope["errors"][0].get("suggestion"), f"{tool_name}: envelope must include a recovery suggestion"
-    assert envelope["errors"][0].get("field", "").startswith(field_prefix)
+    assert envelope["errors"][0].get("field") == "filters.concept_ids"
+    assert "input_value" not in envelope["errors"][0]["message"]
+    assert "errors.pydantic.dev" not in envelope["errors"][0]["message"]
+
+
+@pytest.mark.xfail(
+    reason="AdCP 3.1 grades create_media_buy schema failures INVALID_REQUEST; all transports currently emit VALIDATION_ERROR",
+    strict=True,
+)
+def test_create_media_buy_typeadapter_error_uses_storyboard_invalid_request_code():
+    is_error, envelope = _call_mcp_tool_capturing_envelope(
+        "create_media_buy",
+        {"brand": "wiretest.example", "packages": [{}]},
+    )
+
+    assert is_error
+    assert_envelope_shape(envelope, "INVALID_REQUEST", recovery="correctable", message_substr="Field required")

--- a/tests/integration/test_mcp_typeadapter_validation_envelope.py
+++ b/tests/integration/test_mcp_typeadapter_validation_envelope.py
@@ -1,0 +1,71 @@
+"""MCP TypeAdapter validation errors are emitted as AdCP wire envelopes.
+
+These tests use the real in-memory FastMCP client and server:
+
+    Client(mcp) -> middleware -> FastMCP TypeAdapter -> CallToolResult
+
+The payloads fail before the tool body runs, so no database setup is required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastmcp import Client
+
+from src.core.main import mcp
+from tests.factories.principal import PrincipalFactory
+from tests.helpers import assert_envelope_shape
+
+pytestmark = pytest.mark.integration
+
+
+def _call_mcp_tool_capturing_envelope(tool_name: str, params: dict) -> tuple[bool, dict | None]:
+    """Invoke a tool through the real in-memory MCP client and parse error content."""
+
+    async def _call() -> tuple[bool, str | None]:
+        identity = PrincipalFactory.make_identity(protocol="mcp")
+        with (
+            patch("src.core.mcp_auth_middleware.resolve_identity_from_context", return_value=identity),
+            patch("src.services.delivery_webhook_scheduler.start_delivery_webhook_scheduler", AsyncMock()),
+            patch("src.services.delivery_webhook_scheduler.stop_delivery_webhook_scheduler", AsyncMock()),
+            patch("src.services.media_buy_status_scheduler.start_media_buy_status_scheduler", AsyncMock()),
+            patch("src.services.media_buy_status_scheduler.stop_media_buy_status_scheduler", AsyncMock()),
+        ):
+            async with Client(mcp) as client:
+                result = await client.call_tool(tool_name, params, raise_on_error=False)
+                text = next((c.text for c in result.content if hasattr(c, "text")), None)
+                return result.is_error, text
+
+    is_error, envelope_text = asyncio.run(_call())
+    return is_error, json.loads(envelope_text) if envelope_text else None
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "params", "message_substr", "field_prefix"),
+    [
+        (
+            "list_creatives",
+            {"filters": {"concept_ids": []}},
+            "filters.concept_ids",
+            "filters.concept_ids",
+        ),
+        (
+            "create_media_buy",
+            {"brand": "wiretest.example", "packages": [{}]},
+            "packages.0",
+            "packages[0].",
+        ),
+    ],
+)
+def test_typeadapter_validation_error_emits_adcp_envelope_on_mcp_wire(tool_name, params, message_substr, field_prefix):
+    is_error, envelope = _call_mcp_tool_capturing_envelope(tool_name, params)
+
+    assert is_error, f"{tool_name}: invalid typed params must produce a tool error"
+    assert envelope is not None, f"{tool_name}: no MCP wire error envelope captured"
+    assert_envelope_shape(envelope, "VALIDATION_ERROR", recovery="correctable", message_substr=message_substr)
+    assert envelope["errors"][0].get("suggestion"), f"{tool_name}: envelope must include a recovery suggestion"
+    assert envelope["errors"][0].get("field", "").startswith(field_prefix)

--- a/tests/integration/test_mcp_typeadapter_validation_envelope.py
+++ b/tests/integration/test_mcp_typeadapter_validation_envelope.py
@@ -58,6 +58,35 @@ def test_typeadapter_validation_error_emits_adcp_envelope_on_mcp_wire():
     assert "errors.pydantic.dev" not in envelope["errors"][0]["message"]
 
 
+def test_create_media_buy_missing_key_preserves_field_on_mcp_wire():
+    is_error, envelope = _call_mcp_tool_capturing_envelope(
+        "create_media_buy",
+        {
+            "brand": {"domain": "wiretest.example"},
+            "packages": [
+                {
+                    "product_id": "prod_1",
+                    "budget": 5000,
+                    "pricing_option_id": "cpm_usd_fixed",
+                }
+            ],
+            "start_time": "2026-08-01T00:00:00Z",
+            "end_time": "2026-09-01T00:00:00Z",
+            "po_number": "WIRE-1",
+        },
+    )
+
+    assert is_error
+    assert envelope is not None
+    assert_envelope_shape(
+        envelope,
+        "VALIDATION_ERROR",
+        recovery="correctable",
+        message_substr="Required field is missing",
+    )
+    assert envelope["errors"][0].get("field") == "idempotency_key"
+
+
 @pytest.mark.xfail(
     reason="AdCP 3.1 grades create_media_buy schema failures INVALID_REQUEST; all transports currently emit VALIDATION_ERROR",
     strict=True,

--- a/tests/integration/test_mcp_typeadapter_validation_envelope.py
+++ b/tests/integration/test_mcp_typeadapter_validation_envelope.py
@@ -68,7 +68,7 @@ def test_create_media_buy_missing_key_preserves_field_on_mcp_wire():
 
 @pytest.mark.xfail(
     reason=(
-        "Tracked in #1604: AdCP 3.1.0-beta.3 BR-UC-002-create-media-buy.feature "
+        "Tracked in #1604: AdCP 3.1.1 BR-UC-002-create-media-buy.feature "
         "@T-UC-002-inv-015-6 grades this in-body missing-field path INVALID_REQUEST; "
         "the current TypeAdapter boundary emits VALIDATION_ERROR"
     ),

--- a/tests/integration/test_mcp_unknown_field_handling.py
+++ b/tests/integration/test_mcp_unknown_field_handling.py
@@ -10,8 +10,8 @@ import os
 from unittest.mock import patch
 
 import pytest
-from fastmcp.exceptions import ToolError
 
+from src.core.exceptions import AdCPValidationError
 from tests.factories import PricingOptionFactory, ProductFactory, TenantFactory
 
 pytestmark = [pytest.mark.integration, pytest.mark.requires_db]
@@ -40,12 +40,12 @@ class TestMcpDevMode:
             assert result is not None
 
     def test_unknown_field_rejected(self, integration_db):
-        """Dev mode: unknown field causes ToolError — loud failure for schema drift detection."""
+        """Dev mode: unknown field fails loudly for schema drift detection."""
         from tests.harness.product import ProductEnv
 
         with ProductEnv(tenant_id=TENANT_ID) as env:
             _create_tenant_with_product()
-            with pytest.raises(ToolError, match="nonsense_field"):
+            with pytest.raises(AdCPValidationError, match="nonsense_field"):
                 env.call_mcp(brief="test ads", nonsense_field="bar")
 
     def test_deprecated_field_translated_even_in_dev(self, integration_db):

--- a/tests/integration/test_mcp_unknown_field_handling.py
+++ b/tests/integration/test_mcp_unknown_field_handling.py
@@ -53,7 +53,7 @@ class TestMcpDevMode:
                 result.wire_error_envelope,
                 "VALIDATION_ERROR",
                 recovery="correctable",
-                message_substr="Extra inputs are not permitted",
+                message_substr="Unexpected keyword argument",
             )
             assert result.wire_error_envelope["errors"][0]["field"] == "nonsense_field"
 

--- a/tests/integration/test_mcp_unknown_field_handling.py
+++ b/tests/integration/test_mcp_unknown_field_handling.py
@@ -11,8 +11,9 @@ from unittest.mock import patch
 
 import pytest
 
-from src.core.exceptions import AdCPValidationError
 from tests.factories import PricingOptionFactory, ProductFactory, TenantFactory
+from tests.harness.transport import Transport
+from tests.helpers import assert_envelope_shape
 
 pytestmark = [pytest.mark.integration, pytest.mark.requires_db]
 
@@ -45,8 +46,16 @@ class TestMcpDevMode:
 
         with ProductEnv(tenant_id=TENANT_ID) as env:
             _create_tenant_with_product()
-            with pytest.raises(AdCPValidationError, match="nonsense_field"):
-                env.call_mcp(brief="test ads", nonsense_field="bar")
+            result = env.call_via(Transport.MCP, brief="test ads", nonsense_field="bar")
+
+            assert result.is_error
+            assert_envelope_shape(
+                result.wire_error_envelope,
+                "VALIDATION_ERROR",
+                recovery="correctable",
+                message_substr="Extra inputs are not permitted",
+            )
+            assert result.wire_error_envelope["errors"][0]["field"] == "nonsense_field"
 
     def test_deprecated_field_translated_even_in_dev(self, integration_db):
         """Deprecated field translation works in dev mode (always active)."""

--- a/tests/unit/test_architecture_error_suggestion_enum_conformance.py
+++ b/tests/unit/test_architecture_error_suggestion_enum_conformance.py
@@ -1,0 +1,74 @@
+"""Oracle: each canonical buyer-facing suggestion constant matches the pinned
+``error-code.json`` ``enumMetadata`` ``suggestion`` for its error code.
+
+Companion to ``test_architecture_error_recovery_enum_conformance.py`` (which pins
+``recovery``). The ``enumMetadata`` block is normative — every error code carries
+its own canonical ``suggestion``, and a module-level constant that supplies the
+buyer-facing hint for one code must not carry another code's text.
+
+This locks in the per-code split where ``VALIDATION_ERROR_SUGGESTION`` had drifted
+to ``INVALID_REQUEST``'s canonical hint ("check request parameters and fix") while
+being emitted on ``VALIDATION_ERROR`` paths. It reddens if the two constants are
+swapped, mis-edited, or the spec advances a suggestion without the constant
+following. A per-site test asserting a hardcoded literal cannot catch a divergence
+between the constant and the spec — this oracle grounds it in the pinned enum.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.core import exceptions
+
+_PINNED_ENUM_PATH = Path(__file__).parent.parent / "fixtures" / "adcp_schemas_pinned" / "enums" / "error-code.json"
+
+
+def _pinned_suggestion_by_code() -> dict[str, str]:
+    """Return ``{error_code: suggestion}`` from the pinned enumMetadata block."""
+    meta = json.loads(_PINNED_ENUM_PATH.read_text())["enumMetadata"]
+    return {
+        code: entry["suggestion"] for code, entry in meta.items() if isinstance(entry, dict) and entry.get("suggestion")
+    }
+
+
+_SUGGESTION_BY_CODE = _pinned_suggestion_by_code()
+
+# (module_constant_name, error_code) for every constant that exposes a code's
+# canonical buyer-facing suggestion. Add a row when a new canonical-suggestion
+# constant is introduced so it is pinned to the spec from birth.
+_CANONICAL_SUGGESTION_CONSTANTS = [
+    ("INVALID_REQUEST_SUGGESTION", "INVALID_REQUEST"),
+    ("VALIDATION_ERROR_SUGGESTION", "VALIDATION_ERROR"),
+]
+
+
+def test_pinned_enum_suggestions_loaded() -> None:
+    """Meta-guard: the pinned enum loaded a representative set of suggestions, so the
+    parametrized oracle below can never silently degrade to zero graded cases."""
+    assert len(_SUGGESTION_BY_CODE) >= 50, (
+        f"Expected the pinned enumMetadata to define suggestions for many codes, got {len(_SUGGESTION_BY_CODE)}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("const_name", "code"),
+    _CANONICAL_SUGGESTION_CONSTANTS,
+    ids=[name for name, _ in _CANONICAL_SUGGESTION_CONSTANTS],
+)
+def test_suggestion_constant_matches_pinned_enum(const_name: str, code: str) -> None:
+    """Each canonical-suggestion constant must equal the pinned enum's suggestion for its code."""
+    assert code in _SUGGESTION_BY_CODE, (
+        f"{code!r} carries no suggestion in the pinned error-code.json enumMetadata; "
+        f"cannot ground {const_name}. Advance the pin or fix the mapping."
+    )
+    actual = getattr(exceptions, const_name)
+    expected = _SUGGESTION_BY_CODE[code]
+    assert actual == expected, (
+        f"{const_name} = {actual!r} but the pinned error-code.json enumMetadata says the "
+        f"{code} suggestion is {expected!r}. A code's canonical suggestion constant must carry "
+        f"that code's text, not another code's: fix the constant, or advance the pin if the spec "
+        f"changed the suggestion."
+    )

--- a/tests/unit/test_exception_normalization.py
+++ b/tests/unit/test_exception_normalization.py
@@ -1,0 +1,58 @@
+import pytest
+from pydantic import ValidationError
+
+from src.core.exceptions import AdCPValidationError, normalize_to_adcp_error
+from src.core.validation_helpers import adcp_validation_boundary
+
+
+def test_pydantic_validation_error_normalization_is_structured_and_sanitized():
+    error = ValidationError.from_exception_data(
+        title="call[create_media_buy]",
+        line_errors=[
+            {
+                "type": "missing",
+                "loc": ("packages", 0, "product_id"),
+                "input": {"secret": "buyer-input"},
+            }
+        ],
+    )
+
+    normalized = normalize_to_adcp_error(error)
+
+    assert isinstance(normalized, AdCPValidationError)
+    assert normalized.message == "Field required"
+    assert normalized.field == "packages[0].product_id"
+    assert normalized.details == {
+        "validation_errors": [
+            {
+                "loc": ["packages", 0, "product_id"],
+                "msg": "Field required",
+                "type": "missing",
+            }
+        ]
+    }
+    assert "buyer-input" not in normalized.message
+    assert "errors.pydantic.dev" not in normalized.message
+
+
+def test_a2a_validation_boundary_uses_shared_sanitized_normalization():
+    error = ValidationError.from_exception_data(
+        title="CreateMediaBuyRequest",
+        line_errors=[
+            {
+                "type": "missing",
+                "loc": ("packages", 0, "product_id"),
+                "input": {"secret": "buyer-input"},
+            }
+        ],
+    )
+
+    with pytest.raises(AdCPValidationError) as exc_info:
+        with adcp_validation_boundary():
+            raise error
+
+    assert exc_info.value.message == "Field required"
+    assert exc_info.value.field == "packages[0].product_id"
+    assert exc_info.value.details == normalize_to_adcp_error(error).details
+    assert "buyer-input" not in exc_info.value.message
+    assert "errors.pydantic.dev" not in exc_info.value.message

--- a/tests/unit/test_exception_normalization.py
+++ b/tests/unit/test_exception_normalization.py
@@ -3,6 +3,7 @@ from pydantic import ValidationError
 
 from src.core.exceptions import AdCPValidationError, normalize_to_adcp_error
 from src.core.validation_helpers import adcp_validation_boundary
+from tests.helpers import assert_no_raw_validation_leak
 
 
 def test_pydantic_validation_error_normalization_is_structured_and_sanitized():
@@ -32,7 +33,7 @@ def test_pydantic_validation_error_normalization_is_structured_and_sanitized():
         ]
     }
     assert "buyer-input" not in normalized.message
-    assert "errors.pydantic.dev" not in normalized.message
+    assert_no_raw_validation_leak(normalized.message)
 
 
 def test_a2a_validation_boundary_preserves_contextual_error_format():
@@ -55,6 +56,14 @@ def test_a2a_validation_boundary_preserves_contextual_error_format():
     assert "packages.0.product_id: Required field is missing" in exc_info.value.message
     assert exc_info.value.field == "packages[0].product_id"
     assert exc_info.value.suggestion == ("Provide the required 'packages.0.product_id' field and resend the request.")
-    assert exc_info.value.details is None
+    assert exc_info.value.details == {
+        "validation_errors": [
+            {
+                "loc": ["packages", 0, "product_id"],
+                "msg": "Field required",
+                "type": "missing",
+            }
+        ]
+    }
     assert "buyer-input" not in exc_info.value.message
-    assert "errors.pydantic.dev" not in exc_info.value.message
+    assert_no_raw_validation_leak(exc_info.value.message)

--- a/tests/unit/test_exception_normalization.py
+++ b/tests/unit/test_exception_normalization.py
@@ -35,7 +35,7 @@ def test_pydantic_validation_error_normalization_is_structured_and_sanitized():
     assert "errors.pydantic.dev" not in normalized.message
 
 
-def test_a2a_validation_boundary_uses_shared_sanitized_normalization():
+def test_a2a_validation_boundary_preserves_contextual_error_format():
     error = ValidationError.from_exception_data(
         title="CreateMediaBuyRequest",
         line_errors=[
@@ -51,8 +51,10 @@ def test_a2a_validation_boundary_uses_shared_sanitized_normalization():
         with adcp_validation_boundary():
             raise error
 
-    assert exc_info.value.message == "Field required"
+    assert "Invalid parameters:" in exc_info.value.message
+    assert "packages.0.product_id: Required field is missing" in exc_info.value.message
     assert exc_info.value.field == "packages[0].product_id"
-    assert exc_info.value.details == normalize_to_adcp_error(error).details
+    assert exc_info.value.suggestion == ("Provide the required 'packages.0.product_id' field and resend the request.")
+    assert exc_info.value.details is None
     assert "buyer-input" not in exc_info.value.message
     assert "errors.pydantic.dev" not in exc_info.value.message

--- a/tests/unit/test_mcp_compat_middleware.py
+++ b/tests/unit/test_mcp_compat_middleware.py
@@ -27,6 +27,7 @@ def _make_context(tool_name: str, arguments: dict | None):
 
     ctx = MagicMock()
     ctx.message = message
+    ctx.fastmcp_context = None
     # .copy() should return a new context with the replaced message
     ctx.copy = MagicMock(side_effect=lambda **kw: _make_copied_context(ctx, **kw))
     return ctx
@@ -174,7 +175,7 @@ class TestTypeAdapterValidationEnvelope:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ("tool_name", "arguments", "line_error", "field"),
+        ("tool_name", "arguments", "line_error", "field", "message"),
         [
             (
                 "list_creatives",
@@ -186,21 +187,23 @@ class TestTypeAdapterValidationEnvelope:
                     "ctx": {"field_type": "List", "min_length": 1, "actual_length": 0},
                 },
                 "filters.statuses",
+                "List should have at least 1 item",
             ),
             (
                 "create_media_buy",
-                {"packages": []},
+                {"packages": [{}]},
                 {
                     "type": "missing",
-                    "loc": ("buyer_ref",),
+                    "loc": ("packages", 0, "product_id"),
                     "input": {},
                 },
-                "buyer_ref",
+                "packages[0].product_id",
+                "Field required",
             ),
         ],
     )
     async def test_typeadapter_validation_errors_are_adcp_tool_errors(
-        self, middleware, tool_name, arguments, line_error, field
+        self, middleware, tool_name, arguments, line_error, field, message
     ):
         ctx = _make_context(tool_name, arguments)
         validation_error = _typeadapter_validation_error(tool_name, line_error)
@@ -214,10 +217,44 @@ class TestTypeAdapterValidationEnvelope:
             exc_info.value,
             "VALIDATION_ERROR",
             recovery="correctable",
-            message_substr=field,
+            message_substr=message,
             check_mcp_tool_error=True,
         )
         assert exc_info.value.envelope["errors"][0]["field"] == field
+        message = exc_info.value.envelope["errors"][0]["message"]
+        assert "input_value" not in message
+        assert "errors.pydantic.dev" not in message
+
+    @pytest.mark.asyncio
+    async def test_typeadapter_validation_errors_are_recorded_at_mcp_boundary(self, middleware):
+        ctx = _make_context("list_creatives", {"filters": {"statuses": []}})
+        identity = MagicMock(tenant_id="tenant-1", principal_id="buyer-1")
+        ctx.fastmcp_context = MagicMock()
+        ctx.fastmcp_context.get_state = AsyncMock(return_value=identity)
+        validation_error = _typeadapter_validation_error(
+            "list_creatives",
+            {
+                "type": "too_short",
+                "loc": ("filters", "statuses"),
+                "input": [],
+                "ctx": {"field_type": "List", "min_length": 1, "actual_length": 0},
+            },
+        )
+
+        with (
+            patch("src.core.config.is_production", return_value=False),
+            patch("src.core.mcp_compat_middleware.record_boundary_error") as record_error,
+            pytest.raises(AdCPToolError),
+        ):
+            await middleware.on_call_tool(ctx, AsyncMock(side_effect=validation_error))
+
+        record_error.assert_called_once_with(
+            "mcp",
+            "list_creatives",
+            ANY,
+            tenant_id="tenant-1",
+            principal_id="buyer-1",
+        )
 
 
 class TestMiddlewareEdgeCases:

--- a/tests/unit/test_mcp_compat_middleware.py
+++ b/tests/unit/test_mcp_compat_middleware.py
@@ -8,10 +8,11 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
+from src.core.exceptions import AdCPValidationError
 from src.core.mcp_compat_middleware import RequestCompatMiddleware
 from src.core.request_compat import NormalizationResult
 from src.core.tool_error_logging import AdCPToolError
-from tests.helpers import assert_envelope_shape
+from tests.helpers import assert_envelope_shape, assert_no_raw_validation_leak
 
 
 @pytest.fixture()
@@ -49,6 +50,16 @@ def _typeadapter_validation_error(tool_name: str, line_error: dict):
         title=f"call[{tool_name}]",
         line_errors=[line_error],
     )
+
+
+class _ValidationErrorRecord:
+    """Matcher that pins the typed boundary error passed to the recorder."""
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, AdCPValidationError) and other.error_code == "VALIDATION_ERROR"
+
+    def __repr__(self) -> str:
+        return "AdCPValidationError(error_code='VALIDATION_ERROR')"
 
 
 class TestMiddlewareCallsNormalizer:
@@ -190,14 +201,14 @@ class TestTypeAdapterValidationEnvelope:
                 "List should have at least 1 item",
             ),
             (
-                "create_media_buy",
-                {"packages": [{}]},
+                "list_creatives",
+                {"filters": {"format_ids": [{}]}},
                 {
                     "type": "missing",
-                    "loc": ("packages", 0, "product_id"),
+                    "loc": ("filters", "format_ids", 0, "agent_url"),
                     "input": {},
                 },
-                "packages[0].product_id",
+                "filters.format_ids[0].agent_url",
                 "Field required",
             ),
         ],
@@ -222,8 +233,7 @@ class TestTypeAdapterValidationEnvelope:
         )
         assert exc_info.value.envelope["errors"][0]["field"] == field
         wire_message = exc_info.value.envelope["errors"][0]["message"]
-        assert "input_value" not in wire_message
-        assert "errors.pydantic.dev" not in wire_message
+        assert_no_raw_validation_leak(wire_message)
 
     @pytest.mark.asyncio
     async def test_typeadapter_validation_errors_are_recorded_at_mcp_boundary(self, middleware):
@@ -248,10 +258,11 @@ class TestTypeAdapterValidationEnvelope:
         ):
             await middleware.on_call_tool(ctx, AsyncMock(side_effect=validation_error))
 
+        ctx.fastmcp_context.get_state.assert_awaited_once_with("identity")
         record_error.assert_called_once_with(
             "mcp",
             "list_creatives",
-            ANY,
+            _ValidationErrorRecord(),
             tenant_id="tenant-1",
             principal_id="buyer-1",
         )

--- a/tests/unit/test_mcp_compat_middleware.py
+++ b/tests/unit/test_mcp_compat_middleware.py
@@ -10,6 +10,8 @@ import pytest
 
 from src.core.mcp_compat_middleware import RequestCompatMiddleware
 from src.core.request_compat import NormalizationResult
+from src.core.tool_error_logging import AdCPToolError
+from tests.helpers import assert_envelope_shape
 
 
 @pytest.fixture()
@@ -36,6 +38,16 @@ def _make_copied_context(original, **kwargs):
     copied.message = kwargs.get("message", original.message)
     copied.copy = original.copy
     return copied
+
+
+def _typeadapter_validation_error(tool_name: str, line_error: dict):
+    """Build the same pydantic ValidationError shape FastMCP TypeAdapter raises."""
+    from pydantic import ValidationError
+
+    return ValidationError.from_exception_data(
+        title=f"call[{tool_name}]",
+        line_errors=[line_error],
+    )
 
 
 class TestMiddlewareCallsNormalizer:
@@ -155,6 +167,57 @@ class TestShouldRetry:
         exc = RuntimeError("unexpected")
         with patch("src.core.config.is_production", return_value=True):
             assert middleware._should_retry(exc) is False
+
+
+class TestTypeAdapterValidationEnvelope:
+    """FastMCP TypeAdapter validation errors become AdCP wire envelopes."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("tool_name", "arguments", "line_error", "field"),
+        [
+            (
+                "list_creatives",
+                {"filters": {"statuses": []}},
+                {
+                    "type": "too_short",
+                    "loc": ("filters", "statuses"),
+                    "input": [],
+                    "ctx": {"field_type": "List", "min_length": 1, "actual_length": 0},
+                },
+                "filters.statuses",
+            ),
+            (
+                "create_media_buy",
+                {"packages": []},
+                {
+                    "type": "missing",
+                    "loc": ("buyer_ref",),
+                    "input": {},
+                },
+                "buyer_ref",
+            ),
+        ],
+    )
+    async def test_typeadapter_validation_errors_are_adcp_tool_errors(
+        self, middleware, tool_name, arguments, line_error, field
+    ):
+        ctx = _make_context(tool_name, arguments)
+        validation_error = _typeadapter_validation_error(tool_name, line_error)
+        call_next = AsyncMock(side_effect=validation_error)
+
+        with patch("src.core.config.is_production", return_value=False):
+            with pytest.raises(AdCPToolError) as exc_info:
+                await middleware.on_call_tool(ctx, call_next)
+
+        assert_envelope_shape(
+            exc_info.value,
+            "VALIDATION_ERROR",
+            recovery="correctable",
+            message_substr=field,
+            check_mcp_tool_error=True,
+        )
+        assert exc_info.value.envelope["errors"][0]["field"] == field
 
 
 class TestMiddlewareEdgeCases:

--- a/tests/unit/test_mcp_compat_middleware.py
+++ b/tests/unit/test_mcp_compat_middleware.py
@@ -221,9 +221,9 @@ class TestTypeAdapterValidationEnvelope:
             check_mcp_tool_error=True,
         )
         assert exc_info.value.envelope["errors"][0]["field"] == field
-        message = exc_info.value.envelope["errors"][0]["message"]
-        assert "input_value" not in message
-        assert "errors.pydantic.dev" not in message
+        wire_message = exc_info.value.envelope["errors"][0]["message"]
+        assert "input_value" not in wire_message
+        assert "errors.pydantic.dev" not in wire_message
 
     @pytest.mark.asyncio
     async def test_typeadapter_validation_errors_are_recorded_at_mcp_boundary(self, middleware):

--- a/tests/unit/test_performance_index_behavioral.py
+++ b/tests/unit/test_performance_index_behavioral.py
@@ -388,7 +388,7 @@ class TestHighRiskA2A:
 
         assert "media_buy_id" in exc_info.value.message
         assert "performance_data" in exc_info.value.message
-        assert exc_info.value.field in {"media_buy_id", "performance_data"}
+        assert exc_info.value.field == "media_buy_id"
         assert exc_info.value.error_code == "VALIDATION_ERROR"
 
     # H9 ---------------------------------------------------------------

--- a/tests/unit/test_performance_index_behavioral.py
+++ b/tests/unit/test_performance_index_behavioral.py
@@ -386,9 +386,8 @@ class TestHighRiskA2A:
                 identity=mock_identity,
             )
 
-        # Validation error mentions the required fields
-        msg = str(exc_info.value)
-        assert "media_buy_id" in msg or "performance_data" in msg
+        assert exc_info.value.message == "Field required"
+        assert exc_info.value.field in {"media_buy_id", "performance_data"}
         assert exc_info.value.error_code == "VALIDATION_ERROR"
 
     # H9 ---------------------------------------------------------------

--- a/tests/unit/test_performance_index_behavioral.py
+++ b/tests/unit/test_performance_index_behavioral.py
@@ -386,7 +386,8 @@ class TestHighRiskA2A:
                 identity=mock_identity,
             )
 
-        assert exc_info.value.message == "Field required"
+        assert "media_buy_id" in exc_info.value.message
+        assert "performance_data" in exc_info.value.message
         assert exc_info.value.field in {"media_buy_id", "performance_data"}
         assert exc_info.value.error_code == "VALIDATION_ERROR"
 

--- a/tests/unit/test_validation_errors.py
+++ b/tests/unit/test_validation_errors.py
@@ -3,6 +3,7 @@
 import pytest
 from pydantic import BaseModel, ValidationError
 
+from src.core.exceptions import AdCPValidationError
 from src.core.schemas import CreateMediaBuyRequest
 from src.core.validation_helpers import first_validation_error_field, format_validation_error
 
@@ -26,6 +27,34 @@ def test_first_validation_error_field_uses_bracket_notation():
         _Req(packages=[{"budget": "not-a-number"}])
 
     assert first_validation_error_field(exc_info.value) == "packages[0].budget"
+
+
+def test_first_validation_error_field_is_owned_by_exception_leaf_module():
+    """The field-path helper must not recreate an exceptions/helpers import cycle."""
+    assert first_validation_error_field.__module__ == "src.core.exceptions"
+
+
+def test_create_media_buy_boundary_validation_preserves_field_suggestion():
+    """Boundary request construction keeps the current field-specific hint."""
+    from src.core.tools.media_buy_create import _build_create_media_buy_request
+
+    with pytest.raises(AdCPValidationError) as exc_info:
+        _build_create_media_buy_request(
+            brand={"domain": "wiretest.example"},
+            packages=None,
+            start_time=None,
+            end_time=None,
+            po_number=None,
+            reporting_webhook=None,
+            context=None,
+            ext=None,
+            account=None,
+            idempotency_key=None,
+        )
+
+    error = exc_info.value
+    assert error.field == "idempotency_key"
+    assert error.suggestion == ("Provide the required 'idempotency_key' field and resend the request.")
 
 
 def test_brand_target_audience_must_be_string():

--- a/tests/unit/test_validation_errors.py
+++ b/tests/unit/test_validation_errors.py
@@ -50,6 +50,7 @@ def test_create_media_buy_boundary_validation_preserves_field_suggestion():
             ext=None,
             account=None,
             idempotency_key=None,
+            paused=None,
         )
 
     error = exc_info.value


### PR DESCRIPTION
## Summary

Fixes #1504.

FastMCP TypeAdapter validation can fail before an MCP tool body runs. Those failures previously escaped as raw Pydantic errors instead of the two-layer AdCP error envelope used at the transport boundaries.

## Changes

- Enrich Pydantic `ValidationError` normalization in the shared `normalize_to_adcp_error` path with a structured field and per-error details.
- Build the buyer-facing message from Pydantic's first safe error message instead of `str(exc)`, avoiding input-value and versioned documentation URL leakage.
- Route terminal MCP TypeAdapter failures through the existing `_translate_to_tool_error` boundary while preserving the production deep-strip retry.
- Record TypeAdapter rejection through the normal MCP boundary audit/activity path, using the identity already resolved by middleware.
- Reuse the structured validation-details builder at the A2A/in-body boundary so all three validation-envelope paths carry the same safe per-error projection.
- Cover real indexed field paths, sanitized messages, retry and no-op-strip behavior, the exact audit identity key and typed record, the in-memory MCP wire envelope, and the shared A2A validation boundary.
- Track the existing `create_media_buy` `INVALID_REQUEST` storyboard mismatch as a strict xfail instead of asserting the current cross-transport gap as intended behavior.
- Link the two dormant validation-error BDD gates to follow-up #1652, which is separate from the error-code classification work in #1604.

## Risk

The behavior change is limited to Pydantic validation failures translated at transport boundaries. The A2A/in-body boundary now adds the same buyer-safe `details.validation_errors` projection already used by MCP and REST. Existing typed `AdCPError` values pass through unchanged, ordinary `ValueError` handling is unchanged, and non-TypeAdapter MCP exceptions still propagate normally.

## Verification

```sh
uv run pytest -q tests/unit/test_exception_normalization.py tests/unit/test_mcp_compat_middleware.py tests/integration/test_mcp_typeadapter_validation_envelope.py tests/unit/test_validation_errors.py tests/unit/test_architecture_error_envelope_two_layer.py tests/unit/test_error_format_consistency.py
uv run pytest tests/unit/ tests/harness/ -q --tb=line
uv run pytest -q -rs tests/harness/test_forward_compat_acceptance.py tests/integration/test_a2a_error_responses.py tests/integration/test_idempotency_wire_matrix.py tests/integration/test_list_creatives_concept_filter.py tests/integration/test_mcp_error_envelope.py tests/integration/test_mcp_typeadapter_validation_envelope.py tests/integration/test_mcp_unknown_field_handling.py tests/unit/test_exception_normalization.py tests/unit/test_mcp_compat_middleware.py tests/unit/test_performance_index_behavioral.py tests/unit/test_validation_errors.py
uv run pytest -q -rx tests/bdd/test_uc018_list_creatives.py -k 'test_validation_failure__description'
uv run pytest -q -rx tests/bdd/test_uc002_create_media_buy.py -k 'test_inv6_holds__creative_asset_lacking_a_valid_asset_type_discriminator_is_rejected'
uv run ruff format --check src/core/exceptions.py src/core/mcp_compat_middleware.py src/core/validation_helpers.py tests/bdd/conftest.py tests/harness/test_forward_compat_acceptance.py tests/helpers tests/integration/test_a2a_error_responses.py tests/integration/test_list_creatives_concept_filter.py tests/integration/test_mcp_typeadapter_validation_envelope.py tests/unit/test_exception_normalization.py tests/unit/test_mcp_compat_middleware.py tests/unit/test_performance_index_behavioral.py tests/unit/test_validation_errors.py
uv run ruff check src/core/exceptions.py src/core/mcp_compat_middleware.py src/core/validation_helpers.py tests/bdd/conftest.py tests/harness/test_forward_compat_acceptance.py tests/helpers tests/integration/test_a2a_error_responses.py tests/integration/test_list_creatives_concept_filter.py tests/integration/test_mcp_typeadapter_validation_envelope.py tests/unit/test_exception_normalization.py tests/unit/test_mcp_compat_middleware.py tests/unit/test_performance_index_behavioral.py tests/unit/test_validation_errors.py
uv run mypy src/ --config-file=mypy.ini
uv run python .pre-commit-hooks/check_code_duplication.py
```

The database-backed cases in the touched integration modules skip locally when
`DATABASE_URL` is unavailable; repository CI provides the PostgreSQL run.
