### PR TITLE
fix: outbound webhook SSRF gate silently rejected the e2e capture server

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -58,6 +58,16 @@ services:
       SUPER_ADMIN_EMAILS: ${SUPER_ADMIN_EMAILS:-}
       ADCP_TESTING: ${ADCP_TESTING:-true}
       ADCP_AUTH_TEST_MODE: ${ADCP_AUTH_TEST_MODE:-true}
+      # Must match the `tests` service's ADCP_WEBHOOK_HOST below: this is the
+      # SERVER's own trusted-test-host allowlist entry for outbound webhook SSRF
+      # validation (WebhookURLValidator._is_trusted_test_host), not just the
+      # runner's callback-URL construction. Without it here, every webhook the
+      # server tries to send to the e2e capture server (http://tests/webhook,
+      # which DNS-resolves to a private compose-network IP) is rejected by the
+      # SSRF gate even under ADCP_TESTING=true, because the gate only trusts
+      # literal localhost/127.0.0.1 plus whatever ADCP_WEBHOOK_HOST names --
+      # and this service never saw that name.
+      ADCP_WEBHOOK_HOST: tests
       # The SERVER must know about the pinned in-network creative agent: sync/
       # create flows resolve format specs server-side, and references carry the
       # PUBLIC canonical agent_url — without this, the registry's connection

--- a/src/core/webhook_validator.py
+++ b/src/core/webhook_validator.py
@@ -149,11 +149,32 @@ class WebhookURLValidator:
     """Validates webhook URLs to prevent SSRF attacks."""
 
     @staticmethod
-    def _maybe_allow_localhost(is_valid: bool, error: str, *, allow_localhost: bool) -> tuple[bool, str]:
-        """Override localhost/loopback SSRF failures when testing allows them."""
-        if not is_valid and allow_localhost:
-            if "localhost" in error.lower() or "127.0.0" in error or "loopback" in error.lower():
-                return True, ""
+    def _is_trusted_test_host(url: str) -> bool:
+        """True when ``url``'s hostname is an operator-configured test target.
+
+        Covers literal localhost/loopback (the common single-process case)
+        and the exact hostname set in ``ADCP_WEBHOOK_HOST`` -- the operator-
+        configured webhook receiver for multi-container test topologies
+        (e.g. the e2e Docker Compose stack, where the capture server is a
+        separate service reachable only by its compose service name, which
+        resolves to a private IP at send time; see docker-compose.e2e.yml's
+        ``ADCP_WEBHOOK_HOST: tests``). Never derived from request/buyer-
+        supplied data -- ``ADCP_WEBHOOK_HOST`` is CI/ops-set environment
+        config, not attacker-controllable. Any other private/internal
+        target (e.g. an arbitrary 192.168.x.x) is still rejected even
+        under testing -- see test_validate_for_testing_blocks_private_networks.
+        """
+        hostname = (urlparse(url).hostname or "").lower()
+        if hostname in {"localhost", "127.0.0.1"}:
+            return True
+        configured_host = os.environ.get("ADCP_WEBHOOK_HOST", "").lower()
+        return bool(configured_host) and hostname == configured_host
+
+    @staticmethod
+    def _maybe_allow_localhost(url: str, is_valid: bool, error: str, *, allow_localhost: bool) -> tuple[bool, str]:
+        """Override SSRF failures for a trusted test host when testing allows them."""
+        if not is_valid and allow_localhost and WebhookURLValidator._is_trusted_test_host(url):
+            return True, ""
         return is_valid, error
 
     @staticmethod
@@ -190,7 +211,7 @@ class WebhookURLValidator:
             resolve_dns=False,
             require_https=cls._require_https(),
         )
-        return cls._maybe_allow_localhost(is_valid, error, allow_localhost=allow_localhost)
+        return cls._maybe_allow_localhost(url, is_valid, error, allow_localhost=allow_localhost)
 
     @classmethod
     def validate_outbound_webhook_url(cls, url: str) -> tuple[bool, str]:
@@ -216,4 +237,4 @@ class WebhookURLValidator:
         """
         # Testing path always allows HTTP (capture servers, local harnesses).
         is_valid, error = check_url_ssrf(url, require_https=False)
-        return cls._maybe_allow_localhost(is_valid, error, allow_localhost=allow_localhost)
+        return cls._maybe_allow_localhost(url, is_valid, error, allow_localhost=allow_localhost)

--- a/tests/unit/test_webhook_security.py
+++ b/tests/unit/test_webhook_security.py
@@ -140,6 +140,32 @@ class TestWebhookURLValidator:
         is_valid, error = WebhookURLValidator.validate_for_testing("http://192.168.1.1/webhook", allow_localhost=True)
         assert not is_valid
 
+    def test_outbound_allows_configured_webhook_host_under_testing(self, monkeypatch):
+        """ADCP_WEBHOOK_HOST (e.g. a Docker Compose service name resolving to a
+        private IP, as set by docker-compose.e2e.yml for the e2e webhook capture
+        server) must be allowed at send time under ADCP_TESTING, even though DNS
+        resolution puts it in a blocked private range. Regression test for the
+        gap where only literal localhost/127.0.0.1/loopback were exempted, so
+        every outbound webhook in the e2e suite was silently SSRF-rejected."""
+        monkeypatch.setenv("ADCP_TESTING", "true")
+        monkeypatch.setenv("ADCP_WEBHOOK_HOST", "tests")
+        # "tests" isn't publicly resolvable in a unit-test process, so exercise
+        # the hostname-allowlist path directly rather than depending on the
+        # e2e Docker network's DNS.
+        assert WebhookURLValidator._is_trusted_test_host("http://tests:8080/webhook") is True
+
+    def test_outbound_still_blocks_unconfigured_hostname_under_testing(self, monkeypatch):
+        """A hostname that doesn't match ADCP_WEBHOOK_HOST is not exempted just
+        because ADCP_TESTING is set -- only the operator-configured test host is."""
+        monkeypatch.setenv("ADCP_TESTING", "true")
+        monkeypatch.setenv("ADCP_WEBHOOK_HOST", "tests")
+        assert WebhookURLValidator._is_trusted_test_host("http://some-other-service:8080/webhook") is False
+
+    def test_outbound_webhook_host_exemption_requires_env_var_set(self, monkeypatch):
+        """No ADCP_WEBHOOK_HOST configured -> no hostname exemption beyond localhost."""
+        monkeypatch.delenv("ADCP_WEBHOOK_HOST", raising=False)
+        assert WebhookURLValidator._is_trusted_test_host("http://tests:8080/webhook") is False
+
     def test_production_requires_https(self, monkeypatch):
         """Production registration/outbound must reject plain HTTP."""
         monkeypatch.setenv("ENVIRONMENT", "production")


### PR DESCRIPTION
## Summary

`main`'s e2e suite has 6 tests failing (`test_a2a_webhook_payload_types.py`, `test_delivery_webhooks_e2e.py`) -- confirmed pre-existing, reproduces on a clean checkout with no other changes. Found while establishing a full-suite baseline for an unrelated PR.

Root cause: #1697's `ADCP_TESTING` SSRF carve-out only recognized literal `localhost`/`127.0.0.1`/`loopback` in the *error message text*, never the Docker Compose service-name address (`ADCP_WEBHOOK_HOST=tests`) this project's own e2e webhook harness actually uses -- and that env var was only ever set on the `tests` runner container, never on `adcp-server`, the process that performs the send-time SSRF check.

Every outbound webhook delivery attempt in e2e was silently SSRF-rejected, always, even with `ADCP_TESTING=true`, because `tests` DNS-resolves to a private compose-network IP (`172.x`) and nothing in the bypass logic recognized it as trusted.

## Fix (two gaps, both required)

1. **`src/core/webhook_validator.py`** -- replaced the fragile error-text string-matching (`"localhost" in error.lower()`) with `WebhookURLValidator._is_trusted_test_host()`, a hostname-based allowlist: literal `localhost`/`127.0.0.1`, or the exact value of `ADCP_WEBHOOK_HOST`. This is intentionally narrow -- arbitrary private IPs (e.g. `192.168.1.1`) remain blocked even under `ADCP_TESTING`, matching the existing `test_validate_for_testing_blocks_private_networks` assertion.
2. **`docker-compose.e2e.yml`** -- added `ADCP_WEBHOOK_HOST: tests` to `adcp-server`'s environment block (it was already set on the `tests` runner service, just never propagated to the server that actually needs it).

3 new regression tests in `tests/unit/test_webhook_security.py` cover the trusted-host allowlist directly.

## Verification

Root-caused via live `py-spy`/`docker logs -f` tracing against the real e2e stack, not just unit-level logic -- confirmed the exact SSRF rejection log line before the fix (`Protocol webhook URL failed SSRF validation ... blocked IP range 172.16.0.0/12`), and its disappearance after.

- `tests/unit/test_webhook_security.py`: 64/64 passing (61 existing + 3 new)
- `ruff format` / `ruff check` / `mypy`: clean on all touched files
- Full e2e suite (`tests/e2e/`): 91 passed, 28 skipped, 4 xfailed, 2 failed (unrelated -- pre-existing schema-validation gap, tracked separately, not touched by this PR)
- Targeted: `test_a2a_webhook_payload_types.py` + `test_delivery_webhooks_e2e.py` -- all 6 previously-failing tests now pass

Marked as draft pending final review pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)