### PR TITLE
test(bdd): wire UC-018 BR-RULE-034 cross-principal isolation scenario…

### DIFF
--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -2846,13 +2846,18 @@ def _harness_env(request: pytest.FixtureRequest, ctx: dict) -> Generator[None, N
             yield
 
     elif uc == "UC-018":
-        # list_creatives — the wired storyboard scenarios are @list-after-sync
-        # (#1405) and @concept-id (#1407). The remaining UC-018 scenarios
-        # (main/partition/boundary/other filter siblings) have no step definitions
-        # yet, so xfail fast at the fixture (mirrors UC-002/006/011) rather than
-        # spinning up a DB per scenario only to auto-xfail at the first missing step.
+        # list_creatives — the wired scenarios are @list-after-sync (#1405),
+        # @concept-id (#1407), and the @BR-RULE-034 cross-principal isolation
+        # invariants (#1503). The remaining UC-018 scenarios (main/partition/
+        # boundary/other filter siblings) have no step definitions yet, so xfail
+        # fast at the fixture (mirrors UC-002/006/011) rather than spinning up a
+        # DB per scenario only to auto-xfail at the first missing step.
+        #
+        # BR-RULE-034 is unambiguous here: this branch only runs for T-UC-018-*
+        # scenarios (see _detect_uc), so the tag never collides with the UC-006
+        # BR-RULE-034 scenarios routed elsewhere.
         marker_names = {m.name for m in request.node.iter_markers()}
-        if marker_names & {"list-after-sync", "concept-id"}:
+        if marker_names & {"list-after-sync", "concept-id", "BR-RULE-034"}:
             # CreativeListEnv mocks only the audit logger; DB, repository, and
             # query building are real. The Background auth step switches the env
             # principal; the seed step owns the creatives under it.
@@ -2864,7 +2869,8 @@ def _harness_env(request: pytest.FixtureRequest, ctx: dict) -> Generator[None, N
                 yield
         else:
             pytest.xfail(
-                "UC-018 harness wired only for the @list-after-sync (#1405) and @concept-id (#1407) storyboard scenarios"
+                "UC-018 harness wired only for the @list-after-sync (#1405), @concept-id (#1407), "
+                "and @BR-RULE-034 isolation (#1503) scenarios"
             )
 
     elif uc == "UC-011":

--- a/tests/bdd/steps/domain/uc003_ext_error_scenarios.py
+++ b/tests/bdd/steps/domain/uc003_ext_error_scenarios.py
@@ -44,21 +44,20 @@ def _inject_privilege_error(ctx: dict) -> None:
 
 @given(parsers.parse('the Buyer is authenticated as principal "{principal_id}"'))
 def given_buyer_authenticated_as(ctx: dict, principal_id: str) -> None:
-    """Override the authenticated principal to a specific principal_id.
+    """Authenticate as *principal_id* and mark the auth state.
 
-    Sets ctx['principal_override'] so the When step can build an identity
-    with a different principal_id. Also marks the auth state.
+    Delegates the principal switch, the canonical ``ctx["principal_id"]``, and the
+    identity post-condition to the shared ``authenticate_env_as`` helper; adds only
+    the use-case-specific ``has_auth`` flag.
+
+    NOTE: this module is currently dormant (see ``steps/generic/_auth.py``) — it is
+    not registered in ``tests/bdd/conftest.py`` ``pytest_plugins`` and UC-003 is not
+    wired into the BDD harness, so these steps do not execute (UC-003 update
+    scenarios auto-xfail). Kept on the shared helper so it is correct when UC-003 is
+    activated.
     """
-    ctx["principal_override"] = principal_id
+    authenticate_env_as(ctx, principal_id)
     ctx["has_auth"] = True
-    # Update the env identity to use this principal_id (shared helper).
-    env = authenticate_env_as(ctx, principal_id)
-    # Post-condition: verify the identity mutation took effect
-    actual = env.identity.principal_id
-    assert actual == principal_id, (
-        f"env.identity.principal_id is {actual!r} after setting "
-        f"env._principal_id to {principal_id!r} — cache not rebuilt"
-    )
 
 
 @given(parsers.parse('the principal "{principal_id}" does not exist in the database'))

--- a/tests/bdd/steps/domain/uc003_ext_error_scenarios.py
+++ b/tests/bdd/steps/domain/uc003_ext_error_scenarios.py
@@ -14,6 +14,7 @@ from pytest_bdd import given, parsers, then
 
 from tests.bdd.steps._harness_db import db_session
 from tests.bdd.steps.domain.uc003_update_media_buy import _ensure_update_defaults
+from tests.bdd.steps.generic._auth import authenticate_env_as
 
 
 def _inject_privilege_error(ctx: dict) -> None:
@@ -50,10 +51,8 @@ def given_buyer_authenticated_as(ctx: dict, principal_id: str) -> None:
     """
     ctx["principal_override"] = principal_id
     ctx["has_auth"] = True
-    # Update the env identity to use this principal_id
-    env = ctx["env"]
-    env._identity_cache.clear()
-    env._principal_id = principal_id
+    # Update the env identity to use this principal_id (shared helper).
+    env = authenticate_env_as(ctx, principal_id)
     # Post-condition: verify the identity mutation took effect
     actual = env.identity.principal_id
     assert actual == principal_id, (

--- a/tests/bdd/steps/domain/uc003_update_media_buy.py
+++ b/tests/bdd/steps/domain/uc003_update_media_buy.py
@@ -15,6 +15,7 @@ from typing import Any
 from pytest_bdd import given, parsers, then, when
 
 from tests.bdd.steps._harness_db import db_session
+from tests.bdd.steps.generic._auth import authenticate_env_as
 from tests.bdd.steps.generic._dispatch import dispatch_request
 from tests.bdd.steps.generic.given_media_buy import _resolve_date_token
 
@@ -2054,9 +2055,7 @@ def given_authenticated_principal(ctx: dict, principal: str) -> None:
     Updates the env's identity to use the specified principal_id.
     """
     principal_id = principal.strip()
-    env = ctx["env"]
-    env._identity_cache.clear()
-    env._principal_id = principal_id
+    authenticate_env_as(ctx, principal_id)
     ctx["principal_override"] = principal_id
 
 

--- a/tests/bdd/steps/domain/uc003_update_media_buy.py
+++ b/tests/bdd/steps/domain/uc003_update_media_buy.py
@@ -2050,13 +2050,14 @@ def given_media_buy_owned_by_principal(ctx: dict, owner_id: str) -> None:
 
 @given(parsers.parse("the authenticated principal is {principal}"))
 def given_authenticated_principal(ctx: dict, principal: str) -> None:
-    """Set the authenticated principal for the request.
+    """Set the authenticated principal for the request via the shared helper.
 
-    Updates the env's identity to use the specified principal_id.
+    ``authenticate_env_as`` owns the switch, the canonical ``ctx["principal_id"]``,
+    and the identity post-condition. Currently dormant — see the note on
+    ``given_buyer_authenticated_as`` / ``steps/generic/_auth.py``; retained on the
+    shared helper so the DRY convention holds when UC-003 is activated.
     """
-    principal_id = principal.strip()
-    authenticate_env_as(ctx, principal_id)
-    ctx["principal_override"] = principal_id
+    authenticate_env_as(ctx, principal.strip())
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/bdd/steps/generic/_auth.py
+++ b/tests/bdd/steps/generic/_auth.py
@@ -1,0 +1,25 @@
+"""Shared authentication helpers for BDD step definitions.
+
+Plain helper module (no ``@given``/``@when``/``@then`` decorators) — importing it
+never registers a step, mirroring ``_account_resolution.py``. Home for the
+principal-switch mutation shared by every "authenticated as principal" Given/When
+across use cases (UC-003 error + update, UC-018 isolation).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def authenticate_env_as(ctx: dict, principal_id: str) -> Any:
+    """Switch the harness env's authenticated principal to *principal_id*; return the env.
+
+    Clears the identity cache so the next ``env.identity`` access re-resolves identity
+    from scratch — picking up a principal row committed after the env was created — then
+    points the env at *principal_id*. Callers layer their own ctx bookkeeping
+    (``principal_id`` / ``principal_override``) and post-conditions on top.
+    """
+    env = ctx["env"]
+    env._identity_cache.clear()
+    env._principal_id = principal_id
+    return env

--- a/tests/bdd/steps/generic/_auth.py
+++ b/tests/bdd/steps/generic/_auth.py
@@ -1,9 +1,20 @@
-"""Shared authentication helpers for BDD step definitions.
+"""Shared authentication helper for BDD step definitions.
 
 Plain helper module (no ``@given``/``@when``/``@then`` decorators) — importing it
 never registers a step, mirroring ``_account_resolution.py``. Home for the
-principal-switch mutation shared by every "authenticated as principal" Given/When
-across use cases (UC-003 error + update, UC-018 isolation).
+principal-switch shared by every "authenticated as principal" Given/When across
+use cases (UC-018 isolation; UC-003 error + update).
+
+**Live coverage.** Only UC-018 (``test_uc018_list_creatives``) exercises this
+helper at runtime today. The UC-003 callers (``uc003_update_media_buy`` and
+``uc003_ext_error_scenarios``) are currently **dormant**: neither step module is
+registered in ``tests/bdd/conftest.py`` ``pytest_plugins`` and UC-003 is not wired
+into the BDD harness, so every UC-003 update scenario auto-xfails (verified: 0
+passed / 1404 xfailed). Those sites are converted to this shared helper anyway so
+they are correct-by-construction when UC-003 is later activated — but the DRY edit
+there is uncovered until then. Wiring UC-003 into the harness (registering the step
+modules + mapping ``MediaBuyUpdateEnv`` in ``_detect_uc`` / ``_harness_env``) remains
+a follow-up.
 """
 
 from __future__ import annotations
@@ -12,14 +23,24 @@ from typing import Any
 
 
 def authenticate_env_as(ctx: dict, principal_id: str) -> Any:
-    """Switch the harness env's authenticated principal to *principal_id*; return the env.
+    """Switch the harness env to *principal_id*, record it canonically; return the env.
 
-    Clears the identity cache so the next ``env.identity`` access re-resolves identity
-    from scratch — picking up a principal row committed after the env was created — then
-    points the env at *principal_id*. Callers layer their own ctx bookkeeping
-    (``principal_id`` / ``principal_override``) and post-conditions on top.
+    Owns the full principal-switch contract so callers don't re-implement it:
+
+    - re-points the env via the public ``env.switch_principal`` (clears the identity
+      cache so the next ``env.identity`` re-resolves — picking up a principal row
+      committed after the env was created);
+    - records the canonical ``ctx["principal_id"]`` (the key read downstream by
+      uc004/uc006 — there is no second key for this concept);
+    - asserts the identity mutation took effect.
+
+    Callers add only genuinely use-case-specific ctx state (e.g. uc003's ``has_auth``).
     """
     env = ctx["env"]
-    env._identity_cache.clear()
-    env._principal_id = principal_id
+    env.switch_principal(principal_id)
+    ctx["principal_id"] = principal_id
+    actual = env.identity.principal_id
+    assert actual == principal_id, (
+        f"env.identity.principal_id is {actual!r} after switching to {principal_id!r} — cache not rebuilt"
+    )
     return env

--- a/tests/bdd/test_uc018_list_creatives.py
+++ b/tests/bdd/test_uc018_list_creatives.py
@@ -1,7 +1,7 @@
 """BDD scenarios + steps for UC-018: list_creatives library queries.
 
-Binds the UC-018 feature; two storyboard scenarios are wired (the rest xfail at
-the conftest harness fixture):
+Binds the UC-018 feature; several scenarios are wired (the rest xfail at the
+conftest harness fixture):
 
 - ``T-UC-018-storyboard-list-all-creatives-after-sync`` (#1405): after the buyer
   syncs creatives across formats, ``list_creatives`` with no filters returns the
@@ -14,7 +14,17 @@ the conftest harness fixture):
   ``core/creative-filters.json`` (concept_ids) and ``list-creatives-response.json``
   (concept_id/concept_name).
 
-Both pinned at v3.1-04f59d2d5 (adcp 3.1.0-beta.3).
+The first two are pinned at v3.1-04f59d2d5 (adcp 3.1.0-beta.3).
+
+- ``T-UC-018-inv-034-1-holds`` / ``T-UC-018-inv-034-1-violated`` (#1503):
+  BR-RULE-034 cross-principal isolation. Two principals in one tenant each own
+  creatives; a buyer authenticated as one sees exactly its own library (holds) and
+  never the other's (counter). Enforced in production by
+  ``CreativeRepository.get_by_principal``'s ``principal_id`` filter — dropping it
+  leaks the co-tenant principal's rows and fails these scenarios. principal_id is
+  ``Field(exclude=True)`` (never on the wire), so ownership is verified by matching
+  returned creative_ids to the seeded per-principal id sets. See the section comment
+  above those steps.
 
 Wired to real production across all wire transports (auto-parametrized; UC-018
 -> CreativeListEnv via conftest ``_detect_uc`` / ``_harness_env``). The repo
@@ -69,19 +79,33 @@ scenarios("features/BR-UC-018-list-creatives.feature")
 # ── Given ────────────────────────────────────────────────────────────
 
 
-@given(parsers.parse('the Buyer is authenticated as principal "{principal_id}"'))
-def given_buyer_authenticated_as_principal(ctx: dict, principal_id: str) -> None:
-    """Authenticate the listing buyer as *principal_id* (Background).
+def _authenticate_env_as(ctx: dict, principal_id: str) -> Any:
+    """Authenticate the harness env as *principal_id*; return the env.
 
-    Mutates the harness env identity so list_creatives is principal-scoped to
-    this buyer, and records it so the seed step owns the creatives under the same
-    principal the query authenticates as (list_creatives is principal-scoped — a
-    mismatch would return an empty library).
+    Shared by the Background Given and the BR-RULE-034 When (#1503). Mutates the env
+    so list_creatives is principal-scoped to this buyer, and records the principal so
+    the seed steps own their creatives under the same id the query authenticates as
+    (list_creatives is principal-scoped — a mismatch returns an empty library).
+
+    Clears the identity cache so the NEXT identity build re-resolves the principal's
+    real auth_token from the DB. Background runs before any principal row exists, so
+    the first ``env.identity`` access caches a tokenless identity under the "mcp"
+    protocol key (shared by IMPL+MCP). Clearing here — invoked again from the When
+    step, after the seed steps have committed the principals — lets the wire dispatch
+    rebuild identity with the real token and run the full header -> token -> DB-lookup
+    auth chain rather than the tokenless injection shortcut.
     """
     env = ctx["env"]
     env._identity_cache.clear()
     env._principal_id = principal_id
     ctx["principal_id"] = principal_id
+    return env
+
+
+@given(parsers.parse('the Buyer is authenticated as principal "{principal_id}"'))
+def given_buyer_authenticated_as_principal(ctx: dict, principal_id: str) -> None:
+    """Authenticate the listing buyer as *principal_id* (Background)."""
+    env = _authenticate_env_as(ctx, principal_id)
     # Post-condition: verify the identity mutation took effect.
     actual = env.identity.principal_id
     assert actual == principal_id, f"env.identity.principal_id is {actual!r} after setting {principal_id!r}"
@@ -344,3 +368,116 @@ def then_each_creative_carries_concept(ctx: dict, concept_id: str) -> None:
             f"creative {entry.get('creative_id')!r} concept_id mismatch: {entry}"
         )
         assert entry.get("concept_name"), f"creative {entry.get('creative_id')!r} missing concept_name: {entry}"
+
+
+# ── @BR-RULE-034 cross-principal isolation scenarios (#1503) ────────────
+#
+# BR-RULE-034 (P0): list_creatives is principal-scoped — a buyer sees only its own
+# creatives, never another principal's, even within the same tenant. Enforced in
+# production by CreativeRepository.get_by_principal's ``principal_id=principal_id``
+# filter (src/core/database/repositories/creative.py). Dropping that filter leaks
+# the co-tenant principal's rows and fails both scenarios below (INV-1 holds asserts
+# an exact-set match; INV-1 counter asserts zero overlap with the other principal).
+#
+# principal_id is ``Field(exclude=True)`` on the Creative schema, so it never appears
+# on the buyer-facing wire. Ownership is therefore verified by matching each returned
+# creative_id against the per-principal id sets recorded at seed time — CreativeFactory
+# assigns a globally-unique creative_id per row, so the two principals' id sets are
+# disjoint and the isolation assertion is well-formed. Assertions read
+# ctx["wire_response"] (the real serialized bytes on a2a/mcp/rest) via _wire_creatives,
+# satisfying the "actual wire bytes" constraint.
+
+_ISOLATION_CREATIVES_KEY = "isolation_creatives_by_principal"
+
+
+@given(parsers.parse('principal "{principal_id}" has {count:d} creatives'))
+@given(parsers.parse('principal "{principal_id}" has {count:d} creatives in the same tenant'))
+def given_principal_has_n_creatives(ctx: dict, principal_id: str, count: int) -> None:
+    """Seed *count* approved creatives owned by *principal_id* under the shared tenant.
+
+    Both isolation scenarios seed two principals in ONE tenant. The tenant is created
+    on the first seed and reused on subsequent ones: neither TenantFactory nor
+    PrincipalFactory uses ``sqlalchemy_get_or_create``, so a second
+    ``TenantFactory(tenant_id=...)`` would raise a duplicate-PK IntegrityError.
+    Records each principal's creative_ids so the Then steps can attribute ownership
+    (principal_id is off-wire — see the section comment).
+
+    Two ``@given`` phrasings map to this one body: ``parsers.parse`` requires a
+    whole-string match, so the "in the same tenant" variant needs its own decorator.
+    """
+    from tests.factories import CreativeFactory, PrincipalFactory, TenantFactory
+
+    env = ctx["env"]
+    tenant = ctx.get("tenant")
+    if tenant is None:
+        tenant = TenantFactory(tenant_id=env._tenant_id)
+        ctx["tenant"] = tenant
+    principal = PrincipalFactory(tenant=tenant, principal_id=principal_id)
+    seeded: dict[str, list[str]] = ctx.setdefault(_ISOLATION_CREATIVES_KEY, {})
+    seeded[principal_id] = [
+        CreativeFactory(
+            tenant=tenant,
+            principal=principal,
+            status="approved",
+            # Present-but-empty assets object: the repository drops rows whose
+            # data["assets"] IS NULL (legacy guard), so the key must exist.
+            data={"assets": {}},
+        ).creative_id
+        for _ in range(count)
+    ]
+
+
+@when(parsers.parse('the Buyer Agent authenticated as "{principal_id}" sends a list_creatives request'))
+def when_authenticated_principal_lists_creatives(ctx: dict, principal_id: str) -> None:
+    """Authenticate as *principal_id* and dispatch an unfiltered list_creatives.
+
+    Re-authenticates via the shared helper (which clears the identity cache) AFTER the
+    seed steps committed the principals, so the wire dispatch resolves the principal's
+    real token and runs the full auth chain. Reuses the canonical generic dispatch
+    helper (``_call_via`` stashes response / wire_response / error on ctx).
+    """
+    from tests.bdd.steps.generic.when_request import _call_via
+
+    _authenticate_env_as(ctx, principal_id)
+    _call_via(ctx, ctx.get("transport"))
+
+
+def _returned_creative_ids(ctx: dict) -> set[str]:
+    """The set of creative_ids in the wire response.
+
+    Ownership is id-based: principal_id is ``Field(exclude=True)`` and never on the
+    wire, so a returned creative's owner is identified by which seeded id set its
+    creative_id came from.
+    """
+    return {entry["creative_id"] for entry in _wire_creatives(ctx)}
+
+
+@then(parsers.parse("the response contains exactly {count:d} creatives"))
+def then_response_contains_exactly_n_creatives(ctx: dict, count: int) -> None:
+    """Assert the wire response carries exactly *count* creatives (all fit on page 1)."""
+    creatives = _wire_creatives(ctx)
+    assert len(creatives) == count, (
+        f"expected exactly {count} creatives, got {len(creatives)}: "
+        f"{sorted(entry.get('creative_id') for entry in creatives)}"
+    )
+
+
+@then(parsers.parse('all creatives belong to principal "{principal_id}"'))
+def then_all_creatives_belong_to(ctx: dict, principal_id: str) -> None:
+    """Assert the returned creatives are exactly the ones this principal seeded."""
+    owned = set(ctx[_ISOLATION_CREATIVES_KEY][principal_id])
+    returned = _returned_creative_ids(ctx)
+    assert returned, "list_creatives returned an empty creatives array"
+    strangers = returned - owned
+    assert not strangers, f"creatives not owned by {principal_id!r} leaked into the response: {sorted(strangers)}"
+    # Falsifiability anchor: an unscoped query returns MORE than the owner's library.
+    assert returned == owned, f"expected exactly {principal_id!r}'s creatives {sorted(owned)}, got {sorted(returned)}"
+
+
+@then(parsers.parse('none of the returned creatives belong to principal "{principal_id}"'))
+def then_none_belong_to(ctx: dict, principal_id: str) -> None:
+    """Assert no returned creative belongs to the co-tenant principal (isolation counter)."""
+    leaked = _returned_creative_ids(ctx) & set(ctx[_ISOLATION_CREATIVES_KEY][principal_id])
+    assert not leaked, (
+        f"cross-principal leak: creatives owned by {principal_id!r} appeared in the response: {sorted(leaked)}"
+    )

--- a/tests/bdd/test_uc018_list_creatives.py
+++ b/tests/bdd/test_uc018_list_creatives.py
@@ -18,7 +18,8 @@ The first two are pinned at v3.1-04f59d2d5 (adcp 3.1.0-beta.3).
 
 - ``T-UC-018-inv-034-1-holds`` / ``T-UC-018-inv-034-1-violated`` (#1503):
   BR-RULE-034 cross-principal isolation — an AdCP normative MUST (v3.1-04f59d2d5:
-  principals-and-security.mdx §Data Isolation), ungraded by any conformance storyboard,
+  accounts-and-security.mdx §Data Isolation; building/by-layer/L1/security.mdx §Agent
+  and Account Isolation), ungraded by any conformance storyboard,
   so these two scenarios are its only executable guard. Two principals in one tenant
   each own creatives; a buyer authenticated as one sees exactly its own library (holds)
   and never the other's (counter). Enforced in production by
@@ -82,6 +83,40 @@ _SYNCED_FORMATS = ("display_300x250", "video_640x480", "audio_30s")
 scenarios("features/BR-UC-018-list-creatives.feature")
 
 
+def _seed_creative(
+    tenant: Any,
+    principal: Any,
+    fmt: str | None = None,
+    *,
+    concept_id: str | None = None,
+    concept_name: str | None = None,
+) -> Any:
+    """Seed one approved creative owned by *principal*, optionally concept-tagged.
+
+    The single place this module assembles a creative: the ``approved`` trait
+    supplies ``status="approved"`` and CreativeFactory's realistic default ``assets``
+    (which already satisfy the repository's ``data["assets"] IS NOT NULL`` guard — an
+    empty ``{"assets": {}}`` is unnecessary). When a concept is given, its
+    ``concept_id`` / ``concept_name`` are layered onto those realistic assets in this
+    one merge site. Replaces the per-seeder ``status=`` + ``data={"assets": {}}``
+    hand-rolls with a single factory idiom.
+    """
+    from tests.factories import CreativeFactory
+    from tests.factories.creative_asset import build_assets, image_spec
+
+    kwargs: dict[str, Any] = {"tenant": tenant, "principal": principal, "approved": True}
+    if fmt is not None:
+        kwargs["format"] = fmt
+    if concept_id or concept_name:
+        data: dict[str, Any] = {"assets": build_assets(image_spec("banner"))}
+        if concept_id:
+            data["concept_id"] = concept_id
+        if concept_name:
+            data["concept_name"] = concept_name
+        kwargs["data"] = data
+    return CreativeFactory(**kwargs)
+
+
 # ── Given ────────────────────────────────────────────────────────────
 
 
@@ -94,12 +129,11 @@ def given_buyer_authenticated_as_principal(ctx: dict, principal_id: str) -> None
     and records the principal so the seed steps own their creatives under the same id
     the query authenticates as (list_creatives is principal-scoped — a mismatch returns
     an empty library).
+
+    The helper owns the switch, the canonical ``ctx["principal_id"]``, and the
+    identity post-condition.
     """
-    env = authenticate_env_as(ctx, principal_id)
-    ctx["principal_id"] = principal_id
-    # Post-condition: verify the identity mutation took effect.
-    actual = env.identity.principal_id
-    assert actual == principal_id, f"env.identity.principal_id is {actual!r} after setting {principal_id!r}"
+    authenticate_env_as(ctx, principal_id)
 
 
 @given("the buyer recently synced three creatives in three different formats via sync_creatives")
@@ -109,25 +143,12 @@ def given_recently_synced_three_creatives(ctx: dict) -> None:
     Seeded via CreativeFactory rather than a live sync_creatives call — see the
     module docstring. Records the synced creative_ids for the Then steps.
     """
-    from tests.factories import CreativeFactory, PrincipalFactory, TenantFactory
+    from tests.factories import PrincipalFactory, TenantFactory
 
     env = ctx["env"]
     tenant = TenantFactory(tenant_id=env._tenant_id)
     principal = PrincipalFactory(tenant=tenant, principal_id=env._principal_id)
-    synced_ids: list[str] = []
-    for fmt in _SYNCED_FORMATS:
-        creative = CreativeFactory(
-            tenant=tenant,
-            principal=principal,
-            format=fmt,
-            status="approved",
-            # An empty-but-present assets object: the repository filters out rows
-            # whose data["assets"] IS NULL (legacy guard), so the key must exist;
-            # keeping it empty stays schema-valid (no asset-union coupling — the
-            # storyboard grades the listing contract, not asset shape).
-            data={"assets": {}},
-        )
-        synced_ids.append(creative.creative_id)
+    synced_ids = [_seed_creative(tenant, principal, fmt).creative_id for fmt in _SYNCED_FORMATS]
     ctx["tenant"] = tenant
     ctx["principal"] = principal
     ctx["synced_creative_ids"] = synced_ids
@@ -239,44 +260,32 @@ def given_creatives_grouped_under_concept(ctx: dict, concept_id: str) -> None:
     all. A broken filter that returned the whole library would surface a decoy
     whose concept_id != the requested one (or is absent), failing the Then steps.
 
-    Seeded via CreativeFactory rather than a live sync (CreativeListEnv has no sync
-    patches; the obligation under test is the listing/filter contract). The
-    empty-but-present ``assets`` is mandatory — the repository drops rows whose
-    ``data["assets"]`` IS NULL (legacy guard).
+    Seeded via ``_seed_creative`` rather than a live sync (CreativeListEnv has no
+    sync patches; the obligation under test is the listing/filter contract). The
+    helper supplies the factory's realistic default ``assets`` (the repository drops
+    rows whose ``data["assets"]`` IS NULL) and layers the concept fields on top.
     """
-    from tests.factories import CreativeFactory, PrincipalFactory, TenantFactory
+    from tests.factories import PrincipalFactory, TenantFactory
 
     env = ctx["env"]
     tenant = TenantFactory(tenant_id=env._tenant_id)
     principal = PrincipalFactory(tenant=tenant, principal_id=env._principal_id)
 
-    in_concept_ids: list[str] = []
-    for fmt in _CONCEPT_FORMATS:
-        creative = CreativeFactory(
-            tenant=tenant,
-            principal=principal,
-            format=fmt,
-            status="approved",
-            data={"assets": {}, "concept_id": concept_id, "concept_name": _CONCEPT_NAME},
-        )
-        in_concept_ids.append(creative.creative_id)
+    in_concept_ids = [
+        _seed_creative(tenant, principal, fmt, concept_id=concept_id, concept_name=_CONCEPT_NAME).creative_id
+        for fmt in _CONCEPT_FORMATS
+    ]
 
     # Decoy under a different concept.
-    CreativeFactory(
-        tenant=tenant,
-        principal=principal,
-        format=_CONCEPT_FORMATS[0],
-        status="approved",
-        data={"assets": {}, "concept_id": _DECOY_CONCEPT_ID, "concept_name": "Winter 2025 Campaign"},
+    _seed_creative(
+        tenant,
+        principal,
+        _CONCEPT_FORMATS[0],
+        concept_id=_DECOY_CONCEPT_ID,
+        concept_name="Winter 2025 Campaign",
     )
     # Decoy with no concept at all.
-    CreativeFactory(
-        tenant=tenant,
-        principal=principal,
-        format=_CONCEPT_FORMATS[0],
-        status="approved",
-        data={"assets": {}},
-    )
+    _seed_creative(tenant, principal, _CONCEPT_FORMATS[0])
 
     ctx["tenant"] = tenant
     ctx["principal"] = principal
@@ -367,12 +376,18 @@ def then_each_creative_carries_concept(ctx: dict, concept_id: str) -> None:
 # creatives, never another principal's, even within the same tenant.
 #
 # Spec ground (Spec-Grounding Gate): this is an AdCP normative MUST, pinned at
-# v3.1-04f59d2d5 — principals-and-security.mdx §Data Isolation ("the server MUST verify
-# that the principal_id from the request matches ... one principal can never view or
-# modify another principal's data"; reference/security.mdx:714,721). It is
-# ungraded-by-storyboard: no conformance storyboard grades multi-principal isolation
-# (universal/security.yaml grades authentication, not authenticated isolation), so these
-# two scenarios are the ONLY executable guard of that MUST.
+# v3.1-04f59d2d5 — docs/media-buy/advanced-topics/accounts-and-security.mdx §Data
+# Isolation (L33-37): a created object is "permanently associated with the account",
+# and for any later read "the server MUST verify that the agent has access to that
+# account", else it "MUST return a permission denied error". The deeper normative
+# reference is docs/building/by-layer/L1/security.mdx §Agent and Account Isolation
+# (L159), incl. §"Client-side isolation: cross-principal tool-call confusion" (L229).
+# (At the pin the superseded 2.5.3 principals-and-security.mdx was renamed to
+# accounts-and-security.mdx; the source docs/ paths resolve at the pin — the built
+# dist/docs/3.1.0-beta.3/ tree is only on later commits.) It is ungraded-by-storyboard:
+# no conformance storyboard grades multi-principal isolation (universal/security.yaml
+# grades authentication, not authenticated isolation), so these two scenarios are the
+# ONLY executable guard of that MUST.
 #
 # Enforcement site: CreativeRepository.get_by_principal's ``principal_id=principal_id``
 # filter (src/core/database/repositories/creative.py). Dropping that filter leaks
@@ -405,7 +420,7 @@ def given_principal_has_n_creatives(ctx: dict, principal_id: str, count: int) ->
     Two ``@given`` phrasings map to this one body: ``parsers.parse`` requires a
     whole-string match, so the "in the same tenant" variant needs its own decorator.
     """
-    from tests.factories import CreativeFactory, PrincipalFactory, TenantFactory
+    from tests.factories import PrincipalFactory, TenantFactory
 
     env = ctx["env"]
     tenant = ctx.get("tenant")
@@ -414,13 +429,7 @@ def given_principal_has_n_creatives(ctx: dict, principal_id: str, count: int) ->
         ctx["tenant"] = tenant
     principal = PrincipalFactory(tenant=tenant, principal_id=principal_id)
     seeded: dict[str, list[str]] = ctx.setdefault(_ISOLATION_CREATIVES_KEY, {})
-    seeded[principal_id] = [
-        # ``approved`` trait -> status="approved"; CreativeFactory's default ``data``
-        # is a realistic {"assets": build_assets(...)}, which already satisfies the
-        # repository's data["assets"] IS NOT NULL guard.
-        CreativeFactory(tenant=tenant, principal=principal, approved=True).creative_id
-        for _ in range(count)
-    ]
+    seeded[principal_id] = [_seed_creative(tenant, principal).creative_id for _ in range(count)]
 
 
 @when(parsers.parse('the Buyer Agent authenticated as "{principal_id}" sends a list_creatives request'))
@@ -438,7 +447,6 @@ def when_authenticated_principal_lists_creatives(ctx: dict, principal_id: str) -
     from tests.bdd.steps.generic.when_request import _call_via
 
     authenticate_env_as(ctx, principal_id)
-    ctx["principal_id"] = principal_id
     _call_via(ctx, ctx.get("transport"))
 
 

--- a/tests/bdd/test_uc018_list_creatives.py
+++ b/tests/bdd/test_uc018_list_creatives.py
@@ -17,19 +17,23 @@ conftest harness fixture):
 The first two are pinned at v3.1-04f59d2d5 (adcp 3.1.0-beta.3).
 
 - ``T-UC-018-inv-034-1-holds`` / ``T-UC-018-inv-034-1-violated`` (#1503):
-  BR-RULE-034 cross-principal isolation. Two principals in one tenant each own
-  creatives; a buyer authenticated as one sees exactly its own library (holds) and
-  never the other's (counter). Enforced in production by
+  BR-RULE-034 cross-principal isolation — an AdCP normative MUST (v3.1-04f59d2d5:
+  principals-and-security.mdx §Data Isolation), ungraded by any conformance storyboard,
+  so these two scenarios are its only executable guard. Two principals in one tenant
+  each own creatives; a buyer authenticated as one sees exactly its own library (holds)
+  and never the other's (counter). Enforced in production by
   ``CreativeRepository.get_by_principal``'s ``principal_id`` filter — dropping it
   leaks the co-tenant principal's rows and fails these scenarios. principal_id is
   ``Field(exclude=True)`` (never on the wire), so ownership is verified by matching
   returned creative_ids to the seeded per-principal id sets. See the section comment
-  above those steps.
+  above those steps for the full spec citation.
 
 Wired to real production across all wire transports (auto-parametrized; UC-018
 -> CreativeListEnv via conftest ``_detect_uc`` / ``_harness_env``). The repo
-sunsets the IMPL pseudo-transport in BDD, so the scenario runs on a2a/mcp/rest
-(plus e2e_rest in-network). Each transport returns the same typed response, and
+sunsets the IMPL pseudo-transport in BDD, so the scenario runs on a2a/mcp/rest.
+(The isolation Then steps read the success-path ``wire_response``, which the E2E
+REST dispatcher does not stash — so those assertions cover a2a/mcp/rest, not
+e2e_rest.) Each transport returns the same typed response, and
 the Then steps validate its production JSON serialization
 (``model_dump(mode="json", exclude_none=True)`` — the same NestedModelSerializerMixin
 path that produces the on-the-wire bytes); the parametrization still exercises
@@ -60,6 +64,7 @@ from typing import Any
 from pytest_bdd import given, parsers, scenarios, then, when
 
 from tests.bdd.steps._outcome_helpers import _require_response
+from tests.bdd.steps.generic._auth import authenticate_env_as
 from tests.harness.transport import Transport
 from tests.helpers.pinned_schema import validate_against_pinned_schema
 
@@ -69,43 +74,29 @@ from tests.helpers.pinned_schema import validate_against_pinned_schema
 # known formats, so an unregistered id would be rejected on that transport.
 _SYNCED_FORMATS = ("display_300x250", "video_640x480", "audio_30s")
 
-# Bind the UC-018 feature. Only the @list-after-sync storyboard scenario is wired
-# here (#1405); the remaining scenarios xfail fast at the conftest _harness_env
-# fixture (no UC-018 harness yet). Whole-feature binding via scenarios() is the
-# repo convention the CI shard-splitter requires (scripts/ci/shard_split.py).
+# Bind the UC-018 feature. The wired scenarios are @list-after-sync (#1405),
+# @concept-id (#1407), and the @BR-RULE-034 isolation invariants (#1503); the
+# remaining scenarios xfail fast at the conftest _harness_env fixture. Whole-feature
+# binding via scenarios() is the repo convention the CI shard-splitter requires
+# (scripts/ci/shard_split.py).
 scenarios("features/BR-UC-018-list-creatives.feature")
 
 
 # ── Given ────────────────────────────────────────────────────────────
 
 
-def _authenticate_env_as(ctx: dict, principal_id: str) -> Any:
-    """Authenticate the harness env as *principal_id*; return the env.
-
-    Shared by the Background Given and the BR-RULE-034 When (#1503). Mutates the env
-    so list_creatives is principal-scoped to this buyer, and records the principal so
-    the seed steps own their creatives under the same id the query authenticates as
-    (list_creatives is principal-scoped — a mismatch returns an empty library).
-
-    Clears the identity cache so the NEXT identity build re-resolves the principal's
-    real auth_token from the DB. Background runs before any principal row exists, so
-    the first ``env.identity`` access caches a tokenless identity under the "mcp"
-    protocol key (shared by IMPL+MCP). Clearing here — invoked again from the When
-    step, after the seed steps have committed the principals — lets the wire dispatch
-    rebuild identity with the real token and run the full header -> token -> DB-lookup
-    auth chain rather than the tokenless injection shortcut.
-    """
-    env = ctx["env"]
-    env._identity_cache.clear()
-    env._principal_id = principal_id
-    ctx["principal_id"] = principal_id
-    return env
-
-
 @given(parsers.parse('the Buyer is authenticated as principal "{principal_id}"'))
 def given_buyer_authenticated_as_principal(ctx: dict, principal_id: str) -> None:
-    """Authenticate the listing buyer as *principal_id* (Background)."""
-    env = _authenticate_env_as(ctx, principal_id)
+    """Authenticate the listing buyer as *principal_id* (Background).
+
+    Uses the shared ``authenticate_env_as`` helper (which clears the identity cache and
+    switches the env's principal) so list_creatives is principal-scoped to this buyer,
+    and records the principal so the seed steps own their creatives under the same id
+    the query authenticates as (list_creatives is principal-scoped — a mismatch returns
+    an empty library).
+    """
+    env = authenticate_env_as(ctx, principal_id)
+    ctx["principal_id"] = principal_id
     # Post-condition: verify the identity mutation took effect.
     actual = env.identity.principal_id
     assert actual == principal_id, f"env.identity.principal_id is {actual!r} after setting {principal_id!r}"
@@ -373,8 +364,17 @@ def then_each_creative_carries_concept(ctx: dict, concept_id: str) -> None:
 # ── @BR-RULE-034 cross-principal isolation scenarios (#1503) ────────────
 #
 # BR-RULE-034 (P0): list_creatives is principal-scoped — a buyer sees only its own
-# creatives, never another principal's, even within the same tenant. Enforced in
-# production by CreativeRepository.get_by_principal's ``principal_id=principal_id``
+# creatives, never another principal's, even within the same tenant.
+#
+# Spec ground (Spec-Grounding Gate): this is an AdCP normative MUST, pinned at
+# v3.1-04f59d2d5 — principals-and-security.mdx §Data Isolation ("the server MUST verify
+# that the principal_id from the request matches ... one principal can never view or
+# modify another principal's data"; reference/security.mdx:714,721). It is
+# ungraded-by-storyboard: no conformance storyboard grades multi-principal isolation
+# (universal/security.yaml grades authentication, not authenticated isolation), so these
+# two scenarios are the ONLY executable guard of that MUST.
+#
+# Enforcement site: CreativeRepository.get_by_principal's ``principal_id=principal_id``
 # filter (src/core/database/repositories/creative.py). Dropping that filter leaks
 # the co-tenant principal's rows and fails both scenarios below (INV-1 holds asserts
 # an exact-set match; INV-1 counter asserts zero overlap with the other principal).
@@ -415,14 +415,10 @@ def given_principal_has_n_creatives(ctx: dict, principal_id: str, count: int) ->
     principal = PrincipalFactory(tenant=tenant, principal_id=principal_id)
     seeded: dict[str, list[str]] = ctx.setdefault(_ISOLATION_CREATIVES_KEY, {})
     seeded[principal_id] = [
-        CreativeFactory(
-            tenant=tenant,
-            principal=principal,
-            status="approved",
-            # Present-but-empty assets object: the repository drops rows whose
-            # data["assets"] IS NULL (legacy guard), so the key must exist.
-            data={"assets": {}},
-        ).creative_id
+        # ``approved`` trait -> status="approved"; CreativeFactory's default ``data``
+        # is a realistic {"assets": build_assets(...)}, which already satisfies the
+        # repository's data["assets"] IS NOT NULL guard.
+        CreativeFactory(tenant=tenant, principal=principal, approved=True).creative_id
         for _ in range(count)
     ]
 
@@ -431,14 +427,18 @@ def given_principal_has_n_creatives(ctx: dict, principal_id: str, count: int) ->
 def when_authenticated_principal_lists_creatives(ctx: dict, principal_id: str) -> None:
     """Authenticate as *principal_id* and dispatch an unfiltered list_creatives.
 
-    Re-authenticates via the shared helper (which clears the identity cache) AFTER the
-    seed steps committed the principals, so the wire dispatch resolves the principal's
-    real token and runs the full auth chain. Reuses the canonical generic dispatch
+    Re-authenticates via the shared ``authenticate_env_as`` helper (which clears the
+    identity cache) AFTER the seed steps committed the principals, so the next identity
+    build resolves the principal's real token from the DB rather than the tokenless
+    identity cached during Background (which ran before any principal row existed). On
+    MCP/A2A this exercises the full header -> token -> DB-lookup auth chain; REST resolves
+    identity via a FastAPI dependency override. Reuses the canonical generic dispatch
     helper (``_call_via`` stashes response / wire_response / error on ctx).
     """
     from tests.bdd.steps.generic.when_request import _call_via
 
-    _authenticate_env_as(ctx, principal_id)
+    authenticate_env_as(ctx, principal_id)
+    ctx["principal_id"] = principal_id
     _call_via(ctx, ctx.get("transport"))
 
 
@@ -477,7 +477,9 @@ def then_all_creatives_belong_to(ctx: dict, principal_id: str) -> None:
 @then(parsers.parse('none of the returned creatives belong to principal "{principal_id}"'))
 def then_none_belong_to(ctx: dict, principal_id: str) -> None:
     """Assert no returned creative belongs to the co-tenant principal (isolation counter)."""
-    leaked = _returned_creative_ids(ctx) & set(ctx[_ISOLATION_CREATIVES_KEY][principal_id])
+    returned = _returned_creative_ids(ctx)
+    assert returned, "isolation counter is vacuous on an empty response (list_creatives returned no creatives)"
+    leaked = returned & set(ctx[_ISOLATION_CREATIVES_KEY][principal_id])
     assert not leaked, (
         f"cross-principal leak: creatives owned by {principal_id!r} appeared in the response: {sorted(leaked)}"
     )

--- a/tests/harness/_base.py
+++ b/tests/harness/_base.py
@@ -419,6 +419,19 @@ class BaseTestEnv:
         ).first()
         return token
 
+    def switch_principal(self, principal_id: str) -> None:
+        """Re-point the env at *principal_id*, clearing cached identity.
+
+        Public accessor for the principal-switch mutation (mirrors
+        ``get_session()``): step functions must not reach into the private
+        ``_identity_cache`` / ``_principal_id``. Clearing the cache forces the
+        next ``identity`` / ``identity_for`` access to re-resolve from scratch —
+        picking up a principal row committed after the env was created (in
+        integration mode this re-runs the auth-token lookup).
+        """
+        self._identity_cache.clear()
+        self._principal_id = principal_id
+
     @property
     def identity(self) -> ResolvedIdentity:
         """Default identity (protocol='mcp'). Backward-compatible.


### PR DESCRIPTION

Wire the two @BR-RULE-034 scenarios in BR-UC-018-list-creatives.feature (INV-1 holds / INV-1 counter) to real production across a2a/mcp/rest, building on the UC-018 scaffolding from #1474.

- conftest.py: route @BR-RULE-034 markers to CreativeListEnv in the UC-018 harness gate (unambiguous — the branch only runs for T-UC-018-* scenarios).
- test_uc018_list_creatives.py: extract a shared _authenticate_env_as helper (reused by the Background Given and the new When), add the seed Given (two phrasings, one body), the isolation When (re-auth after seeding so the wire auth token resolves), and three Then steps.

Ownership is verified by matching returned creative_ids against the seeded per-principal id sets: principal_id is Field(exclude=True) and never appears on the buyer-facing wire, and CreativeFactory assigns globally-unique ids so the two principals' sets are disjoint. Assertions read ctx["wire_response"] (real serialized bytes).

Verified: both scenarios pass on a2a/mcp/rest; removing the principal_id filter from CreativeRepository.get_by_principal turns all six red; no regression in the rest of the UC-018 suite; DRY duplication baseline unchanged.

Closes #1503 