### PR TITLE
fix(ci): free disk before BDD In-Network tox sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,6 +320,23 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
+      # #1662: image build + /opt/venv + second full tox env under tox_data
+      # overflowed ubuntu-latest (~14GB free) → ENOSPC on uv sync into /app/.tox.
+      # Drop unused preinstalled toolchains and prune builder cache before compose.
+      - name: Free disk space
+        run: |
+          set -eux
+          df -h
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
+            /opt/ghc \
+            /opt/hostedtoolcache/CodeQL \
+            /usr/local/share/boost \
+            /usr/share/swift \
+            || true
+          docker builder prune -af 2>/dev/null || true
+          df -h
       - name: Clean up lingering containers
         run: |
           docker compose -f docker-compose.e2e.yml down -v 2>/dev/null || true
@@ -334,6 +351,9 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
           COMPOSE_DOCKER_CLI_BUILD: 1
+          # Serial e2e_rest leg — no xdist fan-out; default 10g tmpfs wastes RAM
+          # on ubuntu-latest and contributes to ENOSPC pressure (#1662).
+          PGDATA_TMPFS_SIZE: 2g
           # No host uvx in this job (no _setup-env); the dedicated Security
           # Audit check owns the uv-secure scan.
           RUN_ALL_SKIP_AUDIT: 1

--- a/tests/unit/test_architecture_ci_suite_coverage.py
+++ b/tests/unit/test_architecture_ci_suite_coverage.py
@@ -235,19 +235,27 @@ class TestCISuiteCoverage:
         steps = job.get("steps", [])
         assert steps, "bdd-in-network must declare steps (empty job is a vacuous pass)."
 
-        free_disk = [s for s in steps if s.get("name") == "Free disk space"]
-        assert free_disk, "bdd-in-network must include a 'Free disk space' step before compose."
-        free_run = str(free_disk[0].get("run", ""))
+        step_names = [s.get("name") for s in steps]
+        assert "Free disk space" in step_names, "bdd-in-network must include a 'Free disk space' step before compose."
+        assert "Run BDD suite in-network" in step_names, "bdd-in-network must run ./run_all_tests.sh bdd_e2e."
+        free_idx = step_names.index("Free disk space")
+        run_idx = step_names.index("Run BDD suite in-network")
+        assert free_idx < run_idx, (
+            "Free disk space must run before 'Run BDD suite in-network' "
+            f"(found Free disk at {free_idx}, run at {run_idx})."
+        )
+
+        free_run = str(steps[free_idx].get("run", ""))
         assert "/usr/share/dotnet" in free_run, "Free disk space must remove /usr/share/dotnet."
         assert "docker builder prune" in free_run, "Free disk space must prune the Docker builder cache."
 
-        run_steps = [s for s in steps if s.get("name") == "Run BDD suite in-network"]
-        assert run_steps, "bdd-in-network must run ./run_all_tests.sh bdd_e2e."
-        env = run_steps[0].get("env") or {}
+        run_step = steps[run_idx]
+        env = run_step.get("env") or {}
         assert env.get("PGDATA_TMPFS_SIZE") == "2g", (
-            "bdd-in-network must set PGDATA_TMPFS_SIZE=2g (serial leg; default 10g overflows runners)."
+            "bdd-in-network must set PGDATA_TMPFS_SIZE=2g "
+            "(serial leg; default 10g wastes RAM / contributes to pressure)."
         )
-        assert "run_all_tests.sh bdd_e2e" in str(run_steps[0].get("run", "")), (
+        assert "run_all_tests.sh bdd_e2e" in str(run_step.get("run", "")), (
             "bdd-in-network must invoke ./run_all_tests.sh bdd_e2e."
         )
 

--- a/tests/unit/test_architecture_ci_suite_coverage.py
+++ b/tests/unit/test_architecture_ci_suite_coverage.py
@@ -224,6 +224,34 @@ class TestCISuiteCoverage:
         )
 
     @pytest.mark.arch_guard
+    def test_bdd_in_network_frees_disk_before_compose(self):
+        """In-network e2e_rest must reclaim runner disk before image build (#1662).
+
+        Regression: after #1613/#1634, ``uv sync`` into ``tox_data`` hit ENOSPC
+        on ubuntu-latest (image + /opt/venv + second full tox env). The job must
+        free preinstalled toolchains and cap PGDATA tmpfs for the serial leg.
+        """
+        job = load_ci_workflow()["jobs"]["bdd-in-network"]
+        steps = job.get("steps", [])
+        assert steps, "bdd-in-network must declare steps (empty job is a vacuous pass)."
+
+        free_disk = [s for s in steps if s.get("name") == "Free disk space"]
+        assert free_disk, "bdd-in-network must include a 'Free disk space' step before compose."
+        free_run = str(free_disk[0].get("run", ""))
+        assert "/usr/share/dotnet" in free_run, "Free disk space must remove /usr/share/dotnet."
+        assert "docker builder prune" in free_run, "Free disk space must prune the Docker builder cache."
+
+        run_steps = [s for s in steps if s.get("name") == "Run BDD suite in-network"]
+        assert run_steps, "bdd-in-network must run ./run_all_tests.sh bdd_e2e."
+        env = run_steps[0].get("env") or {}
+        assert env.get("PGDATA_TMPFS_SIZE") == "2g", (
+            "bdd-in-network must set PGDATA_TMPFS_SIZE=2g (serial leg; default 10g overflows runners)."
+        )
+        assert "run_all_tests.sh bdd_e2e" in str(run_steps[0].get("run", "")), (
+            "bdd-in-network must invoke ./run_all_tests.sh bdd_e2e."
+        )
+
+    @pytest.mark.arch_guard
     def test_bdd_and_e2e_run_on_pull_request(self):
         """The gate is worthless if it doesn't run on PRs.
 


### PR DESCRIPTION
## Summary

- `main` is red after #1613 / #1634: Quality Gate is green, but **BDD In-Network (e2e_rest)** dies on `uv sync` into `tox_data` with `No space left on device` (reproduced on merge + rerun of https://github.com/prebid/salesagent/actions/runs/29512105304).
- Free runner disk (drop unused toolchains + `docker builder prune`) before compose build; cap `PGDATA_TMPFS_SIZE=2g` for this serial leg (default 10g is for heavy xdist).
- Guard `test_bdd_in_network_frees_disk_before_compose` pins the mitigations (mutation-proofed).

Closes #1662.

## Context (what the ratchet merges actually did)

| Merge | Effect on `main` |
|-------|------------------|
| #1613 | Quality Gate red: live `PLR0912=135` vs baseline `134` |
| #1634 | Quality Gate fixed (helper extract → 134; C901 auto-lower 186→185). BDD In-Network then ENOSPCs |

Ratchet baselines themselves match live counts (`C901=185`, `PLR0912=134`, `PLR0915=108`, mypy untyped-defs `227`).

## Test plan

- [x] `make quality-ci` green locally
- [x] Guard passes; fails when `Free disk space` step is renamed (mutation proof)
- [ ] CI: BDD In-Network green on this PR
- [ ] Post-merge: `main` CI green