### PR TITLE
test(bdd): wire UC-019 get_media_buys BDD scenarios across transports

### DIFF
--- a/.duplication-baseline
+++ b/.duplication-baseline
@@ -1,5 +1,5 @@
 {
   "src": 36,
-  "tests": 89,
+  "tests": 88,
   "scripts": 0
 }

--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -63,6 +63,7 @@ pytest_plugins = [
     "tests.bdd.steps.domain.admin_accounts",
     "tests.bdd.steps.domain.uc_get_products_inventory",
     "tests.bdd.steps.domain.compat_normalization",
+    "tests.bdd.steps.domain.uc019_query_media_buys",
 ]
 
 # ---------------------------------------------------------------------------
@@ -1865,6 +1866,34 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
                 )
             )
 
+        # --- UC-019: REST transport has no query route — blanket gap ---
+        # src/routes/api_v1.py registers POST /media-buys (create), PUT
+        # /media-buys/{id} (update), and POST /media-buys/delivery (metrics) —
+        # but no query route for get_media_buys. MediaBuyListEnv.REST_ENDPOINT
+        # ("/api/v1/media-buys/query") targets a route that was never built
+        # server-side, so every REST-transport UC-019 scenario 405s
+        # (Method Not Allowed) regardless of what it's otherwise testing. #1555.
+        #
+        # Excluded: T-UC-019-partition-status-invalid. Its Given step
+        # (missing start_date/end_date) hits a DB NOT NULL constraint and sets
+        # ctx["error"] directly during setup — _dispatch_query short-circuits
+        # before any transport call, so these never reach the network layer
+        # and pass on REST regardless of the missing route (empirically
+        # verified: xpassed under strict=False before this exclusion). #1555.
+        _UC019_REST_ROUTE_INDEPENDENT_TAGS = {"T-UC-019-partition-status-invalid"}
+        if (
+            is_rest
+            and any(t.startswith("T-UC-019") for t in marker_names)
+            and not (marker_names & _UC019_REST_ROUTE_INDEPENDENT_TAGS)
+        ):
+            item.add_marker(
+                pytest.mark.xfail(
+                    reason="UC-019: REST transport has no get_media_buys query route "
+                    "(405 Method Not Allowed) — spec-production gap",
+                    strict=False,
+                )
+            )
+
         # --- UC-019: xfails for spec-production gaps ---
         # Graduated (k31s): status_computation active variants, default_status_filter
         # simple variants, status_filter boundary simple variants, inv-150-2/4,
@@ -1885,12 +1914,22 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
             "T-UC-019-inv-153-3",
             "T-UC-019-inv-153-4",
             "T-UC-019-inv-153-5",
+            # Unmapped persisted status: the feature's literal test value
+            # "some_unmapped_internal_state" (29 chars) exceeds
+            # media_buys.status VARCHAR(20) — DataError on insert, all
+            # transports. Not fixable without a schema migration (no
+            # intentional production changes in this PR). #1555.
+            "T-UC-019-inv-150-11",
             # Sandbox mode — not implemented
             "T-UC-019-sandbox-happy",
             "T-UC-019-sandbox-validation",
             # Graduated: T-UC-019-partition-principal-invalid identity_missing (impl/a2a/mcp pass)
             # — moved to _UC019_PARAM_XFAIL for selective identity_missing exclusion.
-            # Graduated: T-UC-019-ext-a (impl/a2a/mcp pass) — moved to selective block below.
+            # T-UC-019-ext-a: REST/e2e_rest xfailed below (suggestion wording).
+            # a2a/mcp xfailed separately below (AUTH_TOKEN_INVALID vs AUTH_REQUIRED,
+            # empirically verified — #1555; the prior "Graduated (impl/a2a/mcp pass)"
+            # comment here predated the harness ever being wired and was never
+            # actually run against this module).
             # Extension errors — error code mismatches / not implemented
             "T-UC-019-ext-b",
             "T-UC-019-ext-c",
@@ -1934,12 +1973,27 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
                 )
 
         # --- UC-019: HTTP transport xfails for auth suggestion mismatch ---
-        # impl/a2a/mcp graduated (kb7y); REST/e2e_rest suggestion string differs
-        # from spec ("authenticate" vs "authentication").
+        # REST/e2e_rest suggestion string differs from spec ("authenticate" vs
+        # "authentication"). a2a/mcp are xfailed separately below for a
+        # different, empirically-verified reason (AUTH_TOKEN_INVALID vs
+        # AUTH_REQUIRED) — #1555.
         if (is_rest or is_e2e_rest) and "T-UC-019-ext-a" in marker_names:
             item.add_marker(
                 pytest.mark.xfail(
                     reason="HTTP transport: auth error suggestion says 'authenticate' not 'authentication' — spec-production gap",
+                    strict=False,
+                )
+            )
+
+        # --- UC-019: a2a/mcp raise the wrong error code for missing credentials ---
+        # T-UC-019-ext-a expects AUTH_REQUIRED; a2a/mcp actually raise
+        # AUTH_TOKEN_INVALID for a no-credentials get_media_buys request.
+        # Empirically verified — #1555.
+        if (is_a2a or is_mcp) and "T-UC-019-ext-a" in marker_names:
+            item.add_marker(
+                pytest.mark.xfail(
+                    reason="UC-019: a2a/mcp raise AUTH_TOKEN_INVALID instead of AUTH_REQUIRED "
+                    "for a missing-credentials get_media_buys request — spec-production gap",
                     strict=False,
                 )
             )
@@ -1966,11 +2020,25 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
                 {"multiple_statuses", "all_statuses"},
                 "UC-019: multi-status filter not implemented",
             ),
-            # Status filter boundary: complex filter variants fail
+            # Status filter boundary: complex filter variants fail. "removed enum
+            # value" (pending_activation) added #1555 — empirically verified: no
+            # error is raised (STATUS_FILTER_INVALID_VALUE/STATUS_FILTER_EMPTY
+            # don't exist anywhere in src/), same production gap as the sibling
+            # T-UC-019-partition-status-filter-invalid tag.
             (
                 "T-UC-019-boundary-status-filter",
-                {"all six", "empty array", "unknown enum", "mix of valid"},
+                {"all six", "empty array", "unknown enum", "mix of valid", "removed enum value"},
                 "UC-019: complex status filter boundary not implemented",
+            ),
+            # Sandbox boundary: "sandbox: true" variant fails — sandbox mode is
+            # not implemented in production (same gap as T-UC-019-sandbox-happy).
+            # The "sandbox absent" variant passes trivially on a2a/mcp (no
+            # sandbox field is ever present) and is covered on REST by the
+            # blanket REST-not-implemented xfail above. #1555.
+            (
+                "T-UC-019-boundary-sandbox",
+                {"sandbox: true in response"},
+                "UC-019: sandbox mode not implemented in production — spec-production gap",
             ),
             # Snapshot: not-requested variant fails (include_snapshot=false path)
             (
@@ -2729,6 +2797,8 @@ def _detect_uc(request: pytest.FixtureRequest) -> str | None:
         return "UC-011"
     if any(t.startswith("T-UC-018") for t in marker_names):
         return "UC-018"
+    if any(t.startswith("T-UC-019") for t in marker_names):
+        return "UC-019"
     if any(t.startswith(_ADMIN_TAG_PREFIX) for t in marker_names):
         return "ADMIN"
     if "inventory_profile" in marker_names:
@@ -2866,6 +2936,24 @@ def _harness_env(request: pytest.FixtureRequest, ctx: dict) -> Generator[None, N
             pytest.xfail(
                 "UC-018 harness wired only for the @list-after-sync (#1405) and @concept-id (#1407) storyboard scenarios"
             )
+
+    elif uc == "UC-019":
+        request.getfixturevalue("integration_db")
+        from tests.harness.media_buy_list import MediaBuyListEnv
+
+        # "buyer-001" matches the Background's principal_id across all UC-019
+        # scenarios (mirrors the UC-004 DeliveryPollEnv convention above).
+        with MediaBuyListEnv(principal_id="buyer-001", e2e_config=ctx.get("e2e_config")) as env:
+            tenant, principal = env.setup_default_data()
+            ctx["env"] = env
+            ctx["tenant"] = tenant
+            ctx["principal"] = principal
+            try:
+                yield
+            finally:
+                for patcher in ctx.get("_patchers", []):
+                    patcher.stop()
+                ctx.pop("_patchers", None)
 
     elif uc == "UC-011":
         marker_names = {m.name for m in request.node.iter_markers()}

--- a/tests/bdd/steps/domain/uc019_query_media_buys.py
+++ b/tests/bdd/steps/domain/uc019_query_media_buys.py
@@ -204,6 +204,87 @@ def given_principal_owns_media_buy_with_dates(ctx: dict, principal_id: str, mb_i
     _register_media_buy(ctx, mb_id, mb)
 
 
+@given(parsers.parse('the principal "{principal_id}" owns media buy "{mb_id}" with persisted status "{status}"'))
+def given_principal_owns_media_buy_with_persisted_status(ctx: dict, principal_id: str, mb_id: str, status: str) -> None:
+    """Create a media buy with a specific raw persisted MediaBuy.status column value.
+
+    Exercises _PERSISTED_STATUS_TO_ADCP mapping (BR-RULE-150 INV-6..INV-11) directly —
+    the raw DB string, not the AdCP wire status.
+    """
+    _register_principal(ctx, principal_id)
+    env = ctx["env"]
+    real_id = _generate_unique_id(mb_id)
+    mb = MediaBuyFactory(
+        tenant=ctx["tenant"],
+        principal=ctx["principal"],
+        media_buy_id=real_id,
+        status=status,
+    )
+    env._commit_factory_data()
+    _register_media_buy(ctx, mb_id, mb)
+
+
+@given(
+    parsers.parse(
+        'the principal "{principal_id}" owns media buy "{mb_id}" with persisted status "{status}" and is_paused true'
+    )
+)
+def given_principal_owns_media_buy_with_persisted_status_paused(
+    ctx: dict, principal_id: str, mb_id: str, status: str
+) -> None:
+    """Create a media buy with a persisted status and is_paused=True (BR-RULE-150 INV-6)."""
+    _register_principal(ctx, principal_id)
+    env = ctx["env"]
+    real_id = _generate_unique_id(mb_id)
+    mb = MediaBuyFactory(
+        tenant=ctx["tenant"],
+        principal=ctx["principal"],
+        media_buy_id=real_id,
+        status=status,
+        is_paused=True,
+    )
+    env._commit_factory_data()
+    _register_media_buy(ctx, mb_id, mb)
+
+
+@given(
+    parsers.parse(
+        'the principal "{principal_id}" owns media buy "{mb_id}" with persisted status "{status}" and is_paused false'
+    )
+)
+def given_principal_owns_media_buy_with_persisted_status_not_paused(
+    ctx: dict, principal_id: str, mb_id: str, status: str
+) -> None:
+    """Create a media buy with a persisted status and is_paused=False (BR-RULE-150 INV-11)."""
+    _register_principal(ctx, principal_id)
+    env = ctx["env"]
+    real_id = _generate_unique_id(mb_id)
+    mb = MediaBuyFactory(
+        tenant=ctx["tenant"],
+        principal=ctx["principal"],
+        media_buy_id=real_id,
+        status=status,
+        is_paused=False,
+    )
+    env._commit_factory_data()
+    _register_media_buy(ctx, mb_id, mb)
+
+
+@given(parsers.parse('media buy "{mb_id}" has start_date "{start}" and end_date "{end}"'))
+def given_media_buy_has_dates(ctx: dict, mb_id: str, start: str, end: str) -> None:
+    """Set flight dates on an already-seeded media buy (follow-up to a persisted-status Given)."""
+    seeded = ctx.get("seeded_media_buys", {})
+    mb = seeded.get(mb_id)
+    assert mb is not None, (
+        f"Media buy '{mb_id}' not found in seeded_media_buys — a prior Given step must create it first. "
+        f"Known: {list(seeded)}"
+    )
+    env = ctx["env"]
+    mb.start_date = date.fromisoformat(start)
+    mb.end_date = date.fromisoformat(end)
+    env._commit_factory_data()
+
+
 @given(parsers.parse('today is "{today_str}"'))
 def given_today_is(ctx: dict, today_str: str) -> None:
     """Override 'today' for status computation.
@@ -389,11 +470,20 @@ def given_principal_owns_various_statuses(ctx: dict, principal_id: str) -> None:
 
 @given(parsers.parse('the principal "{principal_id}" owns active media buy "{mb1}" and completed media buy "{mb2}"'))
 def given_principal_owns_active_and_completed(ctx: dict, principal_id: str, mb1: str, mb2: str) -> None:
-    """Create one active and one completed media buy (INV-151-1)."""
+    """Create one active and one completed media buy (INV-151-1).
+
+    This scenario has no preceding "today is ..." step, so no datetime patch
+    is installed on src.core.tools.media_buy_list — production evaluates
+    status against the real wall clock. Flight dates must therefore be seeded
+    relative to that same real clock (datetime.now(UTC).date()), not a
+    hardcoded fallback, or the "active" buy can drift out of its window and
+    the default {active} filter silently excludes it.
+    """
     _register_principal(ctx, principal_id)
     env = ctx["env"]
-    today = date.fromisoformat(ctx.get("mock_today", "2026-03-15"))
-    from datetime import timedelta
+    from datetime import UTC, datetime, timedelta
+
+    today = date.fromisoformat(ctx["mock_today"]) if "mock_today" in ctx else datetime.now(UTC).date()
 
     # Active: today is within flight dates
     real_id1 = _generate_unique_id(mb1)
@@ -899,16 +989,9 @@ def given_principal_owns_mb_no_end(ctx: dict, principal_id: str, mb_id: str) -> 
     _create_media_buy_with_null_dates(ctx, principal_id, mb_id, null_start=False, null_end=True)
 
 
-@given(parsers.parse("the request targets a sandbox account"))
-def given_sandbox_account(ctx: dict) -> None:
-    """Mark request as targeting a sandbox account."""
-    ctx["sandbox"] = True
-
-
-@given(parsers.parse("the request targets a production account"))
-def given_production_account(ctx: dict) -> None:
-    """Mark request as targeting a production (non-sandbox) account."""
-    ctx["sandbox"] = False
+# "the request targets a sandbox/production account" — no domain-specific
+# implementation. Uses tests.bdd.steps.generic.given_auth (sets ctx["sandbox"]);
+# equivalent effect, and shared across UCs. See #1555 collision resolution.
 
 
 @given("an authenticated identity with no principal_id")
@@ -1638,30 +1721,9 @@ def then_error_recovery_correctable(ctx: dict) -> None:
     )
 
 
-@then(parsers.parse('the error should include a "suggestion" field'))
-def then_error_has_suggestion(ctx: dict) -> None:
-    """Assert error includes a suggestion field with actionable content.
-
-    Step text: 'the error should include a "suggestion" field'.
-    The error must be an AdCPError with a details dict containing a non-empty
-    suggestion string. No xfail escape — if production omits the suggestion,
-    the test must fail.
-    """
-    error = ctx.get("error")
-    assert error is not None, "Expected an error"
-    from src.core.exceptions import AdCPError
-
-    assert isinstance(error, AdCPError), (
-        f"Expected AdCPError with suggestion field, got {type(error).__name__}: {error}"
-    )
-    assert error.details is not None, (
-        f"AdCPError(error_code={error.error_code!r}) has no details dict — cannot contain 'suggestion' field"
-    )
-    assert "suggestion" in error.details, f"Expected 'suggestion' in error details: {error.details}"
-    suggestion = error.details["suggestion"]
-    assert isinstance(suggestion, str) and suggestion.strip(), (
-        f"Expected non-empty suggestion string, got {suggestion!r}"
-    )
+# 'the error should include a "suggestion" field' — no domain-specific
+# implementation. Uses tests.bdd.steps.generic.then_error (same object path:
+# error.details["suggestion"]); equivalent, and shared across UCs. See #1555.
 
 
 @then(parsers.parse('the error message should contain "{fragment}"'))
@@ -2063,107 +2125,22 @@ def then_response_has_media_buys_array(ctx: dict) -> None:
     assert isinstance(buys, list), f"Expected media_buys to be a list (array), got {type(buys).__name__}"
 
 
-@then("the response should include sandbox equals true")
-def then_sandbox_true(ctx: dict) -> None:
-    """Assert response includes sandbox=true.
-
-    Scenario-level xfail (T-UC-019-sandbox-happy) handles the expected failure
-    when sandbox mode is not yet implemented in production.
-    """
-    resp = ctx.get("response")
-    assert resp is not None, f"Expected response, got error: {ctx.get('error')}"
-    sandbox = getattr(resp, "sandbox", None)
-    assert sandbox is True, f"Expected sandbox=true, got {sandbox!r}"
-
-
-@then("the response should not include a sandbox field")
-def then_no_sandbox_field(ctx: dict) -> None:
-    """Assert response does not include sandbox field for production accounts.
-
-    Step text: 'should not include a sandbox field'. If production includes
-    it anyway, this is a spec-production gap.
-    """
-
-    resp = ctx.get("response")
-    assert resp is not None, f"Expected response, got error: {ctx.get('error')}"
-    sandbox = getattr(resp, "sandbox", None)
-    # Violation path: sandbox IS present when it should NOT be
-    assert sandbox is None, (
-        f"Production response includes sandbox={sandbox!r} for production account — should be absent"
-    )
-
-
-@then("the response should indicate a validation error")
-def then_validation_error(ctx: dict) -> None:
-    """Assert response indicates a validation error.
-
-    Step text says 'indicate a validation error' — must verify either:
-    1. An exception was raised with validation-related keywords, OR
-    2. Response.errors contains validation-related content.
-    """
-
-    error = ctx.get("error")
-    if error:
-        # Verify it's actually a validation error, not just any error
-        msg = str(error).lower()
-        assert any(kw in msg for kw in ("validation", "invalid", "required", "type", "field")), (
-            f"Expected a validation error, but error doesn't indicate validation: {error}"
-        )
-        return
-    resp = ctx.get("response")
-    if resp:
-        errors = getattr(resp, "errors", None)
-        if errors:
-            # Verify at least one error relates to validation
-            error_strs = [str(e).lower() for e in errors]
-            has_validation_keyword = any(
-                any(kw in s for kw in ("validation", "invalid", "required", "type", "field")) for s in error_strs
-            )
-            assert has_validation_keyword, f"Response has errors but none indicate validation: {errors}"
-            return
-    raise AssertionError(
-        "Expected validation error: neither error raised nor response.errors contains validation content"
-    )
-
-
-@then("the error should be a real validation error, not simulated")
-def then_real_validation_error(ctx: dict) -> None:
-    """Assert error is a real validation error (not simulated sandbox response)."""
-
-    error = ctx.get("error")
-    assert error is not None, "Expected a real validation error but no error was raised"
-    from src.core.exceptions import AdCPError
-
-    # A "real" validation error is an actual exception (not a response-embedded simulated one)
-    assert isinstance(error, (AdCPError, ValueError, TypeError)), (
-        f"Expected a real validation error (AdCPError/ValueError/TypeError), got {type(error).__name__}: {error}"
-    )
-
-
-@then("the error should include a suggestion for how to fix the issue")
-def then_error_suggestion_for_fix(ctx: dict) -> None:
-    """Assert error includes a suggestion with actionable fix guidance.
-
-    Step text: 'suggestion for how to fix the issue' — the suggestion must be
-    a non-empty string with enough content to be actionable (at least 5 chars).
-    No xfail escape — if production omits suggestions, the test must fail.
-    """
-    error = ctx.get("error")
-    assert error is not None, "Expected an error to check suggestion on"
-    from src.core.exceptions import AdCPError
-
-    assert isinstance(error, AdCPError), (
-        f"Expected AdCPError with suggestion field, got {type(error).__name__}: {error}"
-    )
-    assert error.details is not None, (
-        f"AdCPError(error_code={error.error_code!r}) has no details dict — cannot contain suggestion"
-    )
-    suggestion = error.details.get("suggestion")
-    assert isinstance(suggestion, str) and len(suggestion.strip()) >= 5, (
-        f"Expected actionable suggestion string (>= 5 chars) in error details, "
-        f"got {suggestion!r}. Step claims 'how to fix the issue' — suggestion "
-        f"must contain meaningful guidance."
-    )
+# 'the response should include sandbox equals true' / 'not include a sandbox
+# field' — no domain-specific implementation. Uses
+# tests.bdd.steps.generic.then_success (same object path: resp.sandbox).
+#
+# 'the response should indicate a validation error' — no domain-specific
+# implementation. Uses tests.bdd.steps.generic.then_error, which requires a
+# raised error with error_code == "VALIDATION_ERROR" (stricter than the old
+# domain version's response.errors fallback). Only used by
+# T-UC-019-sandbox-validation, whose next step (below) requires ctx["error"]
+# to be a real pydantic.ValidationError anyway, so a soft response.errors path
+# was never reachable here. See #1555 collision resolution.
+#
+# 'the error should be a real validation error, not simulated' / 'the error
+# should include a suggestion for how to fix the issue' — no domain-specific
+# implementation. Uses tests.bdd.steps.generic.then_error (same object path:
+# error.details["suggestion"] / isinstance(error, ValidationError)).
 
 
 @then(parsers.parse('only media buys with status "{status}" are returned'))

--- a/tests/unit/test_architecture_bdd_step_module_reachability.py
+++ b/tests/unit/test_architecture_bdd_step_module_reachability.py
@@ -45,7 +45,6 @@ _ALLOWED_UNREGISTERED: set[str] = {
     "tests.bdd.steps.domain.uc002_task_query",
     "tests.bdd.steps.domain.uc003_ext_error_scenarios",
     "tests.bdd.steps.domain.uc003_update_media_buy",
-    "tests.bdd.steps.domain.uc019_query_media_buys",
     "tests.bdd.steps.domain.uc026_package_media_buy",
     "tests.bdd.steps.generic.given_media_buy",
     "tests.bdd.steps.generic.then_media_buy",


### PR DESCRIPTION
## Summary

Closes #1555.

Wires the UC-019 get_media_buys BDD scenarios into the existing multi-transport BDD harness.

This PR is intentionally scoped to harness reachability, UC-019 step registration, collision cleanup, missing Given setup, and empirical xfail re-baselining. It does not intentionally change production behavior.

## What changed
- Registered `tests.bdd.steps.domain.uc019_query_media_buys` in `pytest_plugins`.
- Removed the UC-019 step module from the BDD reachability guard allowlist.
- Added `T-UC-019 -> "UC-019"` detection in `_detect_uc`.
- Added a UC-019 branch in `_harness_env` using the existing `MediaBuyListEnv`.
- Added teardown for any `ctx["_patchers"]` started by UC-019 datetime steps.
- Added missing UC-019 Given steps for persisted status, persisted status plus `is_paused true`, and start/end date updates for already-seeded media buys.
- Resolved the eight step-text collisions in favor of established generic steps after verifying they preserve the reachable UC-019 assertions.
- Fixed one test-data determinism bug in `given_principal_owns_active_and_completed`: when no `today is "..."` step is present, the scenario now seeds dates relative to the current UTC date instead of a hardcoded `2026-03-15` fallback.
- Re-baselined UC-019 xfails based on the focused empirical run.

## Remaining xfails / known gaps

The newly active UC-019 scenarios now expose several real gaps that remain xfailed rather than being fixed in this PR:

- REST UC-019 query scenarios: no `/media-buys/query` production route exists.
- `T-UC-019-inv-150-11`: generated feature literal `some_unmapped_internal_state` exceeds `media_buys.status VARCHAR(20)`, causing insert failure before the scenario can exercise behavior.
- `T-UC-019-ext-a` on A2A/MCP: actual error is `AUTH_TOKEN_INVALID`; spec expectation is `AUTH_REQUIRED`.
- Sandbox boundary/production scenarios: same known gap as the existing sandbox-happy xfail; sandbox mode is not implemented.
- Boundary status-filter "removed enum value": same underlying production gap as the existing invalid-status-filter xfail family.

## Generated feature-file note

#1545 carries separate UC-019 generated-feature corrections:

- INV-1: `pending_activation` -> `pending_start`
- INV-8: `draft` -> `pending_creatives`

`tests/bdd/features/BR-UC-019-query-media-buys.feature` is machine-generated from an external `adcp-req` source and should not be hand-edited in this repo. This PR intentionally wires against the generated feature file as it currently exists on main and accounts for not-yet-applied corrections through the UC-019 xfail baseline.

## Verification

- `tests/unit/test_architecture_bdd_step_module_reachability.py` — pass
- `tests/unit/test_architecture_bdd_no_shadowed_steps.py` — pass
- Full BDD architecture guard suite — 31 passed
- Focused UC-019 BDD run — 108 passed, 621 xfailed, 0 failed, 0 xpassed, 729 total
- `ruff format` / `ruff check` — clean
- `mypy` — no new errors; existing unrelated harness errors remain
- Full `tests/unit/` — 5155 passed, 8 skipped, 26 xfailed, 0 failed
- Duplication guard — net improvement; `.duplication-baseline` auto-shrunk

## Notes

No `src/` files are changed. All changes are limited to BDD/test harness files, the reachability guard, and the duplication baseline.

## Environment note
This local worktree path contains a space (`Antigravity Builds`), which breaks `tox -e bdd -- -k ...` under xdist because `{toxworkdir}` is not quoted. Focused BDD verification was therefore run through `.tox/bdd/bin/pytest` directly with the same DB environment sourced from the test stack.