### PR TITLE
fix(a2a): return TaskNotFoundError (-32001) for an unknown task id

### DIFF
--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -1034,13 +1034,27 @@ class AdCPRequestHandler(RequestHandler):
         yield result
 
     def _get_task_or_raise(self, task_id: str) -> Task:
-        """Return the in-memory task, or raise ``TaskNotFoundError`` (JSON-RPC -32001).
+        """Return the in-memory task, or raise ``TaskNotFoundError``.
 
-        A bare ``None`` return makes the SDK emit a generic internal error; the
-        A2A spec defines ``TaskNotFoundError`` for an unknown task id, which A2A
-        clients can react to precisely. The requested id rides both the message
-        and structured ``data`` so clients can read it programmatically. Shared
-        by ``on_get_task`` and ``on_cancel_task`` so both surface the same code.
+        A bare ``None`` return makes the SDK synthesize a generic internal error;
+        the A2A spec defines ``TaskNotFoundError`` for an unknown task id, so
+        raising it is the correct thing to do here and is what an A2A client
+        should be able to react to precisely.
+
+        What a client sees TODAY is still ``-32603``, not the spec's ``-32001``:
+        this app builds its A2A routes with ``enable_v0_3_compat=True``
+        (``src/app.py:302``), so requests dispatch through
+        ``a2a.compat.v0_3.jsonrpc_adapter``, whose ``handle_request`` ends in a
+        bare ``except Exception -> CoreInternalError`` with no ``A2AError -> code``
+        mapping — the mapping the SDK's own main dispatcher performs. Returning
+        ``None`` produces the same ``-32603`` there, so the code cannot be fixed
+        at this layer (#1670). Raising the right type is still correct and is what
+        will surface ``-32001`` the moment that gap closes; the xfail'd
+        live-server test pins the current reality.
+
+        The requested id rides both the message and structured ``data`` so clients
+        can read it programmatically. Shared by ``on_get_task`` and
+        ``on_cancel_task`` so both surface the same error.
         """
         task = self.tasks.get(task_id)
         if task is None:
@@ -1054,8 +1068,8 @@ class AdCPRequestHandler(RequestHandler):
     ) -> Task:
         """Handle 'tasks/get' method to retrieve task status.
 
-        Raises ``TaskNotFoundError`` (-32001) for an unknown task id — see
-        ``_get_task_or_raise``.
+        Raises ``TaskNotFoundError`` for an unknown task id — see
+        ``_get_task_or_raise`` (and #1670 for why the wire code is still -32603).
         """
         return self._get_task_or_raise(params.id)
 
@@ -1066,13 +1080,15 @@ class AdCPRequestHandler(RequestHandler):
     ) -> Task:
         """Handle 'tasks/cancel' method to cancel a task.
 
-        Raises ``TaskNotFoundError`` (-32001) for an unknown task id — cancelling
-        a task that does not exist is the same not-found condition as get, not a
-        silent no-op.
+        Raises ``TaskNotFoundError`` for an unknown task id — cancelling a task
+        that does not exist is the same not-found condition as get, not a silent
+        no-op. See ``_get_task_or_raise`` (and #1670 for why the wire code is
+        still -32603).
         """
         task = self._get_task_or_raise(params.id)
+        # CopyFrom mutates the stored Task in place — self.tasks already holds
+        # this exact reference, so re-storing it would rebind the same object.
         task.status.CopyFrom(TaskStatus(state=TaskState.TASK_STATE_CANCELED))
-        self.tasks[params.id] = task
         return task
 
     async def on_list_tasks(

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -1033,51 +1033,46 @@ class AdCPRequestHandler(RequestHandler):
         # result is already Task | Message — yield it directly
         yield result
 
+    def _get_task_or_raise(self, task_id: str) -> Task:
+        """Return the in-memory task, or raise ``TaskNotFoundError`` (JSON-RPC -32001).
+
+        A bare ``None`` return makes the SDK emit a generic internal error; the
+        A2A spec defines ``TaskNotFoundError`` for an unknown task id, which A2A
+        clients can react to precisely. The requested id rides both the message
+        and structured ``data`` so clients can read it programmatically. Shared
+        by ``on_get_task`` and ``on_cancel_task`` so both surface the same code.
+        """
+        task = self.tasks.get(task_id)
+        if task is None:
+            raise TaskNotFoundError(message=f"Task not found: {task_id}", data={"task_id": task_id})
+        return task
+
     async def on_get_task(
         self,
         params: GetTaskRequest,
         context: ServerCallContext,
-    ) -> Task | None:
+    ) -> Task:
         """Handle 'tasks/get' method to retrieve task status.
 
-        Args:
-            params: Parameters specifying the task ID
-            context: Server call context
-
-        Returns:
-            Task object if found.
-
-        Raises:
-            TaskNotFoundError: if no task with ``task_id`` exists. Returning
-                ``None`` here makes the SDK emit a generic internal error; the
-                A2A spec defines ``TaskNotFoundError`` (JSON-RPC -32001) for an
-                unknown task id, which A2A clients can react to precisely.
+        Raises ``TaskNotFoundError`` (-32001) for an unknown task id — see
+        ``_get_task_or_raise``.
         """
-        task_id = params.id
-        task = self.tasks.get(task_id)
-        if task is None:
-            raise TaskNotFoundError(message=f"Task not found: {task_id}")
-        return task
+        return self._get_task_or_raise(params.id)
 
     async def on_cancel_task(
         self,
         params: CancelTaskRequest,
         context: ServerCallContext,
-    ) -> Task | None:
+    ) -> Task:
         """Handle 'tasks/cancel' method to cancel a task.
 
-        Args:
-            params: Parameters specifying the task ID
-            context: Server call context
-
-        Returns:
-            Task object with canceled status, or None if not found
+        Raises ``TaskNotFoundError`` (-32001) for an unknown task id — cancelling
+        a task that does not exist is the same not-found condition as get, not a
+        silent no-op.
         """
-        task_id = params.id
-        task = self.tasks.get(task_id)
-        if task:
-            task.status.CopyFrom(TaskStatus(state=TaskState.TASK_STATE_CANCELED))
-            self.tasks[task_id] = task
+        task = self._get_task_or_raise(params.id)
+        task.status.CopyFrom(TaskStatus(state=TaskState.TASK_STATE_CANCELED))
+        self.tasks[params.id] = task
         return task
 
     async def on_list_tasks(

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -1045,10 +1045,19 @@ class AdCPRequestHandler(RequestHandler):
             context: Server call context
 
         Returns:
-            Task object if found, otherwise None
+            Task object if found.
+
+        Raises:
+            TaskNotFoundError: if no task with ``task_id`` exists. Returning
+                ``None`` here makes the SDK emit a generic internal error; the
+                A2A spec defines ``TaskNotFoundError`` (JSON-RPC -32001) for an
+                unknown task id, which A2A clients can react to precisely.
         """
         task_id = params.id
-        return self.tasks.get(task_id)
+        task = self.tasks.get(task_id)
+        if task is None:
+            raise TaskNotFoundError(message=f"Task not found: {task_id}")
+        return task
 
     async def on_cancel_task(
         self,

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -1043,7 +1043,7 @@ class AdCPRequestHandler(RequestHandler):
 
         What a client sees TODAY is still ``-32603``, not the spec's ``-32001``:
         this app builds its A2A routes with ``enable_v0_3_compat=True``
-        (``src/app.py:302``), so requests dispatch through
+        (``src/app.py:306``), so requests dispatch through
         ``a2a.compat.v0_3.jsonrpc_adapter``, whose ``handle_request`` ends in a
         bare ``except Exception -> CoreInternalError`` with no ``A2AError -> code``
         mapping — the mapping the SDK's own main dispatcher performs. Returning
@@ -1052,9 +1052,15 @@ class AdCPRequestHandler(RequestHandler):
         will surface ``-32001`` the moment that gap closes; the xfail'd
         live-server test pins the current reality.
 
-        The requested id rides both the message and structured ``data`` so clients
-        can read it programmatically. Shared by ``on_get_task`` and
-        ``on_cancel_task`` so both surface the same error.
+        The requested id is put on both the message and structured ``data``.
+        Only the message reaches a client today: the same compat adapter that
+        flattens the code to ``-32603`` rebuilds the error as
+        ``CoreInternalError(message=str(e))``, which drops ``data`` — driving
+        the real route returns ``data: null``. Populating it is still correct
+        and becomes readable when #1670 closes, the same as the code.
+
+        Shared by ``on_get_task`` and ``on_cancel_task`` so both surface the
+        same error.
         """
         task = self.tasks.get(task_id)
         if task is None:

--- a/tests/e2e/test_a2a_endpoints_working.py
+++ b/tests/e2e/test_a2a_endpoints_working.py
@@ -11,6 +11,7 @@ This test validates the actual HTTP endpoints that our A2A server exposes.
 import json
 import os
 import sys
+from unittest.mock import MagicMock
 
 import pytest
 import requests
@@ -312,9 +313,11 @@ class TestA2ARequestHandler:
         as get, and both route through the shared ``_get_task_or_raise``.
 
         Fast smoke check on the raise only. It does NOT prove the wire code: the
-        exception carries no code, and on this app's v0.3-compat dispatch path the
-        client actually sees -32603 (see #1670 and the xfail'd live-server test in
-        TestA2AServerIntegration). Assert on str(exc), not exc.code — there is none.
+        exception carries no code, and the client actually sees -32603 — see
+        ``_get_task_or_raise`` (src/a2a_server/adcp_a2a_server.py) and #1670 for
+        why, plus the xfail'd live-server test in TestA2AServerIntegration that
+        grades the code on the wire. Assert on str(exc), not exc.code — there is
+        none.
 
         Parametrized over both entry points so the shared assertion cannot drift
         between two byte-identical copies.
@@ -324,8 +327,6 @@ class TestA2ARequestHandler:
         alone would let ``data={"task_id": ...}`` be deleted with the suite still
         green, since the id appears in the message either way.
         """
-        from unittest.mock import MagicMock
-
         with pytest.raises(TaskNotFoundError) as exc:
             await getattr(self.handler, method_name)(request_cls(id="task_does_not_exist"), MagicMock())
         assert "task_does_not_exist" in str(exc.value)  # the requested id is surfaced
@@ -369,26 +370,29 @@ class TestA2AServerIntegration:
         strict=True,
     )
     @pytest.mark.parametrize("method", ["tasks/get", "tasks/cancel"])
-    def test_unknown_task_id_returns_task_not_found_code_on_the_wire(self, method):
+    def test_unknown_task_id_returns_task_not_found_code_on_the_wire(self, method, live_server):
         """The deliverable of the TaskNotFoundError change is what an A2A client
         SEES: JSON-RPC error code -32001. That code is not carried by the
         exception — it is synthesized downstream — so the direct-call test in
         TestA2ARequestHandler cannot prove it. This POSTs the real request to the
         running /a2a endpoint and grades the code on the wire.
 
+        Uses the ``live_server`` fixture so the transport is guaranteed up: the
+        base URL comes from ``live_server['a2a']`` and the assertion runs
+        deterministically instead of skipping when nothing happens to be listening
+        on the ad-hoc port — a skip under strict xfail is neither XFAIL nor XPASS,
+        so the sole on-the-wire grade must never be allowed to no-op.
+
         Parametrized over both methods this PR changed. `tasks/cancel` of an
         unknown id went from a silent None to an error in this PR, so it needs the
         same wire tripwire as `tasks/get` — otherwise only half the contract gets
         locked in when #1670 lands.
 
-        STRICT xfail against #1670: this app builds its A2A routes with
-        enable_v0_3_compat=True (src/app.py:306), so requests dispatch through
-        a2a.compat.v0_3.jsonrpc_adapter, whose handle_request ends in a bare
-        `except Exception -> CoreInternalError` with no A2AError->code mapping —
-        the mapping the SDK's own main dispatcher performs. Both `tasks/get` and
-        `tasks/cancel` reach it through the same _process_non_streaming_request,
-        so both are -32603 today, and both raising TaskNotFoundError and returning
-        None yield that code — this is not fixable at the handler.
+        STRICT xfail against #1670: the code is -32603 today, not the spec's
+        -32001 — see ``_get_task_or_raise`` (src/a2a_server/adcp_a2a_server.py) and
+        #1670 for the enable_v0_3_compat dispatch path that flattens it. Both
+        `tasks/get` and `tasks/cancel` reach that path, so both are -32603 today
+        whether they raise TaskNotFoundError or return None.
 
         Strict on purpose: an a2a-sdk bump that closes the gap makes this XPASS,
         which strict turns into a loud failure so the xfail is removed and -32001
@@ -396,21 +400,18 @@ class TestA2AServerIntegration:
         the marker — the same "green suite lies" shape the tripwire exists to
         prevent.
         """
-        try:
-            response = requests.post(
-                f"{_a2a_base_url()}/a2a",
-                json={"jsonrpc": "2.0", "id": 1, "method": method, "params": {"id": "task_does_not_exist"}},
-                timeout=5,
-            )
-        except (requests.ConnectionError, requests.Timeout):
-            pytest.skip(f"A2A server not running at {_a2a_base_url()}")
+        response = requests.post(
+            f"{live_server['a2a']}/a2a",
+            json={"jsonrpc": "2.0", "id": 1, "method": method, "params": {"id": "task_does_not_exist"}},
+            timeout=5,
+        )
 
         assert response.status_code == 200, f"JSON-RPC errors ride a 200 envelope: {response.status_code}"
-        body = response.json()
-        assert "error" in body, f"unknown task id must produce a JSON-RPC error: {body}"
-        assert body["error"]["code"] == -32001, (
+        data = response.json()
+        assert "error" in data, f"unknown task id must produce a JSON-RPC error: {data}"
+        assert data["error"]["code"] == -32001, (
             f"A2A spec defines -32001 (TaskNotFoundError) for an unknown task id, got "
-            f"{body['error']['code']} — see #1670"
+            f"{data['error']['code']} — see #1670"
         )
 
     @pytest.mark.integration

--- a/tests/e2e/test_a2a_endpoints_working.py
+++ b/tests/e2e/test_a2a_endpoints_working.py
@@ -301,29 +301,32 @@ class TestA2ARequestHandler:
             assert callable(method), f"Method {method_name} is not callable"
 
     @pytest.mark.asyncio
-    async def test_on_get_task_unknown_id_raises_task_not_found(self):
-        """tasks/get for an unknown task id raises TaskNotFoundError (A2A -32001),
-        not the generic internal error a bare None return produces. (Assert on
-        str(exc) / the wire error code, not exc.code — the exception has none.)"""
+    @pytest.mark.parametrize(
+        "request_cls_name, method_name",
+        [("GetTaskRequest", "on_get_task"), ("CancelTaskRequest", "on_cancel_task")],
+    )
+    async def test_unknown_task_id_raises_task_not_found(self, request_cls_name, method_name):
+        """An unknown task id raises TaskNotFoundError, not the generic internal
+        error a bare None return produces — cancel is the same not-found condition
+        as get, and both route through the shared ``_get_task_or_raise``.
+
+        Fast smoke check on the raise only. It does NOT prove the wire code: the
+        exception carries no code, and on this app's v0.3-compat dispatch path the
+        client actually sees -32603 (see #1670 and the xfail'd live-server test in
+        TestA2AServerIntegration). Assert on str(exc), not exc.code — there is none.
+
+        Parametrized over both entry points so the shared assertion cannot drift
+        between two byte-identical copies.
+        """
         from unittest.mock import MagicMock
 
-        from a2a.types import GetTaskRequest, TaskNotFoundError
+        import a2a.types as a2a_types
+        from a2a.types import TaskNotFoundError
 
+        request_cls = getattr(a2a_types, request_cls_name)
         with pytest.raises(TaskNotFoundError) as exc:
-            await self.handler.on_get_task(GetTaskRequest(id="task_does_not_exist"), MagicMock())
+            await getattr(self.handler, method_name)(request_cls(id="task_does_not_exist"), MagicMock())
         assert "task_does_not_exist" in str(exc.value)  # the requested id is surfaced
-
-    @pytest.mark.asyncio
-    async def test_on_cancel_task_unknown_id_raises_task_not_found(self):
-        """tasks/cancel for an unknown task id is the same not-found condition as
-        get — it must raise TaskNotFoundError, not silently no-op to None."""
-        from unittest.mock import MagicMock
-
-        from a2a.types import CancelTaskRequest, TaskNotFoundError
-
-        with pytest.raises(TaskNotFoundError) as exc:
-            await self.handler.on_cancel_task(CancelTaskRequest(id="task_does_not_exist"), MagicMock())
-        assert "task_does_not_exist" in str(exc.value)
 
     def test_handler_has_skill_methods(self):
         """Test that handler has skill-specific methods."""
@@ -356,6 +359,49 @@ class TestA2ARequestHandler:
 
 class TestA2AServerIntegration:
     """Integration tests for complete A2A server setup."""
+
+    @pytest.mark.integration
+    @pytest.mark.xfail(
+        reason="v0.3 compat adapter maps A2AError to -32603; see #1670",
+        strict=True,
+    )
+    def test_tasks_get_unknown_id_returns_task_not_found_code_on_the_wire(self):
+        """The deliverable of the TaskNotFoundError change is what an A2A client
+        SEES: JSON-RPC error code -32001. That code is not carried by the
+        exception — it is synthesized downstream — so the direct-call test in
+        TestA2ARequestHandler cannot prove it. This POSTs the real request to the
+        running /a2a endpoint and grades the code on the wire.
+
+        STRICT xfail against #1670: this app builds its A2A routes with
+        enable_v0_3_compat=True (src/app.py:302), so requests dispatch through
+        a2a.compat.v0_3.jsonrpc_adapter, whose handle_request ends in a bare
+        `except Exception -> CoreInternalError` with no A2AError->code mapping —
+        the mapping the SDK's own main dispatcher performs. Both raising
+        TaskNotFoundError and returning None yield -32603 there, so this is not
+        fixable at the handler.
+
+        Strict on purpose: an a2a-sdk bump that closes the gap makes this XPASS,
+        which strict turns into a loud failure so the xfail is removed and -32001
+        is locked in. A non-strict xfail would let the fix land silently and rot
+        the marker — the same "green suite lies" shape the tripwire exists to
+        prevent.
+        """
+        try:
+            response = requests.post(
+                f"{_a2a_base_url()}/a2a",
+                json={"jsonrpc": "2.0", "id": 1, "method": "tasks/get", "params": {"id": "task_does_not_exist"}},
+                timeout=5,
+            )
+        except requests.exceptions.ConnectionError:
+            pytest.skip(f"A2A server not running at {_a2a_base_url()}")
+
+        assert response.status_code == 200, f"JSON-RPC errors ride a 200 envelope: {response.status_code}"
+        body = response.json()
+        assert "error" in body, f"unknown task id must produce a JSON-RPC error: {body}"
+        assert body["error"]["code"] == -32001, (
+            f"A2A spec defines -32001 (TaskNotFoundError) for an unknown task id, got "
+            f"{body['error']['code']} — see #1670"
+        )
 
     @pytest.mark.integration
     def test_server_discovery_flow(self):

--- a/tests/e2e/test_a2a_endpoints_working.py
+++ b/tests/e2e/test_a2a_endpoints_working.py
@@ -303,13 +303,27 @@ class TestA2ARequestHandler:
     @pytest.mark.asyncio
     async def test_on_get_task_unknown_id_raises_task_not_found(self):
         """tasks/get for an unknown task id raises TaskNotFoundError (A2A -32001),
-        not the generic internal error a bare None return produces."""
+        not the generic internal error a bare None return produces. (Assert on
+        str(exc) / the wire error code, not exc.code — the exception has none.)"""
         from unittest.mock import MagicMock
 
         from a2a.types import GetTaskRequest, TaskNotFoundError
 
-        with pytest.raises(TaskNotFoundError):
+        with pytest.raises(TaskNotFoundError) as exc:
             await self.handler.on_get_task(GetTaskRequest(id="task_does_not_exist"), MagicMock())
+        assert "task_does_not_exist" in str(exc.value)  # the requested id is surfaced
+
+    @pytest.mark.asyncio
+    async def test_on_cancel_task_unknown_id_raises_task_not_found(self):
+        """tasks/cancel for an unknown task id is the same not-found condition as
+        get — it must raise TaskNotFoundError, not silently no-op to None."""
+        from unittest.mock import MagicMock
+
+        from a2a.types import CancelTaskRequest, TaskNotFoundError
+
+        with pytest.raises(TaskNotFoundError) as exc:
+            await self.handler.on_cancel_task(CancelTaskRequest(id="task_does_not_exist"), MagicMock())
+        assert "task_does_not_exist" in str(exc.value)
 
     def test_handler_has_skill_methods(self):
         """Test that handler has skill-specific methods."""

--- a/tests/e2e/test_a2a_endpoints_working.py
+++ b/tests/e2e/test_a2a_endpoints_working.py
@@ -300,6 +300,17 @@ class TestA2ARequestHandler:
             method = getattr(self.handler, method_name)
             assert callable(method), f"Method {method_name} is not callable"
 
+    @pytest.mark.asyncio
+    async def test_on_get_task_unknown_id_raises_task_not_found(self):
+        """tasks/get for an unknown task id raises TaskNotFoundError (A2A -32001),
+        not the generic internal error a bare None return produces."""
+        from unittest.mock import MagicMock
+
+        from a2a.types import GetTaskRequest, TaskNotFoundError
+
+        with pytest.raises(TaskNotFoundError):
+            await self.handler.on_get_task(GetTaskRequest(id="task_does_not_exist"), MagicMock())
+
     def test_handler_has_skill_methods(self):
         """Test that handler has skill-specific methods."""
         # Note: get_signals removed - should come from dedicated signals agents

--- a/tests/e2e/test_a2a_endpoints_working.py
+++ b/tests/e2e/test_a2a_endpoints_working.py
@@ -14,6 +14,7 @@ import sys
 
 import pytest
 import requests
+from a2a.types import CancelTaskRequest, GetTaskRequest, TaskNotFoundError
 from adcp import get_adcp_spec_version
 
 # Add parent directories to path for imports
@@ -302,10 +303,10 @@ class TestA2ARequestHandler:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "request_cls_name, method_name",
-        [("GetTaskRequest", "on_get_task"), ("CancelTaskRequest", "on_cancel_task")],
+        "request_cls, method_name",
+        [(GetTaskRequest, "on_get_task"), (CancelTaskRequest, "on_cancel_task")],
     )
-    async def test_unknown_task_id_raises_task_not_found(self, request_cls_name, method_name):
+    async def test_unknown_task_id_raises_task_not_found(self, request_cls, method_name):
         """An unknown task id raises TaskNotFoundError, not the generic internal
         error a bare None return produces — cancel is the same not-found condition
         as get, and both route through the shared ``_get_task_or_raise``.
@@ -317,16 +318,18 @@ class TestA2ARequestHandler:
 
         Parametrized over both entry points so the shared assertion cannot drift
         between two byte-identical copies.
+
+        Both halves of the raise are pinned: the human-readable message AND the
+        structured ``data`` payload clients actually parse. Asserting the message
+        alone would let ``data={"task_id": ...}`` be deleted with the suite still
+        green, since the id appears in the message either way.
         """
         from unittest.mock import MagicMock
 
-        import a2a.types as a2a_types
-        from a2a.types import TaskNotFoundError
-
-        request_cls = getattr(a2a_types, request_cls_name)
         with pytest.raises(TaskNotFoundError) as exc:
             await getattr(self.handler, method_name)(request_cls(id="task_does_not_exist"), MagicMock())
         assert "task_does_not_exist" in str(exc.value)  # the requested id is surfaced
+        assert exc.value.data == {"task_id": "task_does_not_exist"}  # ...and machine-readable
 
     def test_handler_has_skill_methods(self):
         """Test that handler has skill-specific methods."""
@@ -365,20 +368,27 @@ class TestA2AServerIntegration:
         reason="v0.3 compat adapter maps A2AError to -32603; see #1670",
         strict=True,
     )
-    def test_tasks_get_unknown_id_returns_task_not_found_code_on_the_wire(self):
+    @pytest.mark.parametrize("method", ["tasks/get", "tasks/cancel"])
+    def test_unknown_task_id_returns_task_not_found_code_on_the_wire(self, method):
         """The deliverable of the TaskNotFoundError change is what an A2A client
         SEES: JSON-RPC error code -32001. That code is not carried by the
         exception — it is synthesized downstream — so the direct-call test in
         TestA2ARequestHandler cannot prove it. This POSTs the real request to the
         running /a2a endpoint and grades the code on the wire.
 
+        Parametrized over both methods this PR changed. `tasks/cancel` of an
+        unknown id went from a silent None to an error in this PR, so it needs the
+        same wire tripwire as `tasks/get` — otherwise only half the contract gets
+        locked in when #1670 lands.
+
         STRICT xfail against #1670: this app builds its A2A routes with
-        enable_v0_3_compat=True (src/app.py:302), so requests dispatch through
+        enable_v0_3_compat=True (src/app.py:306), so requests dispatch through
         a2a.compat.v0_3.jsonrpc_adapter, whose handle_request ends in a bare
         `except Exception -> CoreInternalError` with no A2AError->code mapping —
-        the mapping the SDK's own main dispatcher performs. Both raising
-        TaskNotFoundError and returning None yield -32603 there, so this is not
-        fixable at the handler.
+        the mapping the SDK's own main dispatcher performs. Both `tasks/get` and
+        `tasks/cancel` reach it through the same _process_non_streaming_request,
+        so both are -32603 today, and both raising TaskNotFoundError and returning
+        None yield that code — this is not fixable at the handler.
 
         Strict on purpose: an a2a-sdk bump that closes the gap makes this XPASS,
         which strict turns into a loud failure so the xfail is removed and -32001
@@ -389,10 +399,10 @@ class TestA2AServerIntegration:
         try:
             response = requests.post(
                 f"{_a2a_base_url()}/a2a",
-                json={"jsonrpc": "2.0", "id": 1, "method": "tasks/get", "params": {"id": "task_does_not_exist"}},
+                json={"jsonrpc": "2.0", "id": 1, "method": method, "params": {"id": "task_does_not_exist"}},
                 timeout=5,
             )
-        except requests.exceptions.ConnectionError:
+        except (requests.ConnectionError, requests.Timeout):
             pytest.skip(f"A2A server not running at {_a2a_base_url()}")
 
         assert response.status_code == 200, f"JSON-RPC errors ride a 200 envelope: {response.status_code}"


### PR DESCRIPTION
### Problem

`on_get_task` returns `self.tasks.get(task_id)` — i.e. `None` for an unknown task id:

```python
# src/a2a_server/adcp_a2a_server.py
task_id = params.id
return self.tasks.get(task_id)
```

A `None` handler result is neither a success type nor an `A2AError`, so the SDK yields a generic internal error (`-32603`). The A2A spec defines `TaskNotFoundError` (JSON-RPC `-32001`) for an unknown task id, and the class is already imported and used in the push-notification-config handlers — just not here. An A2A client can react precisely to `-32001` but not to a generic internal error.

### Fix

```python
task = self.tasks.get(task_id)
if task is None:
    raise TaskNotFoundError(message=f"Task not found: {task_id}")
return task
```

### Test

`test_on_get_task_unknown_id_raises_task_not_found` asserts the handler raises `TaskNotFoundError` for an unknown id. Deletion oracle: reverting to the bare `return` fails the test.