### PR TITLE
chore(deps): bump pyasn1 to 0.6.4 for PYSEC-2026-3455/3456/3457

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "cryptography>=46.0.7",  # GHSA-r6ph-v2qm-q3c2 + GHSA-p423-j2cm-9vmq
     "pillow>=12.3.0",  # GHSA-cfh3-3jmp-rvhc + GHSA-whj4-6x5x-4v2j; PYSEC-2026-2253/2254/2255/2256/2257
     "python-multipart>=0.0.27",  # GHSA-wp53-j4wj-2cfg + GHSA-mj87-hwqh-73pj + GHSA-pp6c-gr5w-3c5g
-    "pyasn1>=0.6.3",  # GHSA-jr27-m4p2-rc6r
+    "pyasn1>=0.6.4",  # GHSA-jr27-m4p2-rc6r; PYSEC-2026-3455/3456/3457
     "mako>=1.3.12",  # GHSA-2h4p-vjrc-8xpq (transitive via alembic)
     "click>=8.3.3",  # PYSEC-2026-2132 (transitive via flask/uvicorn)
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -222,7 +222,7 @@ requires-dist = [
     { name = "playwright", marker = "extra == 'ui-tests'", specifier = "==1.60.0" },
     { name = "prometheus-client", specifier = ">=0.23.1" },
     { name = "psycopg2-binary", specifier = ">=2.9.9" },
-    { name = "pyasn1", specifier = ">=0.6.3" },
+    { name = "pyasn1", specifier = ">=0.6.4" },
     { name = "pydantic-ai-slim", extras = ["google", "openai", "anthropic", "cohere", "mistral", "groq"], specifier = ">=1.99.0" },
     { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "pytest-asyncio", marker = "extra == 'ui-tests'", specifier = ">=1.1.0" },
@@ -3138,11 +3138,11 @@ memory = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`pip-audit` and `Security Audit` are failing on every open PR as of today. `pyasn1 0.6.3` picked up three advisories, all fixed in `0.6.4`:

```
Name   Version ID              Fix Versions
------ ------- --------------- ------------
pyasn1 0.6.3   PYSEC-2026-3455 0.6.4
pyasn1 0.6.3   PYSEC-2026-3456 0.6.4
pyasn1 0.6.3   PYSEC-2026-3457 0.6.4
```

The pin is already direct in `pyproject.toml` (raised once before for GHSA-jr27-m4p2-rc6r), so this is the same one-line bump plus the lock, matching the convention of the neighbouring entries.

## Verification

Ran the scanner against both versions in isolation:

- `pip-audit --no-deps` on `pyasn1==0.6.3` reports the three PYSEC IDs above
- `pip-audit --no-deps` on `pyasn1==0.6.4` reports `No known vulnerabilities found`
- `uv export --no-hashes --format requirements-txt` now resolves `pyasn1==0.6.4`, which is the input the CI job audits

## Scope

Two files, no source changes. `pyasn1` is transitive-in-practice (it arrives via the Google auth stack); the direct pin exists only to hold a floor for advisories like this one.