### PR TITLE
fix: upgrade mcp for CVE-2026-59950

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "a2wsgi>=1.10.0",
     "adcp==6.6.0",  # exact pin — 6.6.0 (latest stable); bump WIP, see docs/adcp-spec-version.md
     "fastmcp>=3.2.0,<3.3.0", # 3.3.0 split fastmcp-slim[server] from the monolith (breaking Context/Middleware imports); stay on 3.2.x
+    "mcp>=1.28.1", # fixes CVE-2026-59950 / GHSA-vj7q-gjh5-988w
     "google-cloud-iam>=2.19.1",
     "rich>=13.7.1",
     "google-ads>=24.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -129,6 +129,7 @@ dependencies = [
     { name = "logfire" },
     { name = "mako" },
     { name = "markdown" },
+    { name = "mcp" },
     { name = "pillow" },
     { name = "prometheus-client" },
     { name = "psycopg2-binary" },
@@ -216,6 +217,7 @@ requires-dist = [
     { name = "logfire", specifier = ">=4.16.0" },
     { name = "mako", specifier = ">=1.3.12" },
     { name = "markdown", specifier = ">=3.4.0" },
+    { name = "mcp", specifier = ">=1.28.1" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "playwright", marker = "extra == 'ui-tests'", specifier = "==1.60.0" },
     { name = "prometheus-client", specifier = ">=0.23.1" },
@@ -2426,7 +2428,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.2"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2444,9 +2446,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- require `mcp>=1.28.1`
- refresh `uv.lock` from MCP 1.27.2 to 1.28.1

## Why

MCP 1.27.2 is affected by CVE-2026-59950 / GHSA-vj7q-gjh5-988w. Both the CI security audit and the standalone `pip-audit` workflow reject that version. MCP 1.28.1 is the first patched release.

## Validation

- `./scripts/security-audit.sh --no-check-uv-tool` — clean, 249 dependencies checked
- `make quality` — passed
- unit suite — 5,493 passed, 9 skipped, 26 expected failures
- runtime import check — FastMCP 3.2.0 with MCP 1.28.1

The local macOS `pip-audit` runner crashed while creating its temporary virtual environment; the GitHub Actions job will exercise that audit on Ubuntu.
