### PR TITLE
chore(security): Remove stale CVE suppressions (#1557 #1558 #1559)

### DIFF
--- a/scripts/security-audit.sh
+++ b/scripts/security-audit.sh
@@ -3,29 +3,32 @@
 # Both ./run_all_tests.sh and .github/workflows/ci.yml call this script, so
 # the list cannot drift between local and CI.
 #
-# Ignored advisories (each documented with rationale):
+# Active suppressions: none (see scripts/security-ignored-vulns.sh).
+#
+# Previously ignored, now resolved (kept here as a record):
 #
 # - PYSEC-2026-89 / CVE-2025-69534 / GHSA-5wmx-573v-2qwq: Python-Markdown
 #     unhandled AssertionError on malformed HTML-like sequences. The
 #     advisory body says "fixed in version 3.8.1"; the OSV record's
-#     affected-range events array is malformed (missing the
-#     ``{"fixed": "3.8.1"}`` event), so uv-secure flags every version. We
-#     are on Markdown >= 3.8.1 (currently 3.10.2) — past the fix.
+#     affected-range events array was malformed (missing the
+#     ``{"fixed": "3.8.1"}`` event), so uv-secure flagged every version. We
+#     were on Markdown >= 3.8.1 — past the fix. Suppression removed 2026-07
+#     (#1557) when uv-secure clean without ignore.
 #
 # - PYSEC-2025-183 / CVE-2025-45768: PyJWT alleged weak signing key —
 #     explicitly DISPUTED by the supplier per the advisory body ("the key
 #     length is chosen by the application that uses the library"). No fix
-#     version exists because the maintainer rejects the framing. OSV record
-#     has the same malformed empty-fixed-event pattern as PYSEC-2026-89.
-#     Inapplicable here regardless: this codebase only invokes PyJWT via
+#     version exists because the maintainer rejects the framing. Inapplicable
+#     here regardless: this codebase only invokes PyJWT via
 #     ``jwt.decode(id_token, options={"verify_signature": False})`` to parse
 #     Google-issued OIDC ID tokens (src/admin/auth_utils.py), so no PyJWT
-#     signing keys are configured by this application at all.
-#     uv-secure's advisory database has shown it flip between flagged and
-#     unflagged across runs as the upstream record gets re-curated, hence
-#     ``--allow-unused-ignores`` below.
+#     signing keys are configured by this application at all. Suppression
+#     removed 2026-07 (#1558) when uv-secure clean without ignore.
 #
-# Previously ignored, now resolved by real dep bumps (kept here as a record):
+# - MAL-2026-4750: fastapi 'fastar' dep — OSV advisory withdrawn 2026-05-26
+#     (internal tooling artefact). Suppression removed 2026-07 (#1559) when
+#     uv-secure and pip-audit clean without ignore.
+#
 # - GHSA-7gcm-g887-7qv7 (protobuf DoS) — resolved by bumping protobuf to 6.33.6.
 # - GHSA-5239-wwwm-4pmq (Pygments AdlLexer ReDoS) — resolved by bumping
 #   Pygments to 2.20.0.

--- a/scripts/security-ignored-vulns.sh
+++ b/scripts/security-ignored-vulns.sh
@@ -5,16 +5,20 @@
 # IDs for the same advisory can differ by tool/vendor namespace — both are
 # listed here for cross-reference. Format: GHSA/PYSEC == CVE.
 #
-# Active suppressions:
-#
-# - MAL-2026-4750: fastapi 0.136.3 — Amazon Inspector flagged an undocumented
-#   'fastar' dep in the [standard] optional group. The OSV advisory was
-#   WITHDRAWN on 2026-05-26 (same day it was published); 'fastar' was an
-#   internal tooling artefact, not a supply-chain injection. Both uv-secure
-#   and pip-audit lag the OSV withdrawal by hours/days — suppress until
-#   their databases catch up.
+# Active suppressions: (none)
 #
 # Previously ignored, now resolved:
+#
+# - PYSEC-2026-89 / CVE-2025-69534 / GHSA-5wmx-573v-2qwq: Python-Markdown
+#   OSV affected-range malformed; we are on Markdown >= 3.8.1. Removed 2026-07
+#   when uv-secure stopped flagging without ignore (#1557).
+#
+# - PYSEC-2025-183 / CVE-2025-45768: PyJWT disputed weak-signing-key advisory;
+#   inapplicable (OIDC decode only, no app signing keys). Removed 2026-07 when
+#   uv-secure stopped flagging without ignore (#1558).
+#
+# - MAL-2026-4750: fastapi 'fastar' dep — OSV advisory withdrawn 2026-05-26.
+#   Removed 2026-07 when uv-secure and pip-audit stopped flagging (#1559).
 #
 # - GHSA-cqp8-fcvh-x7r3 == CVE-2026-46678: pydantic-ai deserialization RCE.
 #   Resolved: pydantic-ai bumped to >=1.99.0 (PR 2). fastmcp was intentionally
@@ -26,7 +30,7 @@
 #   Resolved: fastapi bumped to >=0.133.0 (starlette 1.0+ support) (PR 2).
 
 # uv-secure supports GHSA/PYSEC/MAL identifiers.
-UV_SECURE_IGNORED_VULNS="PYSEC-2026-89,PYSEC-2025-183,MAL-2026-4750"
+UV_SECURE_IGNORED_VULNS=""
 
 # pip-audit supports CVE, GHSA, PYSEC, and MAL IDs.
-PIP_AUDIT_IGNORED_VULNS="MAL-2026-4750"
+PIP_AUDIT_IGNORED_VULNS=""


### PR DESCRIPTION
## Summary
Remove all three active suppressions from `scripts/security-ignored-vulns.sh`. Advisory databases no longer flag these IDs against our locked dependencies without `--ignore-vulns`.

Closes #1557, closes #1558, closes #1559.

## Test plan
- [x] `./scripts/security-audit.sh` — clean locally (249 deps, zero ignores)
- [ ] `security.yml` → **pip-audit** job green on this PR (ubuntu; local macOS `uvx pip-audit` unreliable due to ensurepip/SIGABRT)

Recurring verification checklist posted on #1557.