### PR TITLE
chore: add optional local hook to scripts/run-test.sh

### DIFF
--- a/scripts/run-test.sh
+++ b/scripts/run-test.sh
@@ -33,6 +33,17 @@ AGENT_DB="$PROJECT_DIR/.claude/skills/agent-db/agent-db.sh"
 TEST_STACK="$PROJECT_DIR/scripts/test-stack.sh"
 STACK_ENV="$PROJECT_DIR/.test-stack.env"
 
+# Optional local test hook: drop a script at the path below to customize or
+# redirect test execution for your own setup (e.g. offload slices to a remote
+# machine). Sourced with the original args; it may `exec` (taking over) or
+# `return` (falling through to normal local execution). Completely inert if the
+# file does not exist. Set REMOTE_TEST_ACTIVE=1 to bypass it.
+_local_hook="${SA_RUN_TEST_HOOK:-$HOME/.config/salesagent/run-test-hook.sh}"
+if [[ -z "${REMOTE_TEST_ACTIVE:-}" && -f "$_local_hook" ]]; then
+    # shellcheck disable=SC1090
+    source "$_local_hook"
+fi
+
 usage() {
     echo "Usage: scripts/run-test.sh [--unit|--db|--stack] <test-path> [pytest-args...]" >&2
     echo "" >&2


### PR DESCRIPTION
## What

Small follow-up to #1572 (test-suite tooling). Adds an optional local extension point to `scripts/run-test.sh`: if a script exists at `$SA_RUN_TEST_HOOK` (default `~/.config/salesagent/run-test-hook.sh`), it is sourced with the original arguments before infrastructure setup. The hook may `exec` to take over execution (e.g. redirect a slice to a remote/CI machine) or `return` to fall through to normal local execution.

## Why

Follows the same motivation as #1572 — making the iterative test path fast on large worktree fleets. Contributors who redirect the runner to their own build/CI host can now do so via a single sourced file kept outside the tree, instead of a private fork of `run-test.sh` or a per-worktree `git update-index --skip-worktree` edit.

## Safety

- **Completely inert** when the hook file is absent — zero behavior change for anyone who doesn't opt in.
- Bypass at any time with `REMOTE_TEST_ACTIVE=1`.
- No new dependencies; +11 lines, one file, purely additive.