### PR TITLE
docs(bdd): annotate UC-019 SERVICE_UNAVAILABLE wire-code rationale

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "logfire>=4.16.0",
     "pydantic-ai-slim[google,openai,anthropic,cohere,mistral,groq]>=1.99.0",  # 1.99.0 fixes CVE-2026-46678 / GHSA-cqp8-fcvh-x7r3; use slim to avoid pydantic-ai meta-package pulling fastmcp>=3.3.0
     # Security patches for transitive dependencies
+    "mcp>=1.28.1",  # CVE-2026-59950 / GHSA-vj7q-gjh5-988w (via fastmcp)
     "pyjwt>=2.13.0",  # GHSA-752w-5fwx-jx9f; PYSEC-2026-175/177/178/179
     "filelock>=3.20.3",  # GHSA-qmgc-5h2g-mvrw
     "urllib3>=2.7.0",  # GHSA-38jv-5279-wg99 + GHSA-qccp-gfcp-xxvc + GHSA-mf9v-mfxr-j63j

--- a/tests/bdd/features/BR-UC-019-query-media-buys.feature
+++ b/tests/bdd/features/BR-UC-019-query-media-buys.feature
@@ -932,8 +932,9 @@ Feature: BR-UC-019 Query Media Buys
     And the suggestion should contain "omit" or "without the `account` filter"
     # BR-RULE-293 INV-5: validation fails -> no DB query; no partial result leak
 
-  # corrected: INTERNAL_ERROR is internal-only (src/core/exceptions.py INTERNAL_CODES)
-  # and collapses to SERVICE_UNAVAILABLE on the wire — AdCP 3.1.1
+  # CORRECTED to AdCP 3.1.1 enums/error-code.json: SERVICE_UNAVAILABLE is on-wire;
+  # INTERNAL_ERROR is absent from the enum (off-wire). Implementation: src/core/exceptions.py
+  # INTERNAL_CODES collapses INTERNAL_ERROR -> SERVICE_UNAVAILABLE on the wire.
   @T-UC-019-partition-targeting-rehydration @partition @targeting_overlay @schema-v3.1
   Scenario Outline: targeting_overlay rehydration - <partition>
     Given the principal "buyer-001" owns media buy "mb-001" with package "pkg-001"
@@ -943,8 +944,6 @@ Feature: BR-UC-019 Query Media Buys
     # BR-RULE-294: per-package fail-soft; TypeError caught narrowly; ValidationError NOT caught
     # @source repo=adcp ref=v3.1-04f59d2d5 commit=04f59d2d5 path=static/schemas/source/media-buy/get-media-buys-response.json
 
-    # corrected: INTERNAL_ERROR is internal-only (src/core/exceptions.py INTERNAL_CODES)
-    # and collapses to SERVICE_UNAVAILABLE on the wire — AdCP 3.1.1
     Examples: Valid partitions
       | partition                            | persisted_state                                       | expected_outcome                                                                                                                                                |
       | no_targeting_persisted               | no targeting_overlay and no legacy targeting          | the package "pkg-001" targeting_overlay should be null and no error should appear in response.errors[] for "pkg-001"                                            |
@@ -952,8 +951,10 @@ Feature: BR-UC-019 Query Media Buys
       | legacy_targeting_key                 | no targeting_overlay but legacy targeting {geo:['US']} | the package "pkg-001" targeting_overlay should be a Targeting object with geo ["US"]                                                                            |
       | rehydration_typeerror_partial_success | targeting_overlay set to the string 'not a dict'      | the package "pkg-001" targeting_overlay should be null and response.errors[] should include a SERVICE_UNAVAILABLE entry with message starting "TARGETING_REHYDRATION_FAILED:" |
 
-  # corrected: INTERNAL_ERROR is internal-only (src/core/exceptions.py INTERNAL_CODES)
-  # and collapses to SERVICE_UNAVAILABLE on the wire — AdCP 3.1.1
+  # CORRECTED to AdCP 3.1.1 enums/error-code.json: SERVICE_UNAVAILABLE is on-wire;
+  # INTERNAL_ERROR is absent from the enum (off-wire). Implementation: src/core/exceptions.py
+  # INTERNAL_CODES collapses INTERNAL_ERROR -> SERVICE_UNAVAILABLE on the wire.
+  # graded: unit — tests/unit/test_get_media_buys.py (BDD errors[] steps not wired; scenario dormant/xfail)
   @T-UC-019-inv-294-3 @invariant @BR-RULE-294 @error @schema-v3.1
   Scenario: INV-3 holds - TypeError during Targeting instantiation yields non-fatal SERVICE_UNAVAILABLE + null overlay
     Given the principal "buyer-001" owns media buy "mb-001" with package "pkg-001"
@@ -1209,8 +1210,9 @@ Feature: BR-UC-019 Query Media Buys
       | sandbox absent in response (production account)         | targets a production account            | should not include a sandbox field         |
       | sandbox: false in response (explicit production)        | targets an explicit production account  | should include sandbox equals false        |
 
-  # corrected: INTERNAL_ERROR is internal-only (src/core/exceptions.py INTERNAL_CODES)
-  # and collapses to SERVICE_UNAVAILABLE on the wire — AdCP 3.1.1
+  # CORRECTED to AdCP 3.1.1 enums/error-code.json: SERVICE_UNAVAILABLE is on-wire;
+  # INTERNAL_ERROR is absent from the enum (off-wire). Implementation: src/core/exceptions.py
+  # INTERNAL_CODES collapses INTERNAL_ERROR -> SERVICE_UNAVAILABLE on the wire.
   @T-UC-019-boundary-targeting-overlay @boundary @targeting_overlay @br-rule-294 @schema-v3.1
   Scenario Outline: targeting_overlay rehydration boundary - <boundary_point>
     Given the principal "buyer-001" owns media buy "mb-001" with package "pkg-001"
@@ -1219,8 +1221,6 @@ Feature: BR-UC-019 Query Media Buys
     Then <expected_outcome>
     # BR-RULE-294 BVA: per-package fail-soft on TypeError; clean rehydration otherwise
 
-    # corrected: INTERNAL_ERROR is internal-only (src/core/exceptions.py INTERNAL_CODES)
-    # and collapses to SERVICE_UNAVAILABLE on the wire — AdCP 3.1.1
     Examples: Boundary values
       | boundary_point                                                                 | persisted_state                                              | expected_outcome                                                                                                                                                                                                                       |
       | targeting_overlay key absent, targeting key absent                             | no targeting_overlay and no legacy targeting                  | the package "pkg-001" targeting_overlay should be null and no error should appear in response.errors[] for "pkg-001"                                                                                                                    |

--- a/tests/bdd/features/BR-UC-019-query-media-buys.feature
+++ b/tests/bdd/features/BR-UC-019-query-media-buys.feature
@@ -932,6 +932,8 @@ Feature: BR-UC-019 Query Media Buys
     And the suggestion should contain "omit" or "without the `account` filter"
     # BR-RULE-293 INV-5: validation fails -> no DB query; no partial result leak
 
+  # corrected: INTERNAL_ERROR is internal-only (src/core/exceptions.py INTERNAL_CODES)
+  # and collapses to SERVICE_UNAVAILABLE on the wire — AdCP 3.1.1
   @T-UC-019-partition-targeting-rehydration @partition @targeting_overlay @schema-v3.1
   Scenario Outline: targeting_overlay rehydration - <partition>
     Given the principal "buyer-001" owns media buy "mb-001" with package "pkg-001"
@@ -941,6 +943,8 @@ Feature: BR-UC-019 Query Media Buys
     # BR-RULE-294: per-package fail-soft; TypeError caught narrowly; ValidationError NOT caught
     # @source repo=adcp ref=v3.1-04f59d2d5 commit=04f59d2d5 path=static/schemas/source/media-buy/get-media-buys-response.json
 
+    # corrected: INTERNAL_ERROR is internal-only (src/core/exceptions.py INTERNAL_CODES)
+    # and collapses to SERVICE_UNAVAILABLE on the wire — AdCP 3.1.1
     Examples: Valid partitions
       | partition                            | persisted_state                                       | expected_outcome                                                                                                                                                |
       | no_targeting_persisted               | no targeting_overlay and no legacy targeting          | the package "pkg-001" targeting_overlay should be null and no error should appear in response.errors[] for "pkg-001"                                            |
@@ -948,6 +952,8 @@ Feature: BR-UC-019 Query Media Buys
       | legacy_targeting_key                 | no targeting_overlay but legacy targeting {geo:['US']} | the package "pkg-001" targeting_overlay should be a Targeting object with geo ["US"]                                                                            |
       | rehydration_typeerror_partial_success | targeting_overlay set to the string 'not a dict'      | the package "pkg-001" targeting_overlay should be null and response.errors[] should include a SERVICE_UNAVAILABLE entry with message starting "TARGETING_REHYDRATION_FAILED:" |
 
+  # corrected: INTERNAL_ERROR is internal-only (src/core/exceptions.py INTERNAL_CODES)
+  # and collapses to SERVICE_UNAVAILABLE on the wire — AdCP 3.1.1
   @T-UC-019-inv-294-3 @invariant @BR-RULE-294 @error @schema-v3.1
   Scenario: INV-3 holds - TypeError during Targeting instantiation yields non-fatal SERVICE_UNAVAILABLE + null overlay
     Given the principal "buyer-001" owns media buy "mb-001" with package "pkg-001"
@@ -1203,6 +1209,8 @@ Feature: BR-UC-019 Query Media Buys
       | sandbox absent in response (production account)         | targets a production account            | should not include a sandbox field         |
       | sandbox: false in response (explicit production)        | targets an explicit production account  | should include sandbox equals false        |
 
+  # corrected: INTERNAL_ERROR is internal-only (src/core/exceptions.py INTERNAL_CODES)
+  # and collapses to SERVICE_UNAVAILABLE on the wire — AdCP 3.1.1
   @T-UC-019-boundary-targeting-overlay @boundary @targeting_overlay @br-rule-294 @schema-v3.1
   Scenario Outline: targeting_overlay rehydration boundary - <boundary_point>
     Given the principal "buyer-001" owns media buy "mb-001" with package "pkg-001"
@@ -1211,6 +1219,8 @@ Feature: BR-UC-019 Query Media Buys
     Then <expected_outcome>
     # BR-RULE-294 BVA: per-package fail-soft on TypeError; clean rehydration otherwise
 
+    # corrected: INTERNAL_ERROR is internal-only (src/core/exceptions.py INTERNAL_CODES)
+    # and collapses to SERVICE_UNAVAILABLE on the wire — AdCP 3.1.1
     Examples: Boundary values
       | boundary_point                                                                 | persisted_state                                              | expected_outcome                                                                                                                                                                                                                       |
       | targeting_overlay key absent, targeting key absent                             | no targeting_overlay and no legacy targeting                  | the package "pkg-001" targeting_overlay should be null and no error should appear in response.errors[] for "pkg-001"                                                                                                                    |

--- a/uv.lock
+++ b/uv.lock
@@ -129,6 +129,7 @@ dependencies = [
     { name = "logfire" },
     { name = "mako" },
     { name = "markdown" },
+    { name = "mcp" },
     { name = "pillow" },
     { name = "prometheus-client" },
     { name = "psycopg2-binary" },
@@ -216,6 +217,7 @@ requires-dist = [
     { name = "logfire", specifier = ">=4.16.0" },
     { name = "mako", specifier = ">=1.3.12" },
     { name = "markdown", specifier = ">=3.4.0" },
+    { name = "mcp", specifier = ">=1.28.1" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "playwright", marker = "extra == 'ui-tests'", specifier = "==1.60.0" },
     { name = "prometheus-client", specifier = ">=0.23.1" },
@@ -2426,7 +2428,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.2"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2444,9 +2446,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Land the optional #1649 review polish: annotate UC-019 targeting-rehydration scenarios/Examples explaining why `SERVICE_UNAVAILABLE` is the wire code (`INTERNAL_ERROR` is internal-only / absent from AdCP 3.1.1 `enums/error-code.json`).
- Comment-only change in `tests/bdd/features/BR-UC-019-query-media-buys.feature`, grounded in the enum; `INTERNAL_CODES` noted as implementation.
- Dropped redundant Examples-block copies; marked INV-3 as unit-graded / dormant until BDD `errors[]` steps are wired.
- **CI unblock:** bump `mcp>=1.28.1` for CVE-2026-59950 / GHSA-vj7q-gjh5-988w (`pip-audit` / Security Audit). Canonical dep landing also in #1669.

Closes #1655.

## Test plan

- [x] Comment-only change in `.feature` file
- [x] Address Konstantin review (spec cite, dormant/unit grade, drop redundant Examples copies)
- [x] CI green on current tip
- [x] Review threads resolved after green CI