### PR TITLE
fix: change AdCPConfigurationError default recovery from terminal to correctable

### DIFF
--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -558,13 +558,19 @@ class AdCPConfigurationError(AdCPError):
     """Server-side configuration is broken (500).
 
     Raised when encrypted secrets cannot be decrypted (key rotation,
-    corruption, missing ENCRYPTION_KEY). Callers should NOT silently
-    fall back — the configuration needs admin intervention, so recovery is
-    ``terminal`` (inherited): the buyer has no lever to fix server config.
+    corruption, missing ENCRYPTION_KEY), or when a required environment
+    variable (e.g. ``TMP_DISCOVERY_API_KEYS``) is absent or empty.
+
+    Recovery is ``correctable``: an operator can fix the configuration
+    (set the env var, rotate the key, etc.) and the service will recover.
+    This is distinct from ``terminal`` (no recovery possible) — the
+    configuration *can* be corrected; it just requires operator action
+    rather than buyer action.
     """
 
     _default_status_code: ClassVar[int] = 500
     _default_error_code: ClassVar[str] = "CONFIGURATION_ERROR"
+    _default_recovery: ClassVar[RecoveryHint] = "correctable"
 
 
 class AdCPServiceUnavailableError(AdCPError):

--- a/tests/unit/test_adcp_exceptions.py
+++ b/tests/unit/test_adcp_exceptions.py
@@ -230,6 +230,19 @@ class TestRecoveryClassification:
         exc = AdCPAuthorizationError("forbidden")
         assert exc.recovery == "terminal"
 
+    def test_configuration_error_defaults_to_correctable(self):
+        """AdCPConfigurationError defaults to recovery='correctable'.
+
+        Operator can fix missing/broken config (env var, key rotation,
+        missing ENCRYPTION_KEY) and the service will recover — which is
+        the definition of correctable, not terminal. The buyer has no
+        lever, but the *operator* does.
+        """
+        from src.core.exceptions import AdCPConfigurationError
+
+        exc = AdCPConfigurationError("ENCRYPTION_KEY missing")
+        assert exc.recovery == "correctable"
+
     def test_not_found_error_defaults_to_terminal(self):
         """AdCPNotFoundError (the *base*) defaults to recovery='terminal'.
 


### PR DESCRIPTION
## Summary

Changes `AdCPConfigurationError._default_recovery` from the inherited `"terminal"` to `"correctable"`.

## Motivation

`terminal` means "no recovery is possible". That is wrong for configuration errors: an operator can set the missing env var, rotate the encryption key, or fix the adapter config — and the service will recover. The buyer has no lever, but the *operator* does, which is the definition of `correctable`.

This was surfaced during review of #1197 (TMP integration), where the discovery route raises `AdCPConfigurationError` for a missing `TMP_DISCOVERY_API_KEYS` env var. Konstantin noted the change is cross-cutting and should be reviewed independently.

## Affected call sites (~14 on main)

| File | Context |
|------|---------|
| `src/adapters/base.py:249` | Adapter missing-field guard |
| `src/adapters/google_ad_manager.py:155,172,312,321,450` | 5 GAM config errors |
| `src/core/database/models.py:183,648,1312` | Fernet decrypt failures (Gemini key, OIDC secret, GAM JSON) |
| `src/core/tools/creatives/_processing.py:217,535` | Creative processing config errors |
| `src/services/ai/factory.py:154` | AI factory config error |

For every one of these: the operator can fix the configuration and the service recovers. None are permanently unrecoverable.

## Changes

- `src/core/exceptions.py` — adds `_default_recovery = "correctable"` to `AdCPConfigurationError`; updates docstring to reflect the corrected semantics
- `tests/unit/test_adcp_exceptions.py` — adds `test_configuration_error_defaults_to_correctable` to `TestRecoveryClassification`, pinning the new default alongside the existing per-subclass recovery tests

## Cross-references

- Surfaced in: #1197 (TMP integration PR, Round 11 review by @KonstantinMirin)