### PR TITLE
test(bdd): wire BR-UC-001 get_products alt-empty/alt-filtered onto ProductEnv (#1822)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ AST-scanning tests enforce architecture invariants on every `make quality` run. 
 
 ## AdCP Spec Version
 
-This project targets AdCP spec **3.1.0-beta.3** via the `adcp==5.7.0` Python SDK. See
+This project targets AdCP spec **3.1.1** via the `adcp==6.6.0` Python SDK. See
 [docs/adcp-spec-version.md](docs/adcp-spec-version.md) for the version mapping
 and bump procedure. The CI guard at `tests/unit/test_adcp_spec_version.py`
 fails on pin drift.

--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -58,6 +58,7 @@ pytest_plugins = [
     "tests.bdd.steps.domain.uc004_delivery",
     "tests.bdd.steps.domain.uc002_create_media_buy",
     "tests.bdd.steps.domain.uc002_nfr",
+    "tests.bdd.steps.domain.uc001_discover_inventory",
     "tests.bdd.steps.domain.uc003_update_media_buy",
     "tests.bdd.steps.domain.uc003_ext_error_scenarios",
     "tests.bdd.steps.domain.uc006_sync_creatives",
@@ -3075,6 +3076,8 @@ def _setup_existing_media_buy(ctx: dict, env: object, tenant: object, principal:
 def _detect_uc(request: pytest.FixtureRequest) -> str | None:
     """Detect which use case a BDD scenario belongs to via its tags."""
     marker_names = {m.name for m in request.node.iter_markers()}
+    if any(t.startswith("T-UC-001-") for t in marker_names):
+        return "UC-001"
     if any(t.startswith("T-UC-002") for t in marker_names):
         return "UC-002"
     if any(t.startswith("T-UC-003") for t in marker_names):
@@ -3517,6 +3520,39 @@ def _harness_env(request: pytest.FixtureRequest, ctx: dict) -> Generator[None, N
                 yield
         else:
             pytest.xfail(f"UC-004 harness not yet wired for type: {harness_type}")
+    elif uc == "UC-001":
+        # get_products discovery (salesagent-cfrg port-minus of salesagent-8wf2/pli8).
+        # The wired set runs a real get_products through every transport on
+        # ProductEnv; the seeded catalog (open US/guaranteed, open GB/non_guaranteed,
+        # and one product restricted to another principal) makes the visibility
+        # and filter asserts non-vacuous. T-UC-001-main (#1595) and
+        # T-UC-001-alt-anonymous (#1591) are not wired on this slice. Everything
+        # else stays dormant here: wiring never forces graduation.
+        _UC001_WIRED = {
+            "T-UC-001-alt-empty",
+            "T-UC-001-alt-filtered",
+        }
+        marker_names = {m.name for m in request.node.iter_markers()}
+        if marker_names & _UC001_WIRED:
+            from tests.factories import PricingOptionFactory, ProductFactory
+            from tests.harness.product import ProductEnv
+
+            with _db_scope_for(request, e2e_config), ProductEnv(e2e_config=e2e_config) as env:
+                tenant, principal = env.setup_default_data()
+                ctx["env"] = env
+                ctx["tenant"] = tenant
+                ctx["principal"] = principal
+                open_us = ProductFactory(tenant=tenant, countries=["US"])
+                PricingOptionFactory(product=open_us)
+                open_gb = ProductFactory(tenant=tenant, delivery_type="non_guaranteed", countries=["GB"])
+                PricingOptionFactory(product=open_gb)
+                restricted = ProductFactory(tenant=tenant, countries=["US"], allowed_principal_ids=["someone-else"])
+                PricingOptionFactory(product=restricted)
+                ctx["seeded_products"] = [open_us, open_gb, restricted]
+                ctx["restricted_product_ids"] = {restricted.product_id}
+                yield
+        else:
+            pytest.xfail("UC-001 harness not yet wired for this scenario (salesagent-cfrg)")
     elif uc == "UC-GET-PRODUCTS":
         from tests.harness.product import ProductEnv
 

--- a/tests/bdd/steps/_datatable.py
+++ b/tests/bdd/steps/_datatable.py
@@ -1,0 +1,21 @@
+"""Shared pytest-bdd datatable parsing helpers.
+
+One canonical headered-table parser for all step modules — per-module copies
+drift (the uc009 copy stripped whitespace, the generic one didn't).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+
+def datatable_to_dicts(datatable: Sequence[Sequence[object]]) -> list[dict[str, str]]:
+    """Convert a pytest-bdd raw datatable (list of lists) to one dict per row.
+
+    The first row is treated as column headers. Remaining rows become dicts
+    keyed by those headers. Header and cell values are str()-coerced and
+    whitespace-stripped, so Gherkin table padding never leaks into keys or
+    values.
+    """
+    headers = [str(cell).strip() for cell in datatable[0]]
+    return [{h: str(v).strip() for h, v in zip(headers, row, strict=True)} for row in datatable[1:]]

--- a/tests/bdd/steps/domain/uc001_discover_inventory.py
+++ b/tests/bdd/steps/domain/uc001_discover_inventory.py
@@ -17,7 +17,7 @@ from typing import Any
 
 from pytest_bdd import given, parsers, then, when
 
-from tests.bdd.steps._outcome_helpers import _require_response, wire_field
+from tests.bdd.steps._outcome_helpers import wire_field
 from tests.bdd.steps.generic._dispatch import dispatch_request
 
 
@@ -117,13 +117,6 @@ def when_send_get_products(ctx: dict, datatable: list) -> None:
 def _wire_products(ctx: dict) -> list[dict[str, Any]]:
     """The products array as the buyer sees it on the serialized wire."""
     return wire_field(ctx, "products")
-
-
-@then(parsers.parse('the response status should be "completed"'))
-def then_status_completed(ctx: dict) -> None:
-    """get_products succeeded — a completed synchronous discovery response."""
-    assert ctx.get("error") is None, f"Request failed: {ctx.get('error')}"
-    assert _require_response(ctx).products is not None
 
 
 @then('the response should contain "products" array')

--- a/tests/bdd/steps/domain/uc001_discover_inventory.py
+++ b/tests/bdd/steps/domain/uc001_discover_inventory.py
@@ -1,0 +1,235 @@
+"""Steps for UC-001 discover available inventory (get_products) — salesagent-8wf2.
+
+Wired scenarios dispatch a real get_products through the parametrized wire
+transport (a2a/mcp/rest) via ProductEnv. The catalog is seeded by the UC-001
+conftest branch (three products: guaranteed/US, non_guaranteed/GB, and one
+restricted to another principal) so visibility and filter assertions are
+non-vacuous. Success-path asserts read the REAL serialized wire body via
+``wire_field`` where the transport stashes it (REST always; A2A/MCP via the
+client/handler dispatchers), so the v3.1.1 format_id object contract on the
+products wire is graded here (r50r follow-up landed with 8wf2).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from pytest_bdd import given, parsers, then, when
+
+from tests.bdd.steps._outcome_helpers import _require_response, wire_field
+from tests.bdd.steps.generic._dispatch import dispatch_request
+
+
+def _datatable_to_kwargs(datatable: list) -> dict[str, Any]:
+    """Convert a two-column field/value datatable to request kwargs.
+
+    JSON-looking values (objects, arrays) are parsed; everything else stays a
+    string. ``buying_mode`` is dropped: production defaults it to brief
+    (BR-RULE-079 pre-v3 fallback) and GetProductsBody does not declare it yet
+    (spec-gap tracked in salesagent-ilbv) — sending it would trip the Pattern
+    #7 dev-forbid gate on REST rather than exercise discovery.
+    """
+    headers = [str(h).strip() for h in datatable[0]]
+    field_idx, value_idx = headers.index("field"), headers.index("value")
+    kwargs: dict[str, Any] = {}
+    for row in datatable[1:]:
+        field = str(row[field_idx]).strip()
+        raw = str(row[value_idx]).strip()
+        if field == "buying_mode":
+            continue
+        if raw.startswith(("{", "[")):
+            kwargs[field] = json.loads(raw)
+        else:
+            kwargs[field] = raw
+    return kwargs
+
+
+# ── Given steps ─────────────────────────────────────────────────────
+
+
+@given("a tenant exists with at least one product in the catalog")
+def given_tenant_with_catalog(ctx: dict) -> None:
+    """Background step: the UC-001 conftest branch seeded tenant + catalog."""
+    env = ctx["env"]
+    tenant, principal = env.setup_default_data()
+    ctx.setdefault("tenant", tenant)
+    ctx.setdefault("principal", principal)
+    assert ctx.get("seeded_products"), "UC-001 conftest branch did not seed the catalog"
+
+
+@given(parsers.parse('the tenant brand_manifest_policy is "{policy}"'))
+def given_brand_manifest_policy(ctx: dict, policy: str) -> None:
+    """Set the tenant's brand manifest policy column (products.py:194 reads it)."""
+    env = ctx["env"]
+    tenant, principal = env.setup_default_data()
+    ctx.setdefault("tenant", tenant)
+    ctx.setdefault("principal", principal)
+    tenant.brand_manifest_policy = policy
+    env.get_session().commit()
+
+
+@given("the tenant has an advertising_policy configured")
+def given_advertising_policy(ctx: dict) -> None:
+    """Give the tenant a non-empty advertising policy."""
+    env = ctx["env"]
+    tenant, _ = env.setup_default_data()
+    tenant.advertising_policy = {"prohibited_categories": ["weapons"]}
+    env.get_session().commit()
+
+
+@given(
+    "the product catalog contains products with valid schema "
+    "(format_ids, publisher_properties, pricing_options, reporting_capabilities)"
+)
+def given_valid_catalog(ctx: dict) -> None:
+    """The conftest UC-001 branch seeded the catalog; assert it is present."""
+    assert ctx.get("seeded_products"), "UC-001 conftest branch did not seed the catalog"
+
+
+@given("no products match the specified filters and brief")
+def given_no_matching_products(ctx: dict) -> None:
+    """Constrain the request so the seeded catalog matches nothing.
+
+    The catalog rows exist (seeded by the fixture); 'no products match the
+    SPECIFIED filters' is made literally true by specifying a country filter
+    no seeded product serves.
+    """
+    ctx.setdefault("request_preset", {})["filters"] = {"countries": ["ZZ"]}
+
+
+# ── When step ───────────────────────────────────────────────────────
+
+
+@when("the Buyer Agent sends a get_products request with:")
+def when_send_get_products(ctx: dict, datatable: list) -> None:
+    """Dispatch get_products with the table fields through the wire transport."""
+    kwargs = {**_datatable_to_kwargs(datatable), **ctx.get("request_preset", {})}
+    if "dispatch_identity" in ctx:
+        dispatch_request(ctx, identity=ctx["dispatch_identity"], **kwargs)
+    else:
+        dispatch_request(ctx, **kwargs)
+
+
+# ── Then steps ──────────────────────────────────────────────────────
+
+
+def _wire_products(ctx: dict) -> list[dict[str, Any]]:
+    """The products array as the buyer sees it on the serialized wire."""
+    return wire_field(ctx, "products")
+
+
+@then(parsers.parse('the response status should be "completed"'))
+def then_status_completed(ctx: dict) -> None:
+    """get_products succeeded — a completed synchronous discovery response."""
+    assert ctx.get("error") is None, f"Request failed: {ctx.get('error')}"
+    assert _require_response(ctx).products is not None
+
+
+@then('the response should contain "products" array')
+def then_contains_products_array(ctx: dict) -> None:
+    products = _wire_products(ctx)
+    assert isinstance(products, list), f"products is not an array on the wire: {type(products).__name__}"
+    assert products, "products array is empty — seeded catalog should be visible"
+    # v3.1.1 core/format-id.json: every format_id on the products wire is an
+    # object carrying agent_url + id, never a bare string (federation contract).
+    from tests.helpers.format_assertions import assert_wire_format_id_is_object
+
+    for product in products:
+        for fid in product.get("format_ids", []):
+            assert_wire_format_id_is_object(fid)
+
+
+@then('the response "products" array should be empty')
+def then_products_array_empty(ctx: dict) -> None:
+    products = _wire_products(ctx)
+    assert products == [], f"expected empty products array, got {len(products)} entries"
+
+
+@then("every product should have pricing_options as an empty array")
+def then_pricing_suppressed(ctx: dict) -> None:
+    """Anonymous requests get pricing suppressed — only meaningful non-vacuously."""
+    products = _wire_products(ctx)
+    assert products, "no products returned — pricing suppression is unobservable on an empty catalog"
+    for product in products:
+        assert product.get("pricing_options") == [], (
+            f"pricing_options not suppressed for anonymous buyer on {product.get('product_id')!r}: "
+            f"{product.get('pricing_options')!r}"
+        )
+
+
+@then("no products with allowed_principal_ids restrictions should be visible")
+def then_restricted_products_hidden(ctx: dict) -> None:
+    products = _wire_products(ctx)
+    restricted_ids = ctx.get("restricted_product_ids", set())
+    assert restricted_ids, "fixture seeded no restricted product — assertion would be vacuous"
+    visible = {p.get("product_id") for p in products}
+    leaked = visible & restricted_ids
+    assert not leaked, f"restricted products visible to anonymous buyer: {leaked}"
+
+
+@then(parsers.parse('every product should match the delivery_type "{expected}"'))
+def then_products_match_delivery_type(ctx: dict, expected: str) -> None:
+    products = _wire_products(ctx)
+    assert products, "no products returned — delivery_type filter is unobservable on an empty result"
+    for product in products:
+        assert product.get("delivery_type") == expected, (
+            f"{product.get('product_id')!r} has delivery_type {product.get('delivery_type')!r}, expected {expected!r}"
+        )
+
+
+@then(parsers.parse("every product should have countries overlapping with {countries}"))
+def then_products_match_countries(ctx: dict, countries: str) -> None:
+    """Country filtering is observable by product identity, not a wire field.
+
+    ``Product.countries`` is an internal filter field (``exclude=True`` in the
+    schema — never serialized), so the filter's effect is asserted against the
+    seeded catalog: only products whose DB row serves an overlapping country
+    may come back, and at least one must (the catalog seeds a matching one).
+    """
+    requested = set(json.loads(countries))
+    products = _wire_products(ctx)
+    assert products, "no products returned — country filter is unobservable on an empty result"
+    matching_ids = {p.product_id for p in ctx["seeded_products"] if set(p.countries or []) & requested}
+    returned_ids = {p.get("product_id") for p in products}
+    off_target = returned_ids - matching_ids
+    assert not off_target, (
+        f"products not serving {sorted(requested)} leaked through the country filter: {sorted(off_target)}"
+    )
+
+
+@then(
+    "each product should have product_id, name, format_ids, publisher_properties, "
+    "pricing_options, and reporting_capabilities"
+)
+def then_products_have_required_fields(ctx: dict) -> None:
+    products = _wire_products(ctx)
+    assert products, "no products returned"
+    required = ("product_id", "name", "format_ids", "publisher_properties", "pricing_options", "reporting_capabilities")
+    for product in products:
+        for field in required:
+            assert product.get(field) is not None, f"{product.get('product_id')!r} missing required field {field!r}"
+
+
+@then("the products should be ordered by relevance_score descending")
+def then_products_ordered_by_relevance(ctx: dict) -> None:
+    """Production gap: relevance_score is not emitted on the products wire.
+
+    The impl sorts internally when AI ranking is enabled but never serializes
+    a relevance_score field. Dormant until T-UC-001-main is wired (#1595).
+    """
+    products = _wire_products(ctx)
+    scores = [p.get("relevance_score") for p in products]
+    assert all(s is not None for s in scores), f"relevance_score missing on the wire: {scores}"
+    assert scores == sorted(scores, reverse=True), f"products not ordered by relevance_score desc: {scores}"
+
+
+@then("each product should include brief_relevance explanation")
+def then_products_have_brief_relevance(ctx: dict) -> None:
+    """Production gap twin of the relevance ordering assert. Dormant until T-UC-001-main is wired (#1595)."""
+    products = _wire_products(ctx)
+    assert products, "no products returned"
+    for product in products:
+        assert product.get("brief_relevance"), (
+            f"{product.get('product_id')!r} has no brief_relevance explanation on the wire"
+        )

--- a/tests/bdd/steps/generic/given_config.py
+++ b/tests/bdd/steps/generic/given_config.py
@@ -15,6 +15,7 @@ from collections.abc import Sequence
 
 from pytest_bdd import given, parsers
 
+from tests.bdd.steps._datatable import datatable_to_dicts
 from tests.bdd.steps.generic._registry import sync_registry as _sync_registry
 from tests.factories.format import (
     CATEGORY_MAP,
@@ -39,16 +40,6 @@ def _add_format(ctx: dict, fmt: object) -> None:
         ctx["registry_formats"] = []
         ctx["_config_replaced"] = True
     ctx["registry_formats"].append(fmt)
-
-
-def _datatable_to_dicts(datatable: Sequence[Sequence[object]]) -> list[dict[str, str]]:
-    """Convert pytest-bdd raw datatable (list of lists) to list of dicts.
-
-    The first row is treated as column headers. Remaining rows become dicts
-    keyed by those headers.
-    """
-    headers = [str(cell) for cell in datatable[0]]
-    return [{headers[i]: str(cell) for i, cell in enumerate(row)} for row in datatable[1:]]
 
 
 # ── Format by type + asset type ──────────────────────────────────────
@@ -120,7 +111,7 @@ def given_registry_format_with_asset_group(ctx: dict, name: str, type_a: str, ty
 @given(parsers.parse('the registry has format "{name}" with renders:'))
 def given_registry_format_with_renders(ctx: dict, name: str, datatable: Sequence[Sequence[object]]) -> None:
     """Register a format with render dimensions from a data table."""
-    rows = _datatable_to_dicts(datatable)
+    rows = datatable_to_dicts(datatable)
     renders = [make_renders(width=int(row["width"]), height=int(row["height"])) for row in rows]
     fmt = FormatFactory.build(name=name, renders=renders)
     _add_format(ctx, fmt)
@@ -199,7 +190,7 @@ def given_registry_format_no_disclosure(ctx: dict, name: str) -> None:
 @given(parsers.parse('the registry has format "{name}" with output_format_ids:'))
 def given_registry_format_output_ids(ctx: dict, name: str, datatable: Sequence[Sequence[object]]) -> None:
     """Register a format with output_format_ids from a data table."""
-    rows = _datatable_to_dicts(datatable)
+    rows = datatable_to_dicts(datatable)
     ids = [FormatIdFactory.build(agent_url=row["agent_url"], id=row["id"]) for row in rows]
     fmt = FormatFactory.build(name=name, output_format_ids=ids)
     _add_format(ctx, fmt)
@@ -217,7 +208,7 @@ def given_registry_format_no_output_ids(ctx: dict, name: str) -> None:
 @given(parsers.parse('the registry has format "{name}" with input_format_ids:'))
 def given_registry_format_input_ids(ctx: dict, name: str, datatable: Sequence[Sequence[object]]) -> None:
     """Register a format with input_format_ids from a data table."""
-    rows = _datatable_to_dicts(datatable)
+    rows = datatable_to_dicts(datatable)
     ids = [FormatIdFactory.build(agent_url=row["agent_url"], id=row["id"]) for row in rows]
     fmt = FormatFactory.build(name=name, input_format_ids=ids)
     _add_format(ctx, fmt)
@@ -238,7 +229,7 @@ def given_registry_format_no_input_ids(ctx: dict, name: str) -> None:
 @given("the registry has formats:")
 def given_registry_formats_table(ctx: dict, datatable: Sequence[Sequence[object]]) -> None:
     """Register multiple formats from a data table with name and type columns."""
-    rows = _datatable_to_dicts(datatable)
+    rows = datatable_to_dicts(datatable)
     formats = [FormatFactory.build(name=row["name"], type=CATEGORY_MAP.get(row["type"])) for row in rows]
     ctx["registry_formats"] = formats
     _sync_registry(ctx)

--- a/tests/bdd/steps/generic/then_success.py
+++ b/tests/bdd/steps/generic/then_success.py
@@ -34,6 +34,7 @@ _STATUSLESS_SUCCESS_ATTRS: tuple[str, ...] = (
     "formats",  # ListCreativeFormatsResponse
     "media_buy_deliveries",  # GetMediaBuyDeliveryResponse
     "aggregated_totals",  # GetMediaBuyDeliveryResponse
+    "products",  # GetProductsResponse
 )
 
 
@@ -83,7 +84,7 @@ def then_response_status(ctx: dict, status: str) -> None:
         assert value is not None, (
             f"Status 'completed' claimed but response.{attr} is None — the schema-required success payload is missing"
         )
-        if attr in ("formats", "media_buy_deliveries"):
+        if attr in ("formats", "media_buy_deliveries", "products"):
             assert isinstance(value, list), (
                 f"Status 'completed' claimed but response.{attr} is {type(value).__name__}, expected a list"
             )

--- a/tests/bdd/test_uc001_discover_available_inventory.py
+++ b/tests/bdd/test_uc001_discover_available_inventory.py
@@ -1,0 +1,16 @@
+"""BDD scenario binding for UC-001: Discover Available Inventory (get_products).
+
+Uses pytest-bdd's ``scenarios()`` to auto-generate test functions from the
+generated feature file. Step definitions are imported via conftest.py.
+
+Wired set (salesagent-cfrg, port-minus of salesagent-pli8 / salesagent-8wf2):
+alt-empty, alt-filtered pass on all wire transports. T-UC-001-main (#1595)
+and T-UC-001-alt-anonymous (#1591) are not wired on this slice. Every other
+scenario stays dormant via the UC-001 fixture catch-all xfail.
+"""
+
+from __future__ import annotations
+
+from pytest_bdd import scenarios
+
+scenarios("features/BR-UC-001-discover-available-inventory.feature")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -510,10 +510,13 @@ def sample_products(integration_db, sample_tenant):
 @pytest.fixture(scope="function")
 def mcp_server(integration_db):
     """Start a real MCP server for integration testing using the test database."""
+    import shutil
     import socket
     import subprocess
     import sys
+    import tempfile
     import time
+    from pathlib import Path
 
     # Find an available port
     def get_free_port():
@@ -564,13 +567,34 @@ from src.core.main import mcp
 mcp.run(transport='http', host='0.0.0.0', port={port})
 """
 
-    process = subprocess.Popen(
-        [sys.executable, "-c", server_script],
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        bufsize=1,  # Line buffered
-    )
+    # The server's output goes to FILES, never PIPEs. A PIPE nobody drains caps
+    # at 64KB; once server logging fills it, the server blocks on a log write
+    # INSIDE a request handler and the calling test awaits forever — this wedged
+    # every full CI run at integration's quiet tail until the >1h run reaper
+    # killed it (salesagent-cu12). Files keep the error-path diagnostics below
+    # without needing a drainer thread.
+    output_dir = Path(tempfile.mkdtemp(prefix=f"mcp-server-{port}-"))
+    stdout_path = output_dir / "stdout.log"
+    stderr_path = output_dir / "stderr.log"
+    stdout_f = stdout_path.open("wb")
+    stderr_f = stderr_path.open("wb")
+    try:
+        process = subprocess.Popen(
+            [sys.executable, "-c", server_script],
+            env=env,
+            stdout=stdout_f,
+            stderr=stderr_f,
+        )
+    finally:
+        # The child inherited the fds; the parent's handles are not needed.
+        stdout_f.close()
+        stderr_f.close()
+
+    def _server_output() -> str:
+        return (
+            f"STDOUT: {stdout_path.read_text(errors='replace') or 'N/A'}\n"
+            f"STDERR: {stderr_path.read_text(errors='replace') or 'N/A'}"
+        )
 
     # Wait for server to be ready.
     # Server startup is dominated by Python imports (fastmcp + adcp SDK + project)
@@ -593,29 +617,13 @@ mcp.run(transport='http', host='0.0.0.0', port={port})
         except (ConnectionRefusedError, OSError):
             # Check if process has died
             if process.poll() is not None:
-                stdout, stderr = process.communicate()
-                raise RuntimeError(
-                    f"MCP server process died unexpectedly.\n"
-                    f"STDOUT: {stdout.decode() if stdout else 'N/A'}\n"
-                    f"STDERR: {stderr.decode() if stderr else 'N/A'}"
-                )
+                raise RuntimeError(f"MCP server process died unexpectedly.\n{_server_output()}")
             time.sleep(0.3)
 
     if not server_ready:
-        # Capture output for debugging
-        try:
-            stdout, stderr = process.communicate(timeout=2)
-        except subprocess.TimeoutExpired:
-            process.kill()
-            stdout, stderr = process.communicate()
-
-        process.terminate()
+        process.kill()
         process.wait(timeout=5)
-        raise RuntimeError(
-            f"MCP server failed to start on port {port} within {max_wait}s.\n"
-            f"STDOUT: {stdout.decode() if stdout else 'N/A'}\n"
-            f"STDERR: {stderr.decode() if stderr else 'N/A'}"
-        )
+        raise RuntimeError(f"MCP server failed to start on port {port} within {max_wait}s.\n{_server_output()}")
 
     # Return server info
     class ServerInfo:
@@ -635,10 +643,7 @@ mcp.run(transport='http', host='0.0.0.0', port={port})
     except subprocess.TimeoutExpired:
         process.kill()
         process.wait()
-    if process.stdout:
-        process.stdout.close()
-    if process.stderr:
-        process.stderr.close()
+    shutil.rmtree(output_dir, ignore_errors=True)
 
     # Don't remove db_name - the PostgreSQL database is managed by integration_db fixture
 


### PR DESCRIPTION
Closes #1822.

Port-minus of `refactor/transport-boundary@4e7b300d5` onto main, per the issue's scope correction: only the two genuinely-grading BR-UC-001 `get_products` scenarios are wired — `T-UC-001-alt-empty` and `T-UC-001-alt-filtered`. The two masked tags move to their production-gap tickets, to be wired in the same change as the fix: `T-UC-001-main` → #1595 (relevance_score / brief_relevance never serialized), `T-UC-001-alt-anonymous` → #1591 (require_identity rejects token-less requests; owned by the #1088 boundary work). No `_UC001_XFAIL_TAGS` block ships — this slice adds zero strict-xfails, zero ledger entries, zero allowlist growth. The remaining 119 scenario blocks stay dormant at the UC-001 fixture catch-all; wiring forces no graduation.

## Spec grounding (AdCP 3.1.1, the pinned version via adcp==6.6.0)

- **alt-filtered**: `dist/schemas/3.1.1/core/product-filters.json` (via `get-products-request.json` `filters` $ref) — `delivery_type` (`enums/delivery-type.json`) and `countries` ("Filter by country coverage using ISO 3166-1 alpha-2 codes… Works for all inventory types.").
- **alt-empty**: `dist/schemas/3.1.1/media-buy/get-products-response.json` — `products` is an unconstrained "Array of matching products"; empty is a valid completed success (feature POST-S1).
- **format_id federation contract** (asserted on the real products wire body): `core/format-id.json` — every `format_id` is an object carrying `agent_url` + `id`, never a bare string.
- Conformance storyboards: `dist/compliance/3.1.1/domains/media-buy/scenarios/` grades only `get_products_async`, `refine_products`, `product_signal_targeting` — sync empty-result and structured-filter behavior are **ungraded**; both scenarios are schema-grounded.

## What's in the diff

- `tests/bdd/steps/domain/uc001_discover_inventory.py`, `tests/bdd/test_uc001_discover_available_inventory.py` — new, from the donor commit.
- `tests/bdd/conftest.py` — three hunks: plugin registration, `_detect_uc` UC-001 branch, `_harness_env` UC-001 block seeding a 3-product catalog (US/guaranteed, GB/non_guaranteed, one restricted to another principal) so visibility/filter asserts are non-vacuous.
- `tests/bdd/steps/_datatable.py` + `tests/bdd/steps/generic/given_config.py` — the shared `datatable_to_dicts` helper (donor `9988e37d5`), replacing given_config's private copy; whitespace-stripping folded in. Its second consumer (UC-009) arrives with #1824.
- `tests/bdd/steps/generic/then_success.py` — fix caught during verification: the ported status-completed step shadowed the generic one for every use case sharing that step text, breaking 3 UC-005 scenarios. Resolved by deleting the duplicate and extending the generic step's statusless-success list with `products`.
- `tests/integration/conftest.py` — cherry-pick of an existing fix for a real infra deadlock hit during the full run (mcp_server fixture wrote subprocess output to undrained pipes; now writes to files). May land independently from its home branch; harmless either way.
- `CLAUDE.md` — stale spec-pin sentence corrected to 3.1.1 / adcp==6.6.0 (matches `pyproject.toml` and `docs/adcp-spec-version.md`).

The issue's "shared harness base" (`_base.py`, `_outcome_helpers.py`, `_dispatch.py`) needed **no porting** — main already carries those changes (and is ahead of the donor branch in places), so copying donor files would have regressed main. Only the datatable helper was actually missing.

## Verification

Full suite (all 7 envs, `innet_310726_2139`): both wired scenarios are plain PASS on **all four transports** — a2a/mcp/rest in-process and e2e_rest in the bdd-in-network run — on main production unchanged (this branch contains zero `src/` changes). unit 5663 / integration 2226 / bdd_inprocess 1753 / bdd_e2e 393 / admin 86 / ui 5 passed, zero failures in every suite except `tests/e2e/`, where 6 pre-existing webhook failures (5× `test_a2a_webhook_payload_types.py`, 1× `test_delivery_webhooks_e2e.py`) trace to an already-tracked bug (SSRF validation from #1697 blocking the e2e webhook-capture server's Docker-internal hostname). This branch touches neither `src/` nor `tests/e2e/`, so it cannot have introduced them.
