### PR TITLE
fix: advertise only backed creative-agent capabilities (drop unbacked 'delivery')

### DIFF
--- a/docs/test-obligations/UC-005-discover-creative-formats.md
+++ b/docs/test-obligations/UC-005-discover-creative-formats.md
@@ -161,7 +161,7 @@ Source: BR-UC-005-main-mcp.md
 **Given** the creative agent registry includes referral information for additional agents
 **When** the Buyer calls `list_creative_formats`
 **Then** the response includes `creative_agents` referrals with capability information
-**And** each referral includes agent URL and capabilities (validation, assembly, generation, preview, delivery)
+**And** each referral includes agent URL and exactly the backed capabilities (validation, assembly, preview) — capabilities are commitments; unbacked values (e.g. delivery, generation) must not be advertised
 **Business Rule** POST-S4
 **Priority** P2 -- referral completeness
 

--- a/src/core/tools/creative_formats.py
+++ b/src/core/tools/creative_formats.py
@@ -22,6 +22,7 @@ from adcp.types import (
     AssetContentType,
     AudioFormatAsset,
     ContextObject,
+    CreativeAgentCapability,
     HtmlFormatAsset,
     ImageFormatAsset,
     TextFormatAsset,
@@ -42,6 +43,26 @@ from src.core.helpers import enum_value
 from src.core.tool_context import ToolContext
 
 logger = logging.getLogger(__name__)
+
+# Capabilities advertised for every creative agent referral in
+# list_creative_formats. AdCP design principle: capabilities are commitments —
+# the conformance runner probes each advertised capability, so only declare
+# what the registry integration actually backs:
+#   - validation/preview: backed by the agent's `preview_creative` tool
+#     (CreativeAgentRegistry.preview_creative, used by sync_creatives for
+#     validation + preview generation).
+#   - assembly: backed by the agent's `build_creative` tool
+#     (CreativeAgentRegistry.build_creative, used by sync_creatives refinement).
+#   - delivery is deliberately NOT advertised: it commits to variant-level
+#     delivery reporting via a `get_creative_delivery` task, which this agent
+#     does not implement.
+# All configured agents (default + tenant DB agents) share the registry's
+# uniform client surface, so one static set is truthful for all of them.
+ADVERTISED_CREATIVE_AGENT_CAPABILITIES: list[CreativeAgentCapability] = [
+    CreativeAgentCapability.validation,
+    CreativeAgentCapability.assembly,
+    CreativeAgentCapability.preview,
+]
 
 
 def _ensure_backward_compatible_format[FormatT: AdcpFormat](f: FormatT) -> FormatT:
@@ -432,7 +453,6 @@ def _list_creative_formats_impl(
     )
 
     # Build creative_agents referrals from registry (POST-S4)
-    from adcp.types import CreativeAgentCapability
     from adcp.types.generated_poc.media_buy.list_creative_formats_response import (
         CreativeAgent as AdcpCreativeAgent,
     )
@@ -447,12 +467,7 @@ def _list_creative_formats_impl(
                     AdcpCreativeAgent(
                         agent_url=agent.agent_url,
                         agent_name=agent.name,
-                        capabilities=[
-                            CreativeAgentCapability.validation,
-                            CreativeAgentCapability.assembly,
-                            CreativeAgentCapability.preview,
-                            CreativeAgentCapability.delivery,
-                        ],
+                        capabilities=list(ADVERTISED_CREATIVE_AGENT_CAPABILITIES),
                     )
                 )
     except Exception:

--- a/src/core/tools/creative_formats.py
+++ b/src/core/tools/creative_formats.py
@@ -56,13 +56,18 @@ logger = logging.getLogger(__name__)
 #   - delivery is deliberately NOT advertised: it commits to variant-level
 #     delivery reporting via a `get_creative_delivery` task, which this agent
 #     does not implement.
-# All configured agents (default + tenant DB agents) share the registry's
-# uniform client surface, so one static set is truthful for all of them.
-ADVERTISED_CREATIVE_AGENT_CAPABILITIES: list[CreativeAgentCapability] = [
+# All configured agents (default + tenant DB agents) are called through the
+# registry's uniform client surface, and agent config carries no per-agent
+# capability metadata yet, so a single static set is the best truthful
+# declaration available today. Caveat: the registry does not verify a remote
+# agent's tool surface up front — a tenant-registered agent that lacks one of
+# these tools fails at call time. Per-agent capability tracking is the
+# follow-up that would close that gap.
+ADVERTISED_CREATIVE_AGENT_CAPABILITIES: tuple[CreativeAgentCapability, ...] = (
     CreativeAgentCapability.validation,
     CreativeAgentCapability.assembly,
     CreativeAgentCapability.preview,
-]
+)
 
 
 def _ensure_backward_compatible_format[FormatT: AdcpFormat](f: FormatT) -> FormatT:

--- a/tests/bdd/steps/generic/then_payload.py
+++ b/tests/bdd/steps/generic/then_payload.py
@@ -134,10 +134,14 @@ def then_referral_fields(ctx: dict) -> None:
     assert resp is not None, "Expected a response"
     referrals = resp.creative_agents
     assert referrals, "No referrals to verify -- expected at least one creative agent"
-    # Capabilities are commitments (AdCP design principle): only the set backed
-    # by the registry integration may be advertised. `delivery` is excluded —
-    # get_creative_delivery is unimplemented.
-    known_capabilities = {"validation", "assembly", "preview"}
+    # Capabilities are commitments (AdCP design principle): referrals must
+    # advertise exactly the backed set — extras are unbacked commitments,
+    # omissions are silent capability loss. Derived from the production
+    # constant; the unit-level policy anchor
+    # (test_creative_formats_behavioral.py) stays hardcoded on purpose.
+    from src.core.tools.creative_formats import ADVERTISED_CREATIVE_AGENT_CAPABILITIES
+
+    known_capabilities = {c.value for c in ADVERTISED_CREATIVE_AGENT_CAPABILITIES}
     for ref in referrals:
         url_value = ref.agent_url
         assert url_value, f"Missing agent_url in referral: {ref}"
@@ -148,8 +152,10 @@ def then_referral_fields(ctx: dict) -> None:
         assert isinstance(caps, (list, tuple)), f"capabilities should be a list, got: {type(caps).__name__}"
         assert caps, "capabilities should be non-empty, got empty list"
         cap_strs = {str(c.value) if isinstance(c, Enum) else str(c) for c in caps}
-        unknown = cap_strs - known_capabilities
-        assert not unknown, f"Unknown capabilities: {unknown}. Expected subset of {known_capabilities}"
+        assert cap_strs == known_capabilities, (
+            f"Advertised capabilities {cap_strs} != backed set {known_capabilities} "
+            "(extras are unbacked commitments; omissions are silent capability loss)"
+        )
 
 
 # -- Format field presence -----------------------------------------------------

--- a/tests/bdd/steps/generic/then_payload.py
+++ b/tests/bdd/steps/generic/then_payload.py
@@ -134,7 +134,10 @@ def then_referral_fields(ctx: dict) -> None:
     assert resp is not None, "Expected a response"
     referrals = resp.creative_agents
     assert referrals, "No referrals to verify -- expected at least one creative agent"
-    known_capabilities = {"validation", "assembly", "preview", "delivery"}
+    # Capabilities are commitments (AdCP design principle): only the set backed
+    # by the registry integration may be advertised. `delivery` is excluded —
+    # get_creative_delivery is unimplemented.
+    known_capabilities = {"validation", "assembly", "preview"}
     for ref in referrals:
         url_value = ref.agent_url
         assert url_value, f"Missing agent_url in referral: {ref}"

--- a/tests/integration/test_creative_formats_pagination.py
+++ b/tests/integration/test_creative_formats_pagination.py
@@ -115,9 +115,13 @@ class TestCreativeAgentReferrals:
         assert response.creative_agents is not None
         for agent in response.creative_agents:
             assert agent.capabilities is not None
-            # Verify expected capability types — exactly the backed set
+            # Verify expected capability types — exactly the backed set,
+            # derived from the production constant (the unit-level policy
+            # anchor stays hardcoded in test_creative_formats_behavioral.py)
+            from src.core.tools.creative_formats import ADVERTISED_CREATIVE_AGENT_CAPABILITIES
+
             cap_values = {c.value for c in agent.capabilities}
-            assert cap_values == {"validation", "assembly", "preview"}
+            assert cap_values == {c.value for c in ADVERTISED_CREATIVE_AGENT_CAPABILITIES}
 
     def test_creative_agent_has_name(self, integration_db):
         """UC-005-MAIN-MCP-13: each referral includes agent name."""

--- a/tests/integration/test_creative_formats_pagination.py
+++ b/tests/integration/test_creative_formats_pagination.py
@@ -97,7 +97,14 @@ class TestCreativeAgentReferrals:
             assert agent.agent_url is not None
 
     def test_creative_agent_has_capabilities(self, integration_db):
-        """UC-005-MAIN-MCP-13: each referral includes capability information."""
+        """UC-005-MAIN-MCP-13: each referral includes capability information.
+
+        AdCP design principle: capabilities are commitments — the referral
+        advertises only capabilities backed by the registry integration
+        (validation/preview via preview_creative, assembly via build_creative).
+        `delivery` must NOT be advertised while get_creative_delivery is
+        unimplemented.
+        """
         formats = [_make_format("d1", "Display Banner")]
         with CreativeFormatsEnv() as env:
             TenantFactory(tenant_id="test_tenant")
@@ -108,13 +115,9 @@ class TestCreativeAgentReferrals:
         assert response.creative_agents is not None
         for agent in response.creative_agents:
             assert agent.capabilities is not None
-            assert len(agent.capabilities) > 0
-            # Verify expected capability types
+            # Verify expected capability types — exactly the backed set
             cap_values = {c.value for c in agent.capabilities}
-            assert "validation" in cap_values
-            assert "assembly" in cap_values
-            assert "preview" in cap_values
-            assert "delivery" in cap_values
+            assert cap_values == {"validation", "assembly", "preview"}
 
     def test_creative_agent_has_name(self, integration_db):
         """UC-005-MAIN-MCP-13: each referral includes agent name."""

--- a/tests/unit/test_creative_formats_behavioral.py
+++ b/tests/unit/test_creative_formats_behavioral.py
@@ -605,6 +605,7 @@ def _call_impl_raw(
     formats: list[Format],
     registry_side_effect: Exception | None = None,
     errors: list | None = None,
+    agents: list | None = None,
 ):
     """Call _list_creative_formats_impl and return the full response (not just formats).
 
@@ -612,6 +613,7 @@ def _call_impl_raw(
         formats: Formats returned by healthy agents.
         registry_side_effect: If set, get_creative_agent_registry() raises this.
         errors: List of AdCP Error objects to include as per-agent failures.
+        agents: CreativeAgent instances returned by _get_tenant_agents (referrals).
     """
     from src.core.creative_agent_registry import FormatFetchResult
     from src.core.tools.creative_formats import _list_creative_formats_impl
@@ -647,7 +649,7 @@ def _call_impl_raw(
 
         mock_reg.list_all_formats_with_errors = mock_list_formats_with_errors
         mock_reg.list_all_formats = mock_list_formats
-        mock_reg._get_tenant_agents = MagicMock(return_value=[])
+        mock_reg._get_tenant_agents = MagicMock(return_value=agents or [])
         mock_registry.return_value = mock_reg
         mock_audit.return_value = MagicMock()
 
@@ -868,3 +870,51 @@ class TestAgentReferralFailureLogsWarning:
         assert any("referral" in msg.lower() or "agent" in msg.lower() for msg in warning_msgs), (
             f"Expected a warning about agent referral failure, got: {warning_msgs}"
         )
+
+
+class TestReferralCapabilitiesAreCommitments:
+    """Advertised creative-agent capabilities must all be backed by real tasks.
+
+    AdCP design principle: capabilities are commitments — the conformance
+    runner probes every advertised capability. Advertising `delivery` commits
+    the agent to variant-level delivery reporting via a `get_creative_delivery`
+    task. This agent does not implement that task, so `delivery` must not
+    appear in the referral capabilities.
+    """
+
+    def test_referral_capabilities_exclude_delivery_while_unimplemented(self):
+        """creative_agents referrals advertise only backed capabilities.
+
+        Guard pair: if get_creative_delivery is ever implemented on the
+        registry, the hasattr assertion below fails, prompting re-evaluation
+        of the advertised set alongside the exclusion assertion.
+        """
+        from src.core.creative_agent_registry import CreativeAgent, CreativeAgentRegistry
+
+        assert not hasattr(CreativeAgentRegistry, "get_creative_delivery"), (
+            "get_creative_delivery is now implemented — re-evaluate whether "
+            "`delivery` should be added back to ADVERTISED_CREATIVE_AGENT_CAPABILITIES"
+        )
+
+        formats = [_make_format("display_300x250", "Display 300x250")]
+        agents = [
+            CreativeAgent(
+                agent_url=DEFAULT_AGENT_URL,
+                name="AdCP Standard Creative Agent",
+                enabled=True,
+                priority=1,
+            )
+        ]
+
+        response = _call_impl_raw(formats, agents=agents)
+
+        assert response.creative_agents, "Expected creative_agents referrals in response"
+        for referral in response.creative_agents:
+            cap_values = {c.value for c in referral.capabilities}
+            assert "delivery" not in cap_values, (
+                f"`delivery` advertised without a get_creative_delivery task "
+                f"(capabilities are commitments): {cap_values}"
+            )
+            assert cap_values == {"validation", "assembly", "preview"}, (
+                f"Advertised capabilities must be exactly the backed set, got {cap_values}"
+            )


### PR DESCRIPTION
## What

`list_creative_formats` creative-agent referrals previously advertised all four values of the AdCP `creative-agent-capability` enum: `validation`, `assembly`, `preview`, and `delivery`. This PR drops `delivery` and centralizes the advertised set in a documented module-level constant, `ADVERTISED_CREATIVE_AGENT_CAPABILITIES`, in `src/core/tools/creative_formats.py`.

## Why

AdCP's design principle is that **capabilities are commitments**: anything a referral advertises is fair game for a buyer (and the conformance runner) to exercise. Advertising `delivery` commits the referred creative agent to variant-level delivery reporting via a `get_creative_delivery` task — and no such task exists anywhere in this codebase. The remaining three are genuinely backed by the registry integration:

- `validation` / `preview` — backed by the agent's `preview_creative` tool (`CreativeAgentRegistry.preview_creative`, used by `sync_creatives` for validation and preview generation)
- `assembly` — backed by the agent's `build_creative` tool (`CreativeAgentRegistry.build_creative`, used by `sync_creatives` refinement)

All configured agents (default + tenant DB agents) share the registry's uniform client surface, so one static set is truthful for all of them.

## Spec

AdCP 3.1.0-beta.3 (`adcp==5.7.0` pin), `list_creative_formats` response `creative_agents[].capabilities` / the `creative-agent-capability` enum. Conformance grading probes advertised capabilities; the `delivery` exclusion is otherwise ungraded (no `get_creative_delivery` implementation to grade).

## Changes

- `src/core/tools/creative_formats.py` — hoist `CreativeAgentCapability` to a module-level import; add `ADVERTISED_CREATIVE_AGENT_CAPABILITIES = [validation, assembly, preview]` with per-entry backing documentation; referral construction uses the constant
- `tests/unit/test_creative_formats_behavioral.py` — new `TestReferralCapabilitiesAreCommitments` guard pair: referrals advertise exactly the backed set, plus a `hasattr` tripwire that fails if `CreativeAgentRegistry` ever grows `get_creative_delivery` (prompting re-evaluation); `_call_impl_raw` gains an `agents` param to inject referrals
- `tests/integration/test_creative_formats_pagination.py` — `test_creative_agent_has_capabilities` tightened from membership checks (including `delivery`) to an exact-set assertion
- `tests/bdd/steps/generic/then_payload.py` — `known_capabilities` tightened to the backed set

## Verification

- `make quality` green (format, lint, mypy, 5145 unit tests passed)
- `scripts/run-test.sh tests/integration/test_creative_formats_pagination.py -q` — 16 passed against real PostgreSQL
- Duplication baseline unchanged (`check_code_duplication.py`: src 36 / tests 89 / scripts 0, all unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)